### PR TITLE
fix(enricher+config): spec key regression, rate_limiter fields, certificate oneOf (#344, #345, #346)

### DIFF
--- a/config/discovered_defaults.yaml
+++ b/config/discovered_defaults.yaml
@@ -377,6 +377,10 @@ resources:
     schema_pattern: "certificate.*SpecType"
     oneof_recommended:
       ocsp_stapling_choice: "use_system_defaults"
+    nested:
+      private_key:
+        oneof_recommended:
+          secret_info_oneof: "clear_secret_info"
 
 # Documentation for adding new defaults:
 # 1. Create resource in F5 XC with minimal/empty spec via API

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -750,10 +750,12 @@ resources:
     domain: "rate_limiting"
     resource_type: "policy"
 
-    # API accepts empty spec — rules are optional
+    # API requires burst_size >= 1 and committed_information_rate >= 1
     required_fields:
       - "metadata.name"
       - "metadata.namespace"
+      - "spec.burst_size"
+      - "spec.committed_information_rate"
 
     example_yaml: |
       apiVersion: v1
@@ -761,7 +763,9 @@ resources:
       metadata:
         name: example-rl
         namespace: default
-      spec: {}
+      spec:
+        burst_size: 1
+        committed_information_rate: 1
 
     example_json: |
       {
@@ -769,7 +773,10 @@ resources:
           "name": "example-rl",
           "namespace": "default"
         },
-        "spec": {}
+        "spec": {
+          "burst_size": 1,
+          "committed_information_rate": 1
+        }
       }
 
     example_curl: |

--- a/docs/specifications/api/admin_console_and_ui.json
+++ b/docs/specifications/api/admin_console_and_ui.json
@@ -611,7 +611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.339811+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -634,7 +634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.339916+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -646,7 +646,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446322+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.476948+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -688,8 +688,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -722,7 +722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340014+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -784,7 +784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.340096+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776748+00:00"
               },
               "deterministic": true
             },
@@ -797,7 +797,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446393+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.476983+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -916,7 +916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.340259+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776814+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -932,7 +932,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446460+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477017+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -1004,7 +1004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.340318+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776839+00:00"
               },
               "deterministic": true
             },
@@ -1017,7 +1017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446511+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477044+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1048,7 +1048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.340357+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776856+00:00"
               },
               "deterministic": true
             },
@@ -1061,7 +1061,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446541+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477060+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -1106,7 +1106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340399+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1119,7 +1119,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446573+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477077+00:00"
           },
           "name": {
             "type": "string",
@@ -1152,7 +1152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.340437+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776891+00:00"
               },
               "deterministic": true
             },
@@ -1165,7 +1165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446617+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477092+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1196,7 +1196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.340477+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776910+00:00"
               },
               "deterministic": true
             },
@@ -1209,7 +1209,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446647+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477108+00:00"
           },
           "tenant": {
             "type": "string",
@@ -1228,7 +1228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340521+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1242,7 +1242,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446677+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477124+00:00"
           },
           "uid": {
             "type": "string",
@@ -1261,7 +1261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340555+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1276,7 +1276,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446709+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477141+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -1337,7 +1337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340636+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1349,7 +1349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446750+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477171+00:00"
           },
           "status": {
             "type": "string",
@@ -1367,7 +1367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340680+00:00"
+                "validatedAt": "2026-05-09T01:40:07.776990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1379,7 +1379,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446779+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477187+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -1421,7 +1421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340738+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1448,7 +1448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340791+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1475,7 +1475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340840+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1503,7 +1503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340897+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1568,7 +1568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.340978+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1617,7 +1617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.341043+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1630,7 +1630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446910+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477286+00:00"
           },
           "uid": {
             "type": "string",
@@ -1649,7 +1649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.341077+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1663,7 +1663,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446940+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477305+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -1713,7 +1713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.341118+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1725,7 +1725,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.446971+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477322+00:00"
           },
           "name": {
             "type": "string",
@@ -1758,7 +1758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.341156+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777215+00:00"
               },
               "deterministic": true
             },
@@ -1771,7 +1771,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.447001+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477338+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1802,7 +1802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.341195+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777232+00:00"
               },
               "deterministic": true
             },
@@ -1815,7 +1815,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.447030+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477354+00:00"
           },
           "uid": {
             "type": "string",
@@ -1832,7 +1832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.341228+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1846,7 +1846,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.447060+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477370+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -1975,7 +1975,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.447150+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477419+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -2032,7 +2032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:27:21.341363+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2095,7 +2095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:21.341432+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2107,7 +2107,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.447219+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477455+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -2173,7 +2173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.341485+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777355+00:00"
               },
               "deterministic": true
             },
@@ -2186,7 +2186,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.447289+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477492+00:00"
           },
           "namespace": {
             "type": "string",
@@ -2215,7 +2215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:21.341523+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777372+00:00"
               },
               "deterministic": true
             },
@@ -2228,7 +2228,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.447318+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477507+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -2251,7 +2251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.341573+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2264,7 +2264,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.447365+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477533+00:00"
           },
           "uid": {
             "type": "string",
@@ -2282,7 +2282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:21.341623+00:00"
+                "validatedAt": "2026-05-09T01:40:07.777408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2296,7 +2296,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.447395+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.477548+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of static_component is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",

--- a/docs/specifications/api/ai_services.json
+++ b/docs/specifications/api/ai_services.json
@@ -2475,7 +2475,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.081287+00:00"
+                "validatedAt": "2026-05-09T01:31:49.773742+00:00"
               },
               "deterministic": true
             },
@@ -2514,7 +2514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.081343+00:00"
+                "validatedAt": "2026-05-09T01:31:49.773817+00:00"
               },
               "deterministic": true
             },
@@ -2527,7 +2527,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986155+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958649+00:00"
           },
           "negative_feedback": {
             "$ref": "#/components/schemas/ai_assistantNegativeFeedbackDetails"
@@ -2551,7 +2551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:08:47.081410+00:00"
+                "validatedAt": "2026-05-09T01:31:49.773846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2584,7 +2584,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.081514+00:00"
+                "validatedAt": "2026-05-09T01:31:49.773893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2635,7 +2635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.081573+00:00"
+                "validatedAt": "2026-05-09T01:31:49.773917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2673,7 +2673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.081641+00:00"
+                "validatedAt": "2026-05-09T01:31:49.773937+00:00"
               },
               "deterministic": true
             },
@@ -2686,7 +2686,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986249+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958696+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -2725,7 +2725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.081701+00:00"
+                "validatedAt": "2026-05-09T01:31:49.773967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2763,7 +2763,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.081773+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2805,7 +2805,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.081881+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2876,7 +2876,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.081950+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2919,8 +2919,8 @@
           "description": "Minimum configuration for ai_assistantNegativeFeedbackType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ai_assistantNegativeFeedbackType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ai_assistantNegativeFeedbackType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ai_assistant_negative_feedback_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ai_services"
@@ -2944,8 +2944,8 @@
           "description": "Minimum configuration for ai_assistantcommonUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ai_assistantcommonUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ai_assistantcommonUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ai_assistantcommon_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ai_services"
@@ -2969,8 +2969,8 @@
           "description": "Minimum configuration for ai_assistantexplain_log_recordAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ai_assistantexplain_log_recordAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ai_assistantexplain_log_recordAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ai_assistantexplain_log_record_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -3017,8 +3017,8 @@
           "description": "Minimum configuration for commonColourType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for commonColourType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for commonColourType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_colour_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3043,8 +3043,8 @@
           "description": "Minimum configuration for commonColumnType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for commonColumnType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for commonColumnType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_column_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3079,7 +3079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.081998+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3091,7 +3091,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986412+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958777+00:00"
           },
           "log_filters": {
             "type": "array",
@@ -3135,7 +3135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.082056+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774124+00:00"
               },
               "deterministic": true
             },
@@ -3148,7 +3148,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986455+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958799+00:00"
           },
           "object_name": {
             "type": "string",
@@ -3165,7 +3165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082107+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3190,7 +3190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082156+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3215,7 +3215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082198+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3227,7 +3227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986506+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958825+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/commonDashboardLinkType"
@@ -3281,8 +3281,8 @@
           "description": "Minimum configuration for commonDashboardLinkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for commonDashboardLinkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for commonDashboardLinkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_dashboard_link_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3321,7 +3321,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.082268+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3368,8 +3368,8 @@
           "description": "Minimum configuration for commonDisplayType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for commonDisplayType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for commonDisplayType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_display_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3413,7 +3413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.082314+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774241+00:00"
               },
               "deterministic": true
             },
@@ -3426,7 +3426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986625+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958875+00:00"
           },
           "title": {
             "type": "string",
@@ -3443,7 +3443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082358+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3455,7 +3455,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986657+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958891+00:00"
           },
           "tooltip": {
             "type": "string",
@@ -3470,7 +3470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082403+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3518,8 +3518,8 @@
           "description": "Minimum configuration for commonFilterOperator",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for commonFilterOperator\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for commonFilterOperator\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_filter_operators\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3544,8 +3544,8 @@
           "description": "Minimum configuration for commonFormatType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for commonFormatType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for commonFormatType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_format_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3580,7 +3580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082446+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3592,7 +3592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986716+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958919+00:00"
           },
           "title": {
             "type": "string",
@@ -3609,7 +3609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082488+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3621,7 +3621,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986747+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958935+00:00"
           },
           "url": {
             "type": "string",
@@ -3646,7 +3646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:08:47.082528+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774333+00:00"
               },
               "deterministic": true
             },
@@ -3713,7 +3713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082597+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3788,7 +3788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082643+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3800,7 +3800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986847+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.958985+00:00"
           },
           "op": {
             "$ref": "#/components/schemas/commonFilterOperator"
@@ -3829,7 +3829,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.082703+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3879,7 +3879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082752+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3891,7 +3891,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.986911+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959017+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/commonDashboardLinkType"
@@ -3933,7 +3933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082803+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3958,7 +3958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082855+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3983,7 +3983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082899+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4008,7 +4008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082948+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4033,7 +4033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.082991+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4058,7 +4058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083037+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4108,8 +4108,8 @@
           "description": "Minimum configuration for commonStatusStyle",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for commonStatusStyle\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for commonStatusStyle\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_status_styles\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -4136,8 +4136,8 @@
           "description": "Minimum configuration for commonWidgetType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for commonWidgetType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for commonWidgetType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_widget_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -4161,8 +4161,8 @@
           "description": "Minimum configuration for explain_log_recordAccuracy",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for explain_log_recordAccuracy\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for explain_log_recordAccuracy\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/explain_log_record_accuracies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -4189,7 +4189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083091+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4228,7 +4228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.083129+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774579+00:00"
               },
               "deterministic": true
             },
@@ -4241,7 +4241,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.987032+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959079+00:00"
           },
           "type": {
             "type": "string",
@@ -4258,7 +4258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083168+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4308,7 +4308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083229+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4333,7 +4333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083275+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4358,7 +4358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083319+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4383,7 +4383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083369+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4428,8 +4428,8 @@
           "description": "Minimum configuration for explain_log_recordEnforcementMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for explain_log_recordEnforcementMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for explain_log_recordEnforcementMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/explain_log_record_enforcement_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -4457,7 +4457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083419+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4482,7 +4482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083469+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4513,7 +4513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083525+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4566,8 +4566,8 @@
           "description": "Minimum configuration for explain_log_recordIPReputation",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for explain_log_recordIPReputation\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for explain_log_recordIPReputation\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/explain_log_record_i_p_reputations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -4594,7 +4594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083580+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4607,7 +4607,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.987205+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959172+00:00"
           },
           "rsp_code": {
             "type": "integer",
@@ -4639,7 +4639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083672+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4664,7 +4664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083738+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4715,7 +4715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083797+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4740,7 +4740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083844+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4767,7 +4767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083876+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4792,7 +4792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.083930+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4831,7 +4831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.083968+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774931+00:00"
               },
               "deterministic": true
             },
@@ -4844,7 +4844,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.987317+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959230+00:00"
           },
           "state": {
             "type": "string",
@@ -4862,7 +4862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084012+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4939,7 +4939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084090+00:00"
+                "validatedAt": "2026-05-09T01:31:49.774980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4964,7 +4964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084146+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4989,7 +4989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084200+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5040,7 +5040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084253+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5067,7 +5067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084284+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5106,7 +5106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.084321+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775083+00:00"
               },
               "deterministic": true
             },
@@ -5119,7 +5119,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.987449+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959300+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5158,7 +5158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084371+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5183,7 +5183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084415+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5208,7 +5208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084466+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5247,7 +5247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.084501+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775172+00:00"
               },
               "deterministic": true
             },
@@ -5260,7 +5260,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.987511+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959331+00:00"
           },
           "state": {
             "type": "string",
@@ -5278,7 +5278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084542+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5330,7 +5330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084613+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5436,7 +5436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084718+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5477,7 +5477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.084775+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5545,7 +5545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:08:47.084959+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5557,7 +5557,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.987682+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959412+00:00"
           },
           "title": {
             "type": "string",
@@ -5574,7 +5574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.085004+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5586,7 +5586,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.987713+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959428+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5634,7 +5634,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.085068+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5662,7 +5662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:08:47.085109+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5687,7 +5687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.085154+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5739,8 +5739,8 @@
           "description": "Minimum configuration for policyIPThreatCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_i_p_threat_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -5762,7 +5762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.085202+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5785,7 +5785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.085247+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5797,7 +5797,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.987793+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959468+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -5825,8 +5825,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -5855,8 +5855,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -5889,7 +5889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.085301+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5947,7 +5947,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.085361+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5982,7 +5982,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.085419+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6010,7 +6010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.085468+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6065,7 +6065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.085521+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6077,7 +6077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:27.987930+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.959539+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6159,7 +6159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:47.085614+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6246,7 +6246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:08:47.085688+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6271,7 +6271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:47.085733+00:00"
+                "validatedAt": "2026-05-09T01:31:49.775636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6327,8 +6327,8 @@
           "description": "Minimum configuration for bfdpEnableFeatureRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bfdpEnableFeatureRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bfdpEnableFeatureRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bfdp_enable_feature_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6344,8 +6344,8 @@
           "description": "Minimum configuration for bfdpEnableFeatureResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bfdpEnableFeatureResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bfdpEnableFeatureResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bfdp_enable_feature_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6373,7 +6373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:50.266572+00:00"
+                "validatedAt": "2026-05-09T01:32:17.693847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6420,7 +6420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:50.266702+00:00"
+                "validatedAt": "2026-05-09T01:32:17.693882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6465,7 +6465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:54.421989+00:00"
+                "validatedAt": "2026-05-09T01:32:19.545085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6511,7 +6511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:54.422115+00:00"
+                "validatedAt": "2026-05-09T01:32:19.545122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6538,7 +6538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:54.422204+00:00"
+                "validatedAt": "2026-05-09T01:32:19.545145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6565,7 +6565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:54.422299+00:00"
+                "validatedAt": "2026-05-09T01:32:19.545176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6592,7 +6592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:54.422360+00:00"
+                "validatedAt": "2026-05-09T01:32:19.545201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6640,7 +6640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:54.422417+00:00"
+                "validatedAt": "2026-05-09T01:32:19.545224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6686,7 +6686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:54.422467+00:00"
+                "validatedAt": "2026-05-09T01:32:19.545248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6731,7 +6731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:54.422519+00:00"
+                "validatedAt": "2026-05-09T01:32:19.545270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6764,8 +6764,8 @@
           "description": "Minimum configuration for subscriptionUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -6794,7 +6794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:37.013743+00:00"
+                "validatedAt": "2026-05-09T01:35:44.381041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6855,7 +6855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:37.013871+00:00"
+                "validatedAt": "2026-05-09T01:35:44.381080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6881,7 +6881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:37.013931+00:00"
+                "validatedAt": "2026-05-09T01:35:44.381095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6929,7 +6929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:37.014015+00:00"
+                "validatedAt": "2026-05-09T01:35:44.381116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6962,7 +6962,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:37.014102+00:00"
+                "validatedAt": "2026-05-09T01:35:44.381158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7009,7 +7009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:37.014155+00:00"
+                "validatedAt": "2026-05-09T01:35:44.381181+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/api.json
+++ b/docs/specifications/api/api.json
@@ -11987,7 +11987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.302360+00:00"
+                "validatedAt": "2026-05-09T01:31:50.729917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12032,8 +12032,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_crawlerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_crawlerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_crawlers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -12099,7 +12099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.302507+00:00"
+                "validatedAt": "2026-05-09T01:31:50.729985+00:00"
               },
               "deterministic": true
             },
@@ -12173,7 +12173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.302557+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730008+00:00"
               },
               "deterministic": true
             },
@@ -12186,7 +12186,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.031711+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.979899+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12216,7 +12216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.302616+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730025+00:00"
               },
               "deterministic": true
             },
@@ -12229,7 +12229,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.031747+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.979916+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12281,7 +12281,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.302710+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12294,7 +12294,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.031785+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.979934+00:00"
           },
           "simple_login": {
             "$ref": "#/components/schemas/api_crawlerSimpleLogin"
@@ -12399,7 +12399,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032306+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980088+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -12458,7 +12458,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.302886+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730139+00:00"
               },
               "deterministic": true
             },
@@ -12524,7 +12524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:08:49.302940+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12587,7 +12587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:08:49.303013+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12599,7 +12599,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032406+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980135+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -12665,7 +12665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.303068+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730226+00:00"
               },
               "deterministic": true
             },
@@ -12678,7 +12678,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032479+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980206+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12707,7 +12707,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.303107+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730243+00:00"
               },
               "deterministic": true
             },
@@ -12720,7 +12720,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032510+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980225+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -12759,7 +12759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303175+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12772,7 +12772,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032570+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980257+00:00"
           },
           "uid": {
             "type": "string",
@@ -12789,7 +12789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303209+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12803,7 +12803,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032623+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980278+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_crawler is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -12853,8 +12853,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_crawlerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_crawlerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_crawler_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -12866,8 +12866,8 @@
           "description": "Minimum configuration for api_crawlerReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_crawlerReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_crawlerReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_crawler_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -12905,7 +12905,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.303290+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730324+00:00"
               },
               "deterministic": true
             },
@@ -12952,7 +12952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303344+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12977,7 +12977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303388+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12990,7 +12990,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032706+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980326+00:00"
           },
           "endpoint_count": {
             "type": "integer",
@@ -13023,7 +13023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303452+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13049,7 +13049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303511+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13075,7 +13075,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303568+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13129,8 +13129,8 @@
           "description": "Minimum configuration for api_crawlerScanStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_crawlerScanStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_crawlerScanStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_crawler_scan_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -13170,7 +13170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.303675+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730477+00:00"
               },
               "deterministic": true
             },
@@ -13296,7 +13296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303772+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13309,7 +13309,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032862+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980415+00:00"
           },
           "name": {
             "type": "string",
@@ -13342,7 +13342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.303809+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730530+00:00"
               },
               "deterministic": true
             },
@@ -13355,7 +13355,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032894+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980431+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13386,7 +13386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.303846+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730547+00:00"
               },
               "deterministic": true
             },
@@ -13399,7 +13399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032924+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980447+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13418,7 +13418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303888+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13432,7 +13432,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032954+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980462+00:00"
           },
           "uid": {
             "type": "string",
@@ -13451,7 +13451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303921+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13466,7 +13466,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.032985+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980479+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -13504,7 +13504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.303969+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13527,7 +13527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304015+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13539,7 +13539,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033031+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980502+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -13582,7 +13582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304071+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13620,7 +13620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.304147+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13632,7 +13632,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033074+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980525+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -13651,7 +13651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304200+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13702,7 +13702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304246+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13714,7 +13714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033118+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980551+00:00"
           },
           "url": {
             "type": "string",
@@ -13752,7 +13752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.304323+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730757+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13809,7 +13809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:08:49.304364+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730775+00:00"
               },
               "deterministic": true
             },
@@ -13835,7 +13835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304418+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13861,7 +13861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304463+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13873,7 +13873,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033180+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980586+00:00"
           },
           "service_name": {
             "type": "string",
@@ -13890,7 +13890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304515+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13923,7 +13923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304562+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13935,7 +13935,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033220+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980607+00:00"
           },
           "type": {
             "type": "string",
@@ -13960,7 +13960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304617+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14014,8 +14014,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14048,7 +14048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.304672+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14110,7 +14110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.304709+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730917+00:00"
               },
               "deterministic": true
             },
@@ -14123,7 +14123,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033296+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980646+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -14241,7 +14241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.304832+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730971+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14257,7 +14257,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033362+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980683+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14327,7 +14327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.304881+00:00"
+                "validatedAt": "2026-05-09T01:31:50.730992+00:00"
               },
               "deterministic": true
             },
@@ -14340,7 +14340,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033415+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980716+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14371,7 +14371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.304920+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731009+00:00"
               },
               "deterministic": true
             },
@@ -14384,7 +14384,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033445+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980732+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -14466,7 +14466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.305020+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731054+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14482,7 +14482,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033489+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980755+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14554,7 +14554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.305069+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731075+00:00"
               },
               "deterministic": true
             },
@@ -14567,7 +14567,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033541+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980782+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14598,7 +14598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.305105+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731091+00:00"
               },
               "deterministic": true
             },
@@ -14611,7 +14611,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033571+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980797+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -14693,7 +14693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.305202+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731136+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14709,7 +14709,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033628+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980820+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14779,7 +14779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.305250+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731163+00:00"
               },
               "deterministic": true
             },
@@ -14792,7 +14792,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033680+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980848+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14823,7 +14823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.305285+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731179+00:00"
               },
               "deterministic": true
             },
@@ -14836,7 +14836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033710+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980863+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -14872,8 +14872,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14931,7 +14931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305350+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14959,7 +14959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305402+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14987,7 +14987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305449+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15016,7 +15016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305499+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15043,7 +15043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305531+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15057,7 +15057,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033815+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980918+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -15073,7 +15073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305578+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15136,8 +15136,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -15182,7 +15182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305657+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15194,7 +15194,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033879+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980950+00:00"
           },
           "status": {
             "type": "string",
@@ -15212,7 +15212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305701+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15224,7 +15224,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.033910+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.980966+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -15266,7 +15266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305756+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15293,7 +15293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305807+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15320,7 +15320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305854+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15348,7 +15348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.305916+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15413,7 +15413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.306004+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15462,7 +15462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.306073+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15475,7 +15475,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.034042+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.981035+00:00"
           },
           "uid": {
             "type": "string",
@@ -15494,7 +15494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.306110+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15508,7 +15508,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.034075+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.981052+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -15558,7 +15558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.306153+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15570,7 +15570,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.034108+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.981068+00:00"
           },
           "name": {
             "type": "string",
@@ -15603,7 +15603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.306190+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731537+00:00"
               },
               "deterministic": true
             },
@@ -15616,7 +15616,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.034138+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.981084+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15647,7 +15647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:49.306229+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731554+00:00"
               },
               "deterministic": true
             },
@@ -15660,7 +15660,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.034169+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.981100+00:00"
           },
           "uid": {
             "type": "string",
@@ -15677,7 +15677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:49.306262+00:00"
+                "validatedAt": "2026-05-09T01:31:50.731571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15691,7 +15691,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.034200+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:02.981117+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -15749,7 +15749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.713851+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15789,7 +15789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.713917+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772701+00:00"
               },
               "deterministic": true
             },
@@ -15802,7 +15802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082218+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003644+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15832,7 +15832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.713960+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772719+00:00"
               },
               "deterministic": true
             },
@@ -15845,7 +15845,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082251+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003661+00:00"
           }
         },
         "x-f5xc-description-short": "Request shape for various API Inventory Requests.",
@@ -15933,7 +15933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:08:51.714033+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15979,7 +15979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.714078+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772767+00:00"
               },
               "deterministic": true
             },
@@ -15992,7 +15992,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082311+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003690+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16023,15 +16023,15 @@
           }
         },
         "x-f5xc-minimum-configuration": {
-          "description": "Minimum configuration for api_definitionCreateRequest",
+          "description": "API definition for documenting and protecting HTTP APIs",
           "required_fields": [
-            "metadata",
-            "spec"
+            "metadata.name",
+            "metadata.namespace"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_definitionCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
-          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_definitions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
+          "example_yaml": "apiVersion: v1\nkind: api_definition\nmetadata:\n  name: example-api\n  namespace: default\nspec: {}\n",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example-api\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}\n",
+          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_definitions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @api-definition.json\n"
         },
         "x-f5xc-cli-domain": "api"
       },
@@ -16113,7 +16113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.714146+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772797+00:00"
               },
               "deterministic": true
             },
@@ -16126,7 +16126,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082407+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003739+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16156,7 +16156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.714183+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772813+00:00"
               },
               "deterministic": true
             },
@@ -16169,7 +16169,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082438+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003755+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16346,7 +16346,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082562+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003819+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16447,7 +16447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:08:51.714382+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16510,7 +16510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:08:51.714454+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16522,7 +16522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082667+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003864+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -16588,7 +16588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.714508+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772957+00:00"
               },
               "deterministic": true
             },
@@ -16601,7 +16601,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082740+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003901+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16630,7 +16630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.714545+00:00"
+                "validatedAt": "2026-05-09T01:31:51.772973+00:00"
               },
               "deterministic": true
             },
@@ -16643,7 +16643,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082769+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003917+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -16682,7 +16682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:51.714630+00:00"
+                "validatedAt": "2026-05-09T01:31:51.773000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16695,7 +16695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082828+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003948+00:00"
           },
           "uid": {
             "type": "string",
@@ -16712,7 +16712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:51.714666+00:00"
+                "validatedAt": "2026-05-09T01:31:51.773014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16726,7 +16726,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.082859+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.003963+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_definition is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -16770,15 +16770,15 @@
           }
         },
         "x-f5xc-minimum-configuration": {
-          "description": "Minimum configuration for api_definitionReplaceRequest",
+          "description": "API definition for documenting and protecting HTTP APIs",
           "required_fields": [
-            "metadata",
-            "spec"
+            "metadata.name",
+            "metadata.namespace"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_definitionReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
-          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_definition_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
+          "example_yaml": "apiVersion: v1\nkind: api_definition\nmetadata:\n  name: example-api\n  namespace: default\nspec: {}\n",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example-api\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}\n",
+          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_definitions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @api-definition.json\n"
         },
         "x-f5xc-cli-domain": "api"
       },
@@ -16789,8 +16789,8 @@
           "description": "Minimum configuration for api_definitionReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_definitionReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_definitionReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_definition_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -16860,8 +16860,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -16891,8 +16891,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -16957,7 +16957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:08:51.715474+00:00"
+                "validatedAt": "2026-05-09T01:31:51.773411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16969,7 +16969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.083350+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.004234+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17015,7 +17015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.715514+00:00"
+                "validatedAt": "2026-05-09T01:31:51.773430+00:00"
               },
               "deterministic": true
             },
@@ -17028,7 +17028,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.083389+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.004255+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Message Metadata\" MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -17091,7 +17091,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717106+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17138,7 +17138,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717192+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17213,7 +17213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717264+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774249+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17229,7 +17229,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.084289+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.004728+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17266,7 +17266,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717332+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774282+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17282,7 +17282,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.084319+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.004745+00:00"
           },
           "tenant": {
             "type": "string",
@@ -17311,7 +17311,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717404+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17325,7 +17325,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.084348+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.004763+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -17387,7 +17387,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717495+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774364+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -17451,7 +17451,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717560+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17488,7 +17488,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717642+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17527,7 +17527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717709+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17574,7 +17574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717775+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17651,7 +17651,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717858+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17688,7 +17688,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717919+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17727,7 +17727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.717986+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17774,7 +17774,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.718051+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17834,7 +17834,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.718116+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17871,7 +17871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.718183+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17910,7 +17910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.718249+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17957,7 +17957,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:51.718315+00:00"
+                "validatedAt": "2026-05-09T01:31:51.774767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18001,8 +18001,8 @@
           "description": "Minimum configuration for api_discoveryAuthParameterType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_discoveryAuthParameterType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_discoveryAuthParameterType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discovery_auth_parameter_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -18022,15 +18022,16 @@
           }
         },
         "x-f5xc-minimum-configuration": {
-          "description": "Minimum configuration for api_discoveryCreateRequest",
+          "description": "API discovery configuration for automatic API endpoint detection",
           "required_fields": [
-            "metadata",
-            "spec"
+            "metadata.name",
+            "metadata.namespace",
+            "spec.user_defined_api_discovery_policy"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_discoveryCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
-          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discoveries\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
+          "example_yaml": "apiVersion: v1\nkind: api_discovery\nmetadata:\n  name: example-discovery\n  namespace: default\nspec:\n  user_defined_api_discovery_policy: {}\n",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example-discovery\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"user_defined_api_discovery_policy\": {}\n  }\n}\n",
+          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discoverys\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @api-discovery.json\n"
         },
         "x-f5xc-cli-domain": "api"
       },
@@ -18092,7 +18093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:53.900037+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18105,14 +18106,16 @@
         },
         "x-f5xc-description-short": "Create API discovery creates a new object in the storage backend for metadata.namespace.",
         "x-f5xc-minimum-configuration": {
-          "description": "Minimum configuration for api_discoveryCreateSpecType",
+          "description": "API discovery configuration for automatic API endpoint detection",
           "required_fields": [
-            "custom_auth_types"
+            "metadata.name",
+            "metadata.namespace",
+            "spec.user_defined_api_discovery_policy"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_discoveryCreateSpecType\nmetadata:\n  name: example\n  namespace: default\nspec:\n  custom_auth_types: value",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"custom_auth_types\": \"value\"\n  }\n}",
-          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discoveries\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
+          "example_yaml": "apiVersion: v1\nkind: api_discovery\nmetadata:\n  name: example-discovery\n  namespace: default\nspec:\n  user_defined_api_discovery_policy: {}\n",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example-discovery\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"user_defined_api_discovery_policy\": {}\n  }\n}\n",
+          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discoverys\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @api-discovery.json\n"
         },
         "x-f5xc-cli-domain": "api"
       },
@@ -18157,7 +18160,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:53.900243+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18234,7 +18237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:53.900312+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730691+00:00"
               },
               "deterministic": true
             },
@@ -18247,7 +18250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.140343+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.031765+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18277,7 +18280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:53.900354+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730709+00:00"
               },
               "deterministic": true
             },
@@ -18290,7 +18293,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.140377+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.031782+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18393,7 +18396,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.140479+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.031833+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -18449,7 +18452,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:53.900513+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18462,14 +18465,16 @@
         },
         "x-f5xc-description-short": "GET api_discovery reads a given object from storage backend for metadata.namespace.",
         "x-f5xc-minimum-configuration": {
-          "description": "Minimum configuration for api_discoveryGetSpecType",
+          "description": "API discovery configuration for automatic API endpoint detection",
           "required_fields": [
-            "custom_auth_types"
+            "metadata.name",
+            "metadata.namespace",
+            "spec.user_defined_api_discovery_policy"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_discoveryGetSpecType\nmetadata:\n  name: example\n  namespace: default\nspec:\n  custom_auth_types: value",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"custom_auth_types\": \"value\"\n  }\n}",
-          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discoveries\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
+          "example_yaml": "apiVersion: v1\nkind: api_discovery\nmetadata:\n  name: example-discovery\n  namespace: default\nspec:\n  user_defined_api_discovery_policy: {}\n",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example-discovery\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"user_defined_api_discovery_policy\": {}\n  }\n}\n",
+          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discoverys\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @api-discovery.json\n"
         },
         "x-f5xc-cli-domain": "api"
       },
@@ -18515,7 +18520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:08:53.900574+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18578,7 +18583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:08:53.900677+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18590,7 +18595,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.140570+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.031879+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18656,7 +18661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:53.900732+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730851+00:00"
               },
               "deterministic": true
             },
@@ -18669,7 +18674,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.140658+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.031916+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18698,7 +18703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:53.900768+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730867+00:00"
               },
               "deterministic": true
             },
@@ -18711,7 +18716,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.140689+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.031931+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -18750,7 +18755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:53.900838+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18763,7 +18768,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.140748+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.031962+00:00"
           },
           "uid": {
             "type": "string",
@@ -18780,7 +18785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:53.900873+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18794,7 +18799,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.140779+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.031978+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_discovery is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -18838,15 +18843,16 @@
           }
         },
         "x-f5xc-minimum-configuration": {
-          "description": "Minimum configuration for api_discoveryReplaceRequest",
+          "description": "API discovery configuration for automatic API endpoint detection",
           "required_fields": [
-            "metadata",
-            "spec"
+            "metadata.name",
+            "metadata.namespace",
+            "spec.user_defined_api_discovery_policy"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_discoveryReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
-          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discovery_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
+          "example_yaml": "apiVersion: v1\nkind: api_discovery\nmetadata:\n  name: example-discovery\n  namespace: default\nspec:\n  user_defined_api_discovery_policy: {}\n",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example-discovery\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"user_defined_api_discovery_policy\": {}\n  }\n}\n",
+          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discoverys\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @api-discovery.json\n"
         },
         "x-f5xc-cli-domain": "api"
       },
@@ -18857,8 +18863,8 @@
           "description": "Minimum configuration for api_discoveryReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_discoveryReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_discoveryReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discovery_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -18893,7 +18899,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:53.900948+00:00"
+                "validatedAt": "2026-05-09T01:31:52.730943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18906,14 +18912,16 @@
         },
         "x-f5xc-description-short": "Replace api_discovery replaces an existing object in the storage backend for metadata.namespace.",
         "x-f5xc-minimum-configuration": {
-          "description": "Minimum configuration for api_discoveryReplaceSpecType",
+          "description": "API discovery configuration for automatic API endpoint detection",
           "required_fields": [
-            "custom_auth_types"
+            "metadata.name",
+            "metadata.namespace",
+            "spec.user_defined_api_discovery_policy"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_discoveryReplaceSpecType\nmetadata:\n  name: example\n  namespace: default\nspec:\n  custom_auth_types: value",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"custom_auth_types\": \"value\"\n  }\n}",
-          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discovery_replace_spec_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
+          "example_yaml": "apiVersion: v1\nkind: api_discovery\nmetadata:\n  name: example-discovery\n  namespace: default\nspec:\n  user_defined_api_discovery_policy: {}\n",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example-discovery\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"user_defined_api_discovery_policy\": {}\n  }\n}\n",
+          "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_discoverys\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @api-discovery.json\n"
         },
         "x-f5xc-cli-domain": "api"
       },
@@ -19054,7 +19062,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178195+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.049942+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19120,7 +19128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:08:55.957882+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19182,7 +19190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:08:55.957966+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19194,7 +19202,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178277+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.049983+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -19260,7 +19268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:55.958025+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622225+00:00"
               },
               "deterministic": true
             },
@@ -19273,7 +19281,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178349+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.050020+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19302,7 +19310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:55.958065+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622243+00:00"
               },
               "deterministic": true
             },
@@ -19315,7 +19323,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178378+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.050036+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -19354,7 +19362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:55.958133+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19367,7 +19375,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178436+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.050067+00:00"
           },
           "uid": {
             "type": "string",
@@ -19384,7 +19392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:55.958170+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19398,7 +19406,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178467+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.050083+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19508,7 +19516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:55.958953+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19521,7 +19529,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178911+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.050344+00:00"
           },
           "name": {
             "type": "string",
@@ -19554,7 +19562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:55.958989+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622630+00:00"
               },
               "deterministic": true
             },
@@ -19567,7 +19575,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178939+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.050360+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19598,7 +19606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:55.959025+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622647+00:00"
               },
               "deterministic": true
             },
@@ -19611,7 +19619,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178969+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.050376+00:00"
           },
           "tenant": {
             "type": "string",
@@ -19630,7 +19638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:55.959068+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19644,7 +19652,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.178998+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.050392+00:00"
           },
           "uid": {
             "type": "string",
@@ -19663,7 +19671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:55.959101+00:00"
+                "validatedAt": "2026-05-09T01:31:53.622679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19678,7 +19686,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.179029+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.050409+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -19727,7 +19735,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:55.960095+00:00"
+                "validatedAt": "2026-05-09T01:31:53.623095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19759,7 +19767,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:55.960163+00:00"
+                "validatedAt": "2026-05-09T01:31:53.623128+00:00"
               },
               "deterministic": true
             },
@@ -19865,7 +19873,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.206911+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.063394+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19932,7 +19940,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:57.996542+00:00"
+                "validatedAt": "2026-05-09T01:31:54.502252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19978,7 +19986,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:57.996665+00:00"
+                "validatedAt": "2026-05-09T01:31:54.502296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20045,7 +20053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:08:57.996730+00:00"
+                "validatedAt": "2026-05-09T01:31:54.502323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20108,7 +20116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:08:57.996804+00:00"
+                "validatedAt": "2026-05-09T01:31:54.502354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20120,7 +20128,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.207015+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.063446+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20186,7 +20194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:57.996860+00:00"
+                "validatedAt": "2026-05-09T01:31:54.502381+00:00"
               },
               "deterministic": true
             },
@@ -20199,7 +20207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.207088+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.063484+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20228,7 +20236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:08:57.996902+00:00"
+                "validatedAt": "2026-05-09T01:31:54.502404+00:00"
               },
               "deterministic": true
             },
@@ -20241,7 +20249,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.207117+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.063500+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -20280,7 +20288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:57.996971+00:00"
+                "validatedAt": "2026-05-09T01:31:54.502437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20293,7 +20301,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.207176+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.063530+00:00"
           },
           "uid": {
             "type": "string",
@@ -20311,7 +20319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:08:57.997006+00:00"
+                "validatedAt": "2026-05-09T01:31:54.502453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20325,7 +20333,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.207207+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.063547+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_group_element is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -20439,7 +20447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.208334+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20451,7 +20459,7 @@
             "x-original-maxLength": 128,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.238895+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.077933+00:00"
           },
           "value": {
             "$ref": "#/components/schemas/schemaSecretType"
@@ -20507,7 +20515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.208484+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460594+00:00"
               },
               "deterministic": true
             },
@@ -20575,8 +20583,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_testingCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_testingCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_testings\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -20636,7 +20644,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.208661+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20673,7 +20681,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.208738+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460684+00:00"
               },
               "deterministic": true
             },
@@ -20756,7 +20764,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.208848+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20842,7 +20850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.208908+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460765+00:00"
               },
               "deterministic": true
             },
@@ -20855,7 +20863,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.239157+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.078069+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20885,7 +20893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.208949+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460783+00:00"
               },
               "deterministic": true
             },
@@ -20898,7 +20906,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.239188+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.078087+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20988,7 +20996,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.209056+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21001,7 +21009,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.239243+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.078120+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21104,7 +21112,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.239343+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.078180+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -21157,7 +21165,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.209236+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21194,7 +21202,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.209307+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460937+00:00"
               },
               "deterministic": true
             },
@@ -21273,7 +21281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:00.209371+00:00"
+                "validatedAt": "2026-05-09T01:31:55.460964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21336,7 +21344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:00.209440+00:00"
+                "validatedAt": "2026-05-09T01:31:55.461016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21348,7 +21356,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.239471+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.078252+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21414,7 +21422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.209492+00:00"
+                "validatedAt": "2026-05-09T01:31:55.461052+00:00"
               },
               "deterministic": true
             },
@@ -21427,7 +21435,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.239540+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.078289+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21456,7 +21464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.209529+00:00"
+                "validatedAt": "2026-05-09T01:31:55.461071+00:00"
               },
               "deterministic": true
             },
@@ -21469,7 +21477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.239570+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.078305+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21508,7 +21516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:00.209613+00:00"
+                "validatedAt": "2026-05-09T01:31:55.461101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21521,7 +21529,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.239644+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.078335+00:00"
           },
           "uid": {
             "type": "string",
@@ -21538,7 +21546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:00.209648+00:00"
+                "validatedAt": "2026-05-09T01:31:55.461117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21552,7 +21560,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.239675+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.078351+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_testing is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21620,7 +21628,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.209744+00:00"
+                "validatedAt": "2026-05-09T01:31:55.461173+00:00"
               },
               "deterministic": true
             },
@@ -21651,7 +21659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:00.209804+00:00"
+                "validatedAt": "2026-05-09T01:31:55.461199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21698,8 +21706,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_testingReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_testingReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_testing_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -21711,8 +21719,8 @@
           "description": "Minimum configuration for api_testingReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_testingReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_testingReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_testing_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -21744,7 +21752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.209901+00:00"
+                "validatedAt": "2026-05-09T01:31:55.461244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21781,7 +21789,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:00.209971+00:00"
+                "validatedAt": "2026-05-09T01:31:55.461285+00:00"
               },
               "deterministic": true
             },
@@ -21897,8 +21905,8 @@
           "description": "Minimum configuration for api_credentialAPICredentialType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_credentialAPICredentialType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_credentialAPICredentialType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_credential_a_p_i_credential_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -21945,7 +21953,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.753886+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22050,7 +22058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754014+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22130,7 +22138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754088+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566544+00:00"
               },
               "deterministic": true
             },
@@ -22143,7 +22151,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292772+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103503+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22172,7 +22180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754128+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566562+00:00"
               },
               "deterministic": true
             },
@@ -22185,7 +22193,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292805+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103519+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/api_credentialCustomCreateSpecType"
@@ -22244,7 +22252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754180+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22268,7 +22276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754241+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22304,7 +22312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754282+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566627+00:00"
               },
               "deterministic": true
             },
@@ -22317,7 +22325,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292879+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103558+00:00"
           }
         },
         "x-f5xc-description-short": "CreateResponse is the response format for the credential's create request.",
@@ -22396,7 +22404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754348+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566654+00:00"
               },
               "deterministic": true
             },
@@ -22409,7 +22417,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292940+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103591+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22438,7 +22446,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754383+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566671+00:00"
               },
               "deterministic": true
             },
@@ -22451,7 +22459,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292969+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103607+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -22495,7 +22503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754455+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22545,7 +22553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754534+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22571,7 +22579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754615+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22642,7 +22650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754675+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22671,7 +22679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754735+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22697,7 +22705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754793+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22795,7 +22803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754845+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566847+00:00"
               },
               "deterministic": true
             },
@@ -22808,7 +22816,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293140+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103697+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22845,7 +22853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754888+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566866+00:00"
               },
               "deterministic": true
             },
@@ -22858,7 +22866,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293169+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103714+00:00"
           }
         },
         "x-f5xc-description-short": "GET credential object with a given name.",
@@ -22937,7 +22945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754955+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22962,7 +22970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755010+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23001,7 +23009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755046+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566932+00:00"
               },
               "deterministic": true
             },
@@ -23014,7 +23022,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293241+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103753+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23043,7 +23051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755081+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566948+00:00"
               },
               "deterministic": true
             },
@@ -23056,7 +23064,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293270+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103768+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -23079,7 +23087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755122+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23093,7 +23101,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293320+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103794+00:00"
           },
           "user_email": {
             "type": "string",
@@ -23111,7 +23119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755171+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23205,7 +23213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755293+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23230,7 +23238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755349+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23253,7 +23261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755396+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23278,7 +23286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755454+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23303,7 +23311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755503+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23340,7 +23348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755570+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23364,7 +23372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755641+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23388,7 +23396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755699+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23446,7 +23454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:02.755744+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23508,7 +23516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755803+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23533,7 +23541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755858+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23572,7 +23580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755897+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567291+00:00"
               },
               "deterministic": true
             },
@@ -23585,7 +23593,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293512+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103897+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23614,7 +23622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755934+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567308+00:00"
               },
               "deterministic": true
             },
@@ -23627,7 +23635,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293542+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103914+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/api_credentialAPICredentialType"
@@ -23647,7 +23655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755971+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23661,7 +23669,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293595+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103935+00:00"
           },
           "user_email": {
             "type": "string",
@@ -23679,7 +23687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756021+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23734,7 +23742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:02.756060+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23796,7 +23804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756121+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23821,7 +23829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756175+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23860,7 +23868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756214+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567473+00:00"
               },
               "deterministic": true
             },
@@ -23873,7 +23881,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293681+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103980+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23902,7 +23910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756249+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567491+00:00"
               },
               "deterministic": true
             },
@@ -23915,7 +23923,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293711+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103995+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -23938,7 +23946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756289+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23952,7 +23960,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293760+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104022+00:00"
           },
           "user_email": {
             "type": "string",
@@ -23970,7 +23978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756339+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24063,7 +24071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756423+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24177,7 +24185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756504+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567615+00:00"
               },
               "deterministic": true
             },
@@ -24190,7 +24198,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293864+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104080+00:00"
           }
         },
         "x-f5xc-description-short": "RecreateScimTokenRequest is the request format for generating SCIM API credential.",
@@ -24267,7 +24275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756565+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567644+00:00"
               },
               "deterministic": true
             },
@@ -24280,7 +24288,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293906+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104102+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24317,7 +24325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756621+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567663+00:00"
               },
               "deterministic": true
             },
@@ -24330,7 +24338,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293935+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104118+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24391,7 +24399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756663+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567681+00:00"
               },
               "deterministic": true
             },
@@ -24404,7 +24412,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293966+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104135+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24434,7 +24442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756699+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567698+00:00"
               },
               "deterministic": true
             },
@@ -24447,7 +24455,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293995+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104150+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -24525,7 +24533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756785+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24564,7 +24572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756820+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567763+00:00"
               },
               "deterministic": true
             },
@@ -24577,7 +24585,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294064+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104193+00:00"
           }
         },
         "x-f5xc-description-short": "Response format for the credential's replace request.",
@@ -24637,7 +24645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756864+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567783+00:00"
               },
               "deterministic": true
             },
@@ -24650,7 +24658,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294095+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104210+00:00"
           }
         },
         "x-f5xc-description-short": "ScimTokenRequest is used for fetching or revoking scim token.",
@@ -24707,7 +24715,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756944+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24778,7 +24786,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294150+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104250+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24821,7 +24829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757016+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24853,7 +24861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757070+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24887,8 +24895,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -24981,7 +24989,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757213+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567941+00:00"
               },
               "deterministic": true
             },
@@ -24994,7 +25002,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104314+00:00"
           },
           "role": {
             "type": "string",
@@ -25024,7 +25032,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757281+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25109,7 +25117,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757380+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568022+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -25125,7 +25133,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294326+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104345+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -25197,7 +25205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757430+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568043+00:00"
               },
               "deterministic": true
             },
@@ -25210,7 +25218,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294377+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104373+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25241,7 +25249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757467+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568059+00:00"
               },
               "deterministic": true
             },
@@ -25254,7 +25262,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294406+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104391+00:00"
           },
           "uid": {
             "type": "string",
@@ -25273,7 +25281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757500+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25288,7 +25296,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294436+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104408+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -25335,7 +25343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757871+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25363,7 +25371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757923+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25392,7 +25400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757975+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25419,7 +25427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758023+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25448,7 +25456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758078+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25473,7 +25481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758131+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25538,7 +25546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758215+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25576,7 +25584,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.758276+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25588,7 +25596,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294796+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104599+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -25629,7 +25637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758344+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25673,7 +25681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758396+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25687,7 +25695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294863+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104636+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -25706,7 +25714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758446+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25733,7 +25741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758480+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25748,7 +25756,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294902+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104657+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -25763,7 +25771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758528+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25865,7 +25873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.420499+00:00"
+                "validatedAt": "2026-05-09T01:32:05.798730+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -25931,7 +25939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.420550+00:00"
+                "validatedAt": "2026-05-09T01:32:05.798758+00:00"
               },
               "deterministic": true
             },
@@ -25944,7 +25952,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716163+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307256+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25973,7 +25981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.420610+00:00"
+                "validatedAt": "2026-05-09T01:32:05.798779+00:00"
               },
               "deterministic": true
             },
@@ -25986,7 +25994,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716196+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307276+00:00"
           }
         },
         "x-f5xc-description-short": "The API Group ID for the API Groups stats response.",
@@ -26161,8 +26169,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_api_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_api_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_api_groups\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -26245,7 +26253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.420729+00:00"
+                "validatedAt": "2026-05-09T01:32:05.798830+00:00"
               },
               "deterministic": true
             },
@@ -26258,7 +26266,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716360+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307365+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26288,7 +26296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.420767+00:00"
+                "validatedAt": "2026-05-09T01:32:05.798848+00:00"
               },
               "deterministic": true
             },
@@ -26301,7 +26309,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716390+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307381+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26356,7 +26364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.420811+00:00"
+                "validatedAt": "2026-05-09T01:32:05.798869+00:00"
               },
               "deterministic": true
             },
@@ -26369,7 +26377,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716431+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307403+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26412,7 +26420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:23.420871+00:00"
+                "validatedAt": "2026-05-09T01:32:05.798895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26491,7 +26499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.420932+00:00"
+                "validatedAt": "2026-05-09T01:32:05.798924+00:00"
               },
               "deterministic": true
             },
@@ -26504,7 +26512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716495+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307436+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26545,7 +26553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:23.420973+00:00"
+                "validatedAt": "2026-05-09T01:32:05.798944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26655,7 +26663,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716622+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307494+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -26723,7 +26731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:23.421113+00:00"
+                "validatedAt": "2026-05-09T01:32:05.799004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26786,7 +26794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:23.421185+00:00"
+                "validatedAt": "2026-05-09T01:32:05.799035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26798,7 +26806,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716700+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307534+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26864,7 +26872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.421236+00:00"
+                "validatedAt": "2026-05-09T01:32:05.799058+00:00"
               },
               "deterministic": true
             },
@@ -26877,7 +26885,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716770+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307570+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26906,7 +26914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.421273+00:00"
+                "validatedAt": "2026-05-09T01:32:05.799075+00:00"
               },
               "deterministic": true
             },
@@ -26919,7 +26927,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716800+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307586+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26958,7 +26966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:23.421341+00:00"
+                "validatedAt": "2026-05-09T01:32:05.799103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26971,7 +26979,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716858+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307616+00:00"
           },
           "uid": {
             "type": "string",
@@ -26988,7 +26996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:23.421375+00:00"
+                "validatedAt": "2026-05-09T01:32:05.799119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27002,7 +27010,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.716889+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.307633+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_api_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27052,8 +27060,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_api_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_api_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_api_group_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -27065,8 +27073,8 @@
           "description": "Minimum configuration for app_api_groupReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_api_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_api_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_api_group_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -27169,7 +27177,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.424254+00:00"
+                "validatedAt": "2026-05-09T01:32:05.800455+00:00"
               },
               "deterministic": true
             },
@@ -27257,7 +27265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.424352+00:00"
+                "validatedAt": "2026-05-09T01:32:05.800501+00:00"
               },
               "deterministic": true
             },
@@ -27348,7 +27356,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.424450+00:00"
+                "validatedAt": "2026-05-09T01:32:05.800591+00:00"
               },
               "deterministic": true
             },
@@ -27421,7 +27429,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:23.424530+00:00"
+                "validatedAt": "2026-05-09T01:32:05.800636+00:00"
               },
               "deterministic": true
             },
@@ -27497,7 +27505,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.474167+00:00"
+                "validatedAt": "2026-05-09T01:32:10.301865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27542,7 +27550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.474287+00:00"
+                "validatedAt": "2026-05-09T01:32:10.301915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27642,7 +27650,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.474372+00:00"
+                "validatedAt": "2026-05-09T01:32:10.301956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27680,7 +27688,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.474465+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302000+00:00"
               },
               "deterministic": true
             },
@@ -27747,7 +27755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.474562+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27793,7 +27801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.474680+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27862,7 +27870,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.474746+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27929,7 +27937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.474842+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27968,7 +27976,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.474920+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28045,7 +28053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:33.474989+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28269,7 +28277,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.475125+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28343,7 +28351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.475200+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28406,7 +28414,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.475288+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28445,7 +28453,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.475367+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28486,7 +28494,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.475458+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28628,7 +28636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.475542+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28734,7 +28742,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.475840+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28793,7 +28801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.475902+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28944,7 +28952,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476022+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302706+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -28960,7 +28968,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.980875+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.432858+00:00"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -29032,7 +29040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476087+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29085,8 +29093,8 @@
           "description": "Minimum configuration for policyIPThreatCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_i_p_threat_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -29138,7 +29146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476154+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29233,7 +29241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476241+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302809+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -29249,7 +29257,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.980989+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.432921+00:00"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -29299,8 +29307,8 @@
           "description": "Minimum configuration for policyKnownTlsFingerprintClass",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyKnownTlsFingerprintClass\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyKnownTlsFingerprintClass\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_known_tls_fingerprint_classes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -29346,7 +29354,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476305+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29392,7 +29400,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476364+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29430,7 +29438,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476424+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29509,7 +29517,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476491+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29566,7 +29574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476554+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29603,7 +29611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476644+00:00"
+                "validatedAt": "2026-05-09T01:32:10.302996+00:00"
               },
               "deterministic": true
             },
@@ -29639,7 +29647,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476704+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29674,7 +29682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476765+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29735,7 +29743,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476827+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29776,7 +29784,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476891+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29818,7 +29826,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.476952+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29868,8 +29876,8 @@
           "description": "Minimum configuration for policyTransformer",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_transformers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -29892,8 +29900,8 @@
           "description": "Minimum configuration for rate_limiterRateLimitPeriodUnit",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_rate_limit_period_units\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -29943,7 +29951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.477001+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303183+00:00"
               },
               "deterministic": true
             },
@@ -29956,7 +29964,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.981157+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.433010+00:00"
           },
           "path": {
             "type": "string",
@@ -29987,7 +29995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.477085+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303222+00:00"
               },
               "deterministic": true
             },
@@ -30021,7 +30029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:33.477141+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30142,7 +30150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.477217+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303279+00:00"
               },
               "deterministic": true
             },
@@ -30155,7 +30163,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.981256+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.433063+00:00"
           },
           "path": {
             "type": "string",
@@ -30186,7 +30194,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.477296+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303317+00:00"
               },
               "deterministic": true
             },
@@ -30220,7 +30228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:33.477352+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30330,7 +30338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.477412+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303367+00:00"
               },
               "deterministic": true
             },
@@ -30343,7 +30351,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.981355+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.433116+00:00"
           },
           "path": {
             "type": "string",
@@ -30374,7 +30382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.477494+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303405+00:00"
               },
               "deterministic": true
             },
@@ -30408,7 +30416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:33.477550+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30512,7 +30520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.477621+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303452+00:00"
               },
               "deterministic": true
             },
@@ -30525,7 +30533,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.981444+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.433169+00:00"
           },
           "path": {
             "type": "string",
@@ -30556,7 +30564,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.477738+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303489+00:00"
               },
               "deterministic": true
             },
@@ -30590,7 +30598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:33.477797+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30672,8 +30680,8 @@
           "description": "Minimum configuration for schemaOpenApiValidationProperties",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_open_api_validation_propertieses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -30750,7 +30758,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.478119+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303658+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -30766,7 +30774,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.981651+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.433281+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -30826,7 +30834,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.478182+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30909,7 +30917,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:33.478265+00:00"
+                "validatedAt": "2026-05-09T01:32:10.303727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30921,7 +30929,7 @@
             "x-original-maxLength": 256,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.981732+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.433324+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -30965,8 +30973,8 @@
           "description": "Minimum configuration for virtual_hostVirtualHostType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_hostVirtualHostType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_hostVirtualHostType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_host_virtual_host_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -31029,7 +31037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:50.486123+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31090,7 +31098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:12:50.486186+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322442+00:00"
               },
               "deterministic": true
             },
@@ -31128,7 +31136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:50.486228+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31238,8 +31246,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for code_base_integrationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for code_base_integrationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/code_base_integrations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -31345,7 +31353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:50.486331+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322512+00:00"
               },
               "deterministic": true
             },
@@ -31358,7 +31366,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.289373+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.478269+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31388,7 +31396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:50.486369+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322529+00:00"
               },
               "deterministic": true
             },
@@ -31401,7 +31409,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.289406+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.478286+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31504,7 +31512,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.289507+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.478337+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -31591,7 +31599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:12:50.486564+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322608+00:00"
               },
               "deterministic": true
             },
@@ -31656,7 +31664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:12:50.486636+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322630+00:00"
               },
               "deterministic": true
             },
@@ -31694,7 +31702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:50.486676+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31755,7 +31763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:50.486719+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31852,7 +31860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:12:50.486777+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322693+00:00"
               },
               "deterministic": true
             },
@@ -31900,8 +31908,8 @@
           "description": "Minimum configuration for code_base_integrationHealthStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for code_base_integrationHealthStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for code_base_integrationHealthStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/code_base_integration_health_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -31928,7 +31936,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:50.486827+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31940,7 +31948,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.289726+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.478440+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31998,7 +32006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:12:50.486886+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32061,7 +32069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:12:50.486955+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32073,7 +32081,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.289793+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.478474+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -32139,7 +32147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:50.487007+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322796+00:00"
               },
               "deterministic": true
             },
@@ -32152,7 +32160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.289863+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.478511+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32181,7 +32189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:50.487044+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322812+00:00"
               },
               "deterministic": true
             },
@@ -32194,7 +32202,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.289892+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.478526+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -32233,7 +32241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:50.487110+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32246,7 +32254,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.289950+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.478556+00:00"
           },
           "uid": {
             "type": "string",
@@ -32264,7 +32272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:50.487145+00:00"
+                "validatedAt": "2026-05-09T01:33:37.322864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32278,7 +32286,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.289981+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.478573+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of code_base_integration is returned in 'List'.",
@@ -32328,8 +32336,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for code_base_integrationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for code_base_integrationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/code_base_integration_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -32341,8 +32349,8 @@
           "description": "Minimum configuration for code_base_integrationReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for code_base_integrationReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for code_base_integrationReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/code_base_integration_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -32458,7 +32466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.858783+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32551,7 +32559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.858873+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32708,7 +32716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.859002+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32835,7 +32843,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859120+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32891,7 +32899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859165+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322778+00:00"
               },
               "deterministic": true
             },
@@ -32904,7 +32912,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.272558+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862383+00:00"
           },
           "namespace_regex": {
             "type": "string",
@@ -32920,7 +32928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.859221+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32995,8 +33003,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discoveryCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discoveryCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discoveries\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -33060,7 +33068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859332+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33154,7 +33162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859390+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322877+00:00"
               },
               "deterministic": true
             },
@@ -33167,7 +33175,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.272752+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862476+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33197,7 +33205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859427+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322895+00:00"
               },
               "deterministic": true
             },
@@ -33210,7 +33218,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.272784+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862493+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33257,7 +33265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859509+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33290,7 +33298,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859608+00:00"
+                "validatedAt": "2026-05-09T01:35:03.322971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33355,7 +33363,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859692+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323008+00:00"
               },
               "deterministic": true
             },
@@ -33368,7 +33376,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.272849+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862527+00:00"
           },
           "pods": {
             "type": "array",
@@ -33424,7 +33432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859799+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33457,7 +33465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859877+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33531,7 +33539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859922+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323110+00:00"
               },
               "deterministic": true
             },
@@ -33544,7 +33552,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.272922+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862565+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33581,7 +33589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.859963+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323129+00:00"
               },
               "deterministic": true
             },
@@ -33594,7 +33602,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.272952+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862581+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33636,7 +33644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.860005+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33747,7 +33755,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.273065+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862641+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -33804,7 +33812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.860176+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33903,8 +33911,8 @@
           "description": "Minimum configuration for discoveryK8SDNSMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discoveryK8SDNSMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discoveryK8SDNSMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovery_k8_s_d_n_s_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -33944,7 +33952,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.860285+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34045,7 +34053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.860379+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323333+00:00"
               },
               "deterministic": true
             },
@@ -34104,7 +34112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.860418+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323351+00:00"
               },
               "deterministic": true
             },
@@ -34117,7 +34125,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.273272+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862756+00:00"
           },
           "namespace_regex": {
             "type": "string",
@@ -34143,7 +34151,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.860500+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34213,7 +34221,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.860568+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323424+00:00"
               },
               "deterministic": true
             },
@@ -34226,7 +34234,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.273314+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862778+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34319,7 +34327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:04.860651+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34381,7 +34389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:04.860716+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34393,7 +34401,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.273421+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862834+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34459,7 +34467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.860770+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323506+00:00"
               },
               "deterministic": true
             },
@@ -34472,7 +34480,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.273491+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862874+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34501,7 +34509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.860805+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323523+00:00"
               },
               "deterministic": true
             },
@@ -34514,7 +34522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.273520+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862890+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -34553,7 +34561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.860870+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34566,7 +34574,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.273577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862921+00:00"
           },
           "uid": {
             "type": "string",
@@ -34583,7 +34591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.860902+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34597,7 +34605,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.273622+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862938+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovery is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -34649,7 +34657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.860943+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323584+00:00"
               },
               "deterministic": true
             },
@@ -34697,7 +34705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:04.860981+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34753,7 +34761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.861020+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323619+00:00"
               },
               "deterministic": true
             },
@@ -34766,7 +34774,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.273680+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.862968+00:00"
           },
           "partition_regex": {
             "type": "string",
@@ -34782,7 +34790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.861070+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34830,7 +34838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.861108+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34855,7 +34863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.861152+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34918,7 +34926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.861195+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323700+00:00"
               },
               "deterministic": true
             },
@@ -34952,7 +34960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.861243+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35027,8 +35035,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discoveryReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discoveryReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovery_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -35040,8 +35048,8 @@
           "description": "Minimum configuration for discoveryReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discoveryReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discoveryReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovery_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -35077,7 +35085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.861353+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35157,7 +35165,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.861444+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35289,7 +35297,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.861600+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323879+00:00"
               },
               "deterministic": true
             },
@@ -35330,7 +35338,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.861684+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35370,7 +35378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.861770+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35447,7 +35455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.861831+00:00"
+                "validatedAt": "2026-05-09T01:35:03.323983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35493,8 +35501,8 @@
           "description": "Minimum configuration for discoveryVirtualIPDiscoveryType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discoveryVirtualIPDiscoveryType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discoveryVirtualIPDiscoveryType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovery_virtual_i_p_discovery_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -35518,7 +35526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.861889+00:00"
+                "validatedAt": "2026-05-09T01:35:03.324008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35556,7 +35564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.861941+00:00"
+                "validatedAt": "2026-05-09T01:35:03.324029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35581,7 +35589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:04.861990+00:00"
+                "validatedAt": "2026-05-09T01:35:03.324050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35646,8 +35654,8 @@
           "description": "Minimum configuration for schemaDiscoveryType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaDiscoveryType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaDiscoveryType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_discovery_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -35686,7 +35694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.863128+00:00"
+                "validatedAt": "2026-05-09T01:35:03.324568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35787,7 +35795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.863776+00:00"
+                "validatedAt": "2026-05-09T01:35:03.324957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35858,7 +35866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:04.864613+00:00"
+                "validatedAt": "2026-05-09T01:35:03.325351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35912,8 +35920,8 @@
           "description": "Minimum configuration for schemaVirtualNetworkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_virtual_network_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -35937,7 +35945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:32.103506+00:00"
+                "validatedAt": "2026-05-09T01:35:15.497027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35981,7 +35989,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:32.103628+00:00"
+                "validatedAt": "2026-05-09T01:35:15.497082+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/authentication.json
+++ b/docs/specifications/api/authentication.json
@@ -3927,8 +3927,8 @@
           "description": "Minimum configuration for api_credentialAPICredentialType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for api_credentialAPICredentialType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for api_credentialAPICredentialType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/api_credential_a_p_i_credential_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "api"
@@ -3975,7 +3975,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.753886+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4080,7 +4080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754014+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4160,7 +4160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754088+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566544+00:00"
               },
               "deterministic": true
             },
@@ -4173,7 +4173,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292772+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103503+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4202,7 +4202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754128+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566562+00:00"
               },
               "deterministic": true
             },
@@ -4215,7 +4215,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292805+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103519+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/api_credentialCustomCreateSpecType"
@@ -4274,7 +4274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754180+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4298,7 +4298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754241+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4334,7 +4334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754282+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566627+00:00"
               },
               "deterministic": true
             },
@@ -4347,7 +4347,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292879+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103558+00:00"
           }
         },
         "x-f5xc-description-short": "CreateResponse is the response format for the credential's create request.",
@@ -4426,7 +4426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754348+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566654+00:00"
               },
               "deterministic": true
             },
@@ -4439,7 +4439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292940+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103591+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4468,7 +4468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754383+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566671+00:00"
               },
               "deterministic": true
             },
@@ -4481,7 +4481,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.292969+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103607+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -4525,7 +4525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754455+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4575,7 +4575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754534+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4601,7 +4601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754615+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4672,7 +4672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754675+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4701,7 +4701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754735+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4727,7 +4727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754793+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4825,7 +4825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754845+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566847+00:00"
               },
               "deterministic": true
             },
@@ -4838,7 +4838,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293140+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103697+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4875,7 +4875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.754888+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566866+00:00"
               },
               "deterministic": true
             },
@@ -4888,7 +4888,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293169+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103714+00:00"
           }
         },
         "x-f5xc-description-short": "GET credential object with a given name.",
@@ -4967,7 +4967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.754955+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4992,7 +4992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755010+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5031,7 +5031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755046+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566932+00:00"
               },
               "deterministic": true
             },
@@ -5044,7 +5044,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293241+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103753+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5073,7 +5073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755081+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566948+00:00"
               },
               "deterministic": true
             },
@@ -5086,7 +5086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293270+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103768+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -5109,7 +5109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755122+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5123,7 +5123,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293320+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103794+00:00"
           },
           "user_email": {
             "type": "string",
@@ -5141,7 +5141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755171+00:00"
+                "validatedAt": "2026-05-09T01:31:56.566985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5235,7 +5235,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755293+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5260,7 +5260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755349+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5283,7 +5283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755396+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5308,7 +5308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755454+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5333,7 +5333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755503+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5370,7 +5370,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755570+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5394,7 +5394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755641+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5418,7 +5418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755699+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5476,7 +5476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:02.755744+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5538,7 +5538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755803+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5563,7 +5563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755858+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5602,7 +5602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755897+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567291+00:00"
               },
               "deterministic": true
             },
@@ -5615,7 +5615,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293512+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103897+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5644,7 +5644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.755934+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567308+00:00"
               },
               "deterministic": true
             },
@@ -5657,7 +5657,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293542+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103914+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/api_credentialAPICredentialType"
@@ -5677,7 +5677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.755971+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5691,7 +5691,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293595+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103935+00:00"
           },
           "user_email": {
             "type": "string",
@@ -5709,7 +5709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756021+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5764,7 +5764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:02.756060+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5826,7 +5826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756121+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5851,7 +5851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756175+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5890,7 +5890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756214+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567473+00:00"
               },
               "deterministic": true
             },
@@ -5903,7 +5903,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293681+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103980+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5932,7 +5932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756249+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567491+00:00"
               },
               "deterministic": true
             },
@@ -5945,7 +5945,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293711+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.103995+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -5968,7 +5968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756289+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5982,7 +5982,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293760+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104022+00:00"
           },
           "user_email": {
             "type": "string",
@@ -6000,7 +6000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756339+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6093,7 +6093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756423+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6207,7 +6207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756504+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567615+00:00"
               },
               "deterministic": true
             },
@@ -6220,7 +6220,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293864+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104080+00:00"
           }
         },
         "x-f5xc-description-short": "RecreateScimTokenRequest is the request format for generating SCIM API credential.",
@@ -6297,7 +6297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756565+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567644+00:00"
               },
               "deterministic": true
             },
@@ -6310,7 +6310,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293906+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104102+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6347,7 +6347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756621+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567663+00:00"
               },
               "deterministic": true
             },
@@ -6360,7 +6360,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293935+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104118+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6421,7 +6421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756663+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567681+00:00"
               },
               "deterministic": true
             },
@@ -6434,7 +6434,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293966+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104135+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6464,7 +6464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756699+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567698+00:00"
               },
               "deterministic": true
             },
@@ -6477,7 +6477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.293995+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104150+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -6555,7 +6555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.756785+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6594,7 +6594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756820+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567763+00:00"
               },
               "deterministic": true
             },
@@ -6607,7 +6607,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294064+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104193+00:00"
           }
         },
         "x-f5xc-description-short": "Response format for the credential's replace request.",
@@ -6667,7 +6667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756864+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567783+00:00"
               },
               "deterministic": true
             },
@@ -6680,7 +6680,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294095+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104210+00:00"
           }
         },
         "x-f5xc-description-short": "ScimTokenRequest is used for fetching or revoking scim token.",
@@ -6737,7 +6737,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.756944+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6808,7 +6808,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294150+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104250+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6851,7 +6851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757016+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6883,7 +6883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757070+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6917,8 +6917,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6959,7 +6959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757112+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567893+00:00"
               },
               "deterministic": true
             },
@@ -6972,7 +6972,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294206+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104278+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -7118,7 +7118,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757213+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567941+00:00"
               },
               "deterministic": true
             },
@@ -7131,7 +7131,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104314+00:00"
           },
           "role": {
             "type": "string",
@@ -7161,7 +7161,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757281+00:00"
+                "validatedAt": "2026-05-09T01:31:56.567973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7246,7 +7246,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757380+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568022+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7262,7 +7262,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294326+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104345+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7334,7 +7334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757430+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568043+00:00"
               },
               "deterministic": true
             },
@@ -7347,7 +7347,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294377+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104373+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7378,7 +7378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757467+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568059+00:00"
               },
               "deterministic": true
             },
@@ -7391,7 +7391,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294406+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104391+00:00"
           },
           "uid": {
             "type": "string",
@@ -7410,7 +7410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757500+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7425,7 +7425,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294436+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104408+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -7472,7 +7472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757542+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7485,7 +7485,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294467+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104425+00:00"
           },
           "name": {
             "type": "string",
@@ -7518,7 +7518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757579+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568108+00:00"
               },
               "deterministic": true
             },
@@ -7531,7 +7531,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294496+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104441+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7562,7 +7562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.757631+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568124+00:00"
               },
               "deterministic": true
             },
@@ -7575,7 +7575,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294525+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104457+00:00"
           },
           "tenant": {
             "type": "string",
@@ -7594,7 +7594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757676+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7608,7 +7608,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294554+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104473+00:00"
           },
           "uid": {
             "type": "string",
@@ -7627,7 +7627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757710+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7642,7 +7642,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294596+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104489+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -7703,7 +7703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757769+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7715,7 +7715,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294639+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104511+00:00"
           },
           "status": {
             "type": "string",
@@ -7733,7 +7733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757813+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7745,7 +7745,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294667+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104527+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7787,7 +7787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757871+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7815,7 +7815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757923+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7844,7 +7844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.757975+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7871,7 +7871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758023+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7900,7 +7900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758078+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7925,7 +7925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758131+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7990,7 +7990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758215+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8028,7 +8028,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.758276+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8040,7 +8040,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294796+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104599+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -8081,7 +8081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758344+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8125,7 +8125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758396+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8139,7 +8139,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294863+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104636+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -8158,7 +8158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758446+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8185,7 +8185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758480+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8200,7 +8200,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294902+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104657+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -8215,7 +8215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758528+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8296,7 +8296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758579+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8308,7 +8308,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294952+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104684+00:00"
           },
           "name": {
             "type": "string",
@@ -8341,7 +8341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.758632+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568563+00:00"
               },
               "deterministic": true
             },
@@ -8354,7 +8354,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.294981+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104700+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8385,7 +8385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:02.758670+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568580+00:00"
               },
               "deterministic": true
             },
@@ -8398,7 +8398,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.295010+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104715+00:00"
           },
           "uid": {
             "type": "string",
@@ -8415,7 +8415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:02.758706+00:00"
+                "validatedAt": "2026-05-09T01:31:56.568595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8429,7 +8429,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.295040+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.104731+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",

--- a/docs/specifications/api/bigip.json
+++ b/docs/specifications/api/bigip.json
@@ -8228,7 +8228,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.851755+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8275,7 +8275,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.851845+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8315,7 +8315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.851928+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8474,8 +8474,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for apmCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for apmCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/apms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -8558,7 +8558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.852029+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289746+00:00"
               },
               "deterministic": true
             },
@@ -8571,7 +8571,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.936895+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.888543+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8601,7 +8601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.852068+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289764+00:00"
               },
               "deterministic": true
             },
@@ -8614,7 +8614,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.936929+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.888560+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8642,8 +8642,8 @@
           "description": "Minimum configuration for apmF5BigIpAppStackBareMetalChoiceReplaceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for apmF5BigIpAppStackBareMetalChoiceReplaceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for apmF5BigIpAppStackBareMetalChoiceReplaceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/apm_f5_big_ip_app_stack_bare_metal_choice_replace_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -8758,7 +8758,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937044+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.888619+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8826,7 +8826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:10:18.852223+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8888,7 +8888,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:10:18.852293+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8900,7 +8900,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937121+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.888660+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8965,7 +8965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.852347+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289878+00:00"
               },
               "deterministic": true
             },
@@ -8978,7 +8978,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937192+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.888696+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9007,7 +9007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.852384+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289894+00:00"
               },
               "deterministic": true
             },
@@ -9020,7 +9020,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937221+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.888712+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9059,7 +9059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.852451+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9072,7 +9072,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937279+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.888743+00:00"
           },
           "uid": {
             "type": "string",
@@ -9089,7 +9089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.852485+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9103,7 +9103,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937310+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.888759+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of apm is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9193,8 +9193,8 @@
           "description": "Minimum configuration for apmMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for apmMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for apmMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/apm_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "label"
@@ -9229,7 +9229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.852558+00:00"
+                "validatedAt": "2026-05-09T01:32:30.289967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9274,7 +9274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.852643+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9301,7 +9301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.852688+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9354,7 +9354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.852742+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290042+00:00"
               },
               "deterministic": true
             },
@@ -9367,7 +9367,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937415+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.888814+00:00"
           },
           "start_time": {
             "type": "string",
@@ -9392,7 +9392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.852795+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9425,7 +9425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.852837+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9502,7 +9502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.852895+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9547,8 +9547,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for apmReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for apmReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/apm_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9560,8 +9560,8 @@
           "description": "Minimum configuration for apmReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for apmReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for apmReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/apm_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9772,7 +9772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853084+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9893,8 +9893,8 @@
           "description": "Minimum configuration for bigipapmMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigipapmMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigipapmMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigipapm_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -9922,7 +9922,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937841+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889031+00:00"
           },
           "value": {
             "type": "array",
@@ -9941,7 +9941,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937875+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889048+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -10003,8 +10003,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10033,7 +10033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.853196+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10046,7 +10046,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937939+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889082+00:00"
           },
           "name": {
             "type": "string",
@@ -10079,7 +10079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853234+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290253+00:00"
               },
               "deterministic": true
             },
@@ -10092,7 +10092,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937968+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889098+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10123,7 +10123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853271+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290270+00:00"
               },
               "deterministic": true
             },
@@ -10136,7 +10136,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.937998+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889114+00:00"
           },
           "tenant": {
             "type": "string",
@@ -10155,7 +10155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.853313+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10169,7 +10169,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938027+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889130+00:00"
           },
           "uid": {
             "type": "string",
@@ -10188,7 +10188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.853346+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10203,7 +10203,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938058+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889146+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -10242,8 +10242,8 @@
           "description": "Minimum configuration for nfv_serviceBMNodeMemorySize",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nfv_serviceBMNodeMemorySize\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nfv_serviceBMNodeMemorySize\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nfv_service_b_m_node_memory_sizes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -10265,8 +10265,8 @@
           "description": "Minimum configuration for nfv_serviceBMNodeVirtualCpuCount",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nfv_serviceBMNodeVirtualCpuCount\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nfv_serviceBMNodeVirtualCpuCount\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nfv_service_b_m_node_virtual_cpu_counts\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -10309,7 +10309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853438+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10349,7 +10349,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853524+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10392,7 +10392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853620+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10436,7 +10436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853695+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290453+00:00"
               },
               "deterministic": true
             },
@@ -10524,7 +10524,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853787+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10571,7 +10571,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853855+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10607,7 +10607,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.853941+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10647,7 +10647,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.854021+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10711,7 +10711,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.854109+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10745,7 +10745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.854168+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10830,7 +10830,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.854276+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10926,7 +10926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.854404+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10972,7 +10972,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.854489+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11007,7 +11007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.854547+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11092,7 +11092,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.854663+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11137,7 +11137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.854710+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11160,7 +11160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.854753+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11172,7 +11172,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938462+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889365+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -11215,7 +11215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.854812+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11253,7 +11253,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.854887+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11265,7 +11265,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938504+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889388+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -11284,7 +11284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.854938+00:00"
+                "validatedAt": "2026-05-09T01:32:30.290995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11335,7 +11335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.854984+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11347,7 +11347,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938546+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889409+00:00"
           },
           "url": {
             "type": "string",
@@ -11385,7 +11385,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.855061+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291051+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11442,7 +11442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:10:18.855102+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291068+00:00"
               },
               "deterministic": true
             },
@@ -11468,7 +11468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.855156+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11495,7 +11495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.855199+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11507,7 +11507,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938620+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889442+00:00"
           },
           "service_name": {
             "type": "string",
@@ -11524,7 +11524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.855249+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11557,7 +11557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.855294+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11569,7 +11569,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938662+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889462+00:00"
           },
           "type": {
             "type": "string",
@@ -11594,7 +11594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.855335+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11648,8 +11648,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11682,7 +11682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.855388+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11726,8 +11726,8 @@
           "description": "Minimum configuration for schemaHashAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_hash_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11773,7 +11773,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.855459+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11833,7 +11833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.855499+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291245+00:00"
               },
               "deterministic": true
             },
@@ -11846,7 +11846,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938751+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889508+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -11944,7 +11944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.855595+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11956,7 +11956,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938823+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889546+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -12034,7 +12034,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.855701+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291325+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12050,7 +12050,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938867+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889569+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12120,7 +12120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.855751+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291346+00:00"
               },
               "deterministic": true
             },
@@ -12133,7 +12133,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938917+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889596+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12164,7 +12164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.855787+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291362+00:00"
               },
               "deterministic": true
             },
@@ -12177,7 +12177,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938946+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889612+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -12259,7 +12259,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.855886+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291406+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12275,7 +12275,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.938990+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889634+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12347,7 +12347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.855935+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291428+00:00"
               },
               "deterministic": true
             },
@@ -12360,7 +12360,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939039+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889661+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12391,7 +12391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.855971+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291447+00:00"
               },
               "deterministic": true
             },
@@ -12404,7 +12404,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939068+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889677+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -12486,7 +12486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.856069+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291492+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12502,7 +12502,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939112+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889700+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12572,7 +12572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.856117+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291515+00:00"
               },
               "deterministic": true
             },
@@ -12585,7 +12585,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939162+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889726+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12616,7 +12616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.856152+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291535+00:00"
               },
               "deterministic": true
             },
@@ -12629,7 +12629,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939191+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889741+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -12689,7 +12689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.856211+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12727,8 +12727,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12786,7 +12786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856278+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12814,7 +12814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856333+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12842,7 +12842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856381+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12871,7 +12871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856431+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12898,7 +12898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856464+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12912,7 +12912,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939306+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889802+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -12928,7 +12928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856508+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12991,8 +12991,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13037,7 +13037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856570+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13049,7 +13049,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939368+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889834+00:00"
           },
           "status": {
             "type": "string",
@@ -13067,7 +13067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856626+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13079,7 +13079,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939397+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889850+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -13121,7 +13121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856682+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13148,7 +13148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856732+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13175,7 +13175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856779+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13203,7 +13203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856835+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13268,7 +13268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856915+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13317,7 +13317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.856979+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13330,7 +13330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939527+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889918+00:00"
           },
           "uid": {
             "type": "string",
@@ -13349,7 +13349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857012+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13363,7 +13363,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939557+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889934+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -13436,7 +13436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.857103+00:00"
+                "validatedAt": "2026-05-09T01:32:30.291997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13468,7 +13468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:10:18.857166+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13480,7 +13480,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939622+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889961+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -13529,8 +13529,8 @@
           "description": "Minimum configuration for schemaTlsProtocol",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tls_protocols\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13552,8 +13552,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13585,7 +13585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:10:18.857237+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13597,7 +13597,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939685+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.889994+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -13615,7 +13615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857287+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13643,7 +13643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857332+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13655,7 +13655,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939733+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.890019+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -13716,8 +13716,8 @@
           "description": "Minimum configuration for schemaUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13744,7 +13744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857371+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13756,7 +13756,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939767+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.890036+00:00"
           },
           "name": {
             "type": "string",
@@ -13789,7 +13789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.857407+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292142+00:00"
               },
               "deterministic": true
             },
@@ -13802,7 +13802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939797+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.890051+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13833,7 +13833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.857442+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292165+00:00"
               },
               "deterministic": true
             },
@@ -13846,7 +13846,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939826+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.890068+00:00"
           },
           "uid": {
             "type": "string",
@@ -13863,7 +13863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857473+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13877,7 +13877,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939857+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.890086+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -13917,8 +13917,8 @@
           "description": "Minimum configuration for schemaXfccElement",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_xfcc_elements\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13973,7 +13973,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.857546+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292222+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13989,7 +13989,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939890+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.890103+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14026,7 +14026,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.857628+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292261+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -14042,7 +14042,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939919+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.890119+00:00"
           },
           "tenant": {
             "type": "string",
@@ -14071,7 +14071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.857702+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14085,7 +14085,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.939949+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.890135+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -14123,8 +14123,8 @@
           "description": "Minimum configuration for terraform_parametersApplyStageState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersApplyStageState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersApplyStageState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_apply_stage_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14150,7 +14150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857767+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14178,7 +14178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857822+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14208,7 +14208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857880+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14234,7 +14234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857933+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14260,7 +14260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.857980+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14283,7 +14283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.858026+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14330,8 +14330,8 @@
           "description": "Minimum configuration for terraform_parametersDestroyStageState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersDestroyStageState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersDestroyStageState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_destroy_stage_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14352,8 +14352,8 @@
           "description": "Minimum configuration for terraform_parametersInfraState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersInfraState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersInfraState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_infra_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14420,7 +14420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:18.858077+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14478,7 +14478,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.858182+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14547,7 +14547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.858245+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14622,7 +14622,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.858321+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14720,7 +14720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:18.858430+00:00"
+                "validatedAt": "2026-05-09T01:32:30.292643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14866,8 +14866,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_iruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_iruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_irules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -14935,7 +14935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.164872+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14965,7 +14965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.164970+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14993,7 +14993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:21.165019+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15068,7 +15068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.165072+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303399+00:00"
               },
               "deterministic": true
             },
@@ -15081,7 +15081,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.000755+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.919742+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15111,7 +15111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.165112+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303418+00:00"
               },
               "deterministic": true
             },
@@ -15124,7 +15124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.000789+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.919758+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -15227,7 +15227,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.000891+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.919811+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -15288,7 +15288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.165285+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15318,7 +15318,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.165364+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15346,7 +15346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:21.165410+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15413,7 +15413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:10:21.165467+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15476,7 +15476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:10:21.165538+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15488,7 +15488,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001001+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.919867+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15554,7 +15554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.165606+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303631+00:00"
               },
               "deterministic": true
             },
@@ -15567,7 +15567,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001072+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.919904+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15596,7 +15596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.165645+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303648+00:00"
               },
               "deterministic": true
             },
@@ -15609,7 +15609,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001102+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.919920+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -15648,7 +15648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:21.165713+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15661,7 +15661,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001159+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.919950+00:00"
           },
           "uid": {
             "type": "string",
@@ -15678,7 +15678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:21.165746+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15692,7 +15692,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001190+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.919966+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bigip_irule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -15742,8 +15742,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_iruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_iruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_irule_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -15755,8 +15755,8 @@
           "description": "Minimum configuration for bigip_iruleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_iruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_iruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_irule_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -15796,7 +15796,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.165834+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15826,7 +15826,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.165911+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15854,7 +15854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:21.165955+00:00"
+                "validatedAt": "2026-05-09T01:32:31.303795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15961,7 +15961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:21.166895+00:00"
+                "validatedAt": "2026-05-09T01:32:31.304205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15974,7 +15974,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001804+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.920283+00:00"
           },
           "name": {
             "type": "string",
@@ -16007,7 +16007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.166930+00:00"
+                "validatedAt": "2026-05-09T01:32:31.304222+00:00"
               },
               "deterministic": true
             },
@@ -16020,7 +16020,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001833+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.920299+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16051,7 +16051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:21.166966+00:00"
+                "validatedAt": "2026-05-09T01:32:31.304239+00:00"
               },
               "deterministic": true
             },
@@ -16064,7 +16064,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001862+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.920314+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16083,7 +16083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:21.167008+00:00"
+                "validatedAt": "2026-05-09T01:32:31.304257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16097,7 +16097,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001891+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.920330+00:00"
           },
           "uid": {
             "type": "string",
@@ -16116,7 +16116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:21.167040+00:00"
+                "validatedAt": "2026-05-09T01:32:31.304272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16131,7 +16131,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.001921+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.920346+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -16172,7 +16172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.640826+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16247,7 +16247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.640915+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392432+00:00"
               },
               "deterministic": true
             },
@@ -16260,7 +16260,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.044469+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.940511+00:00"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -16315,7 +16315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.640990+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16340,7 +16340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.641039+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16373,7 +16373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.641102+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16497,7 +16497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.641184+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16586,7 +16586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.641276+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16610,7 +16610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.641327+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16681,7 +16681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.641389+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16705,7 +16705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.641443+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16774,7 +16774,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.641519+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16813,8 +16813,8 @@
           "description": "Minimum configuration for bigip_virtual_serverBigIpVirtualServerType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_virtual_serverBigIpVirtualServerType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_virtual_serverBigIpVirtualServerType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_virtual_server_big_ip_virtual_server_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -16902,7 +16902,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.044854+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.940702+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16976,7 +16976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.641681+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392742+00:00"
               },
               "deterministic": true
             },
@@ -16989,7 +16989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.044919+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.940734+00:00"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -17049,7 +17049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:10:23.641737+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17112,7 +17112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:10:23.641809+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17124,7 +17124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.044986+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.940769+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17190,7 +17190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.641860+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392819+00:00"
               },
               "deterministic": true
             },
@@ -17203,7 +17203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.045057+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.940806+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17232,7 +17232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.641896+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392837+00:00"
               },
               "deterministic": true
             },
@@ -17245,7 +17245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.045086+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.940822+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -17284,7 +17284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.641964+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17297,7 +17297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.045143+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.940853+00:00"
           },
           "uid": {
             "type": "string",
@@ -17315,7 +17315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.642001+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17329,7 +17329,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.045174+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.940869+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bigip_virtual_server is returned in 'List'.",
@@ -17379,8 +17379,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_virtual_serverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_virtual_serverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_virtual_server_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -17392,8 +17392,8 @@
           "description": "Minimum configuration for bigip_virtual_serverReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_virtual_serverReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_virtual_serverReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_virtual_server_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -17745,7 +17745,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.642270+00:00"
+                "validatedAt": "2026-05-09T01:32:32.392992+00:00"
               },
               "deterministic": true
             },
@@ -17828,7 +17828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.642341+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17940,7 +17940,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.642427+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17978,7 +17978,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.642514+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393111+00:00"
               },
               "deterministic": true
             },
@@ -18070,7 +18070,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.642606+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18128,7 +18128,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.642687+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18141,7 +18141,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.045573+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.941077+00:00"
           },
           "simple_login": {
             "$ref": "#/components/schemas/common_wafSimpleLogin"
@@ -18204,7 +18204,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.642787+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18243,7 +18243,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.642867+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18472,7 +18472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.642998+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18546,7 +18546,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.643073+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18609,7 +18609,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.643160+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18648,7 +18648,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.643239+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18689,7 +18689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.643327+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18760,7 +18760,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.643404+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393527+00:00"
               },
               "deterministic": true
             },
@@ -18825,7 +18825,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.643471+00:00"
+                "validatedAt": "2026-05-09T01:32:32.393558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18932,8 +18932,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18957,8 +18957,8 @@
           "description": "Minimum configuration for schemaHttpSections",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpSections\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpSections\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_sectionses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18995,7 +18995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.644579+00:00"
+                "validatedAt": "2026-05-09T01:32:32.394036+00:00"
               },
               "deterministic": true
             },
@@ -19008,7 +19008,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.046517+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.941570+00:00"
           },
           "name": {
             "type": "string",
@@ -19052,7 +19052,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.644658+00:00"
+                "validatedAt": "2026-05-09T01:32:32.394068+00:00"
               },
               "deterministic": true
             },
@@ -19064,7 +19064,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.046545+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.941585+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -19105,8 +19105,8 @@
           "description": "Minimum configuration for schemaOpenApiValidationProperties",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_open_api_validation_propertieses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19137,7 +19137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.646239+00:00"
+                "validatedAt": "2026-05-09T01:32:32.394763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19170,7 +19170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.646322+00:00"
+                "validatedAt": "2026-05-09T01:32:32.394801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19192,7 +19192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:23.646379+00:00"
+                "validatedAt": "2026-05-09T01:32:32.394824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19237,7 +19237,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:23.646477+00:00"
+                "validatedAt": "2026-05-09T01:32:32.394868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19374,8 +19374,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for application_profilesCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for application_profilesCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/application_profileses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19448,7 +19448,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.391568+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19484,7 +19484,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.391679+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19593,7 +19593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.391749+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338128+00:00"
               },
               "deterministic": true
             },
@@ -19606,7 +19606,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.443350+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.039496+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19636,7 +19636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.391789+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338147+00:00"
               },
               "deterministic": true
             },
@@ -19649,7 +19649,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.443384+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.039514+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19796,7 +19796,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.391937+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19832,7 +19832,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392003+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19895,7 +19895,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392072+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19932,7 +19932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392134+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19969,7 +19969,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392195+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20006,7 +20006,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392259+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20043,7 +20043,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392321+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20080,7 +20080,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392383+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20117,7 +20117,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392449+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20179,7 +20179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392513+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20216,7 +20216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392573+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20253,7 +20253,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392650+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20290,7 +20290,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392711+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20327,7 +20327,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392773+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20364,7 +20364,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392835+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20401,7 +20401,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.392898+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20472,7 +20472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:13:33.392955+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20535,7 +20535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:33.393029+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20547,7 +20547,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.443743+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.039697+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20613,7 +20613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393083+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338773+00:00"
               },
               "deterministic": true
             },
@@ -20626,7 +20626,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.443815+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.039735+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20655,7 +20655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393120+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338790+00:00"
               },
               "deterministic": true
             },
@@ -20668,7 +20668,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.443845+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.039751+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -20691,7 +20691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:33.393170+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20704,7 +20704,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.443893+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.039778+00:00"
           },
           "uid": {
             "type": "string",
@@ -20722,7 +20722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:33.393205+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20736,7 +20736,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.443925+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.039795+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of application_profiles is returned in 'List'.",
@@ -20785,8 +20785,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for application_profilesReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for application_profilesReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/application_profiles_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20798,8 +20798,8 @@
           "description": "Minimum configuration for application_profilesReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for application_profilesReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for application_profilesReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/application_profiles_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20844,7 +20844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393282+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20880,7 +20880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393343+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20944,7 +20944,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393410+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20981,7 +20981,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393471+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21039,7 +21039,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393532+00:00"
+                "validatedAt": "2026-05-09T01:33:56.338988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21076,7 +21076,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393606+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21144,7 +21144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393678+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21182,7 +21182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393740+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21268,7 +21268,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393860+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21306,7 +21306,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393919+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21343,7 +21343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.393986+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21380,7 +21380,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.394045+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21426,7 +21426,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.394115+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21469,7 +21469,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.394184+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21509,7 +21509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:33.394249+00:00"
+                "validatedAt": "2026-05-09T01:33:56.339341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22050,8 +22050,8 @@
           "description": "Minimum configuration for bigip_http_proxyBigIPHTTPDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_http_proxyBigIPHTTPDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_http_proxyBigIPHTTPDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_http_proxy_big_i_p_h_t_t_p_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -22100,8 +22100,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_http_proxyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_http_proxyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_http_proxies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -22184,7 +22184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.742702+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080466+00:00"
               },
               "deterministic": true
             },
@@ -22197,7 +22197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.008296+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.308751+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22227,7 +22227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.742774+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080489+00:00"
               },
               "deterministic": true
             },
@@ -22240,7 +22240,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.008328+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.308767+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22343,7 +22343,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.008428+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.308819+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22421,7 +22421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.743027+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080570+00:00"
               },
               "deterministic": true
             },
@@ -22525,7 +22525,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.743115+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22592,7 +22592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:13:48.743191+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080646+00:00"
               },
               "deterministic": true
             },
@@ -22633,7 +22633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:13:48.743235+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080667+00:00"
               },
               "deterministic": true
             },
@@ -22724,7 +22724,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.743323+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22814,7 +22814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:13:48.743385+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22877,7 +22877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:48.743458+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22889,7 +22889,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.008656+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.308935+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22955,7 +22955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.743512+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080790+00:00"
               },
               "deterministic": true
             },
@@ -22968,7 +22968,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.008726+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.308976+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22997,7 +22997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.743550+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080808+00:00"
               },
               "deterministic": true
             },
@@ -23010,7 +23010,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.008755+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.308992+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -23049,7 +23049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:48.743642+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23062,7 +23062,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.008812+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.309022+00:00"
           },
           "uid": {
             "type": "string",
@@ -23080,7 +23080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:48.743681+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23094,7 +23094,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.008843+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.309039+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bigip_http_proxy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23156,7 +23156,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.743756+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080888+00:00"
               },
               "deterministic": true
             },
@@ -23231,7 +23231,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.743835+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23269,7 +23269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.743875+00:00"
+                "validatedAt": "2026-05-09T01:34:03.080944+00:00"
               },
               "deterministic": true
             },
@@ -23351,8 +23351,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_http_proxyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_http_proxyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_http_proxy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -23364,8 +23364,8 @@
           "description": "Minimum configuration for bigip_http_proxyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bigip_http_proxyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bigip_http_proxyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bigip_http_proxy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -23465,7 +23465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744028+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23500,7 +23500,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744111+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23576,7 +23576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744159+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081070+00:00"
               },
               "deterministic": true
             },
@@ -23622,7 +23622,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744245+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23700,7 +23700,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744338+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23802,7 +23802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744434+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081198+00:00"
               },
               "deterministic": true
             },
@@ -23848,7 +23848,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744519+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23884,7 +23884,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744615+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23985,7 +23985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744719+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24089,7 +24089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744827+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081361+00:00"
               },
               "deterministic": true
             },
@@ -24135,7 +24135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744911+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24171,7 +24171,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.744990+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24265,7 +24265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:48.745265+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24340,7 +24340,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.745347+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24413,7 +24413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.745427+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24485,7 +24485,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.745506+00:00"
+                "validatedAt": "2026-05-09T01:34:03.081675+00:00"
               },
               "deterministic": true
             },
@@ -24550,8 +24550,8 @@
           "description": "Minimum configuration for origin_poolProtocolType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for origin_poolProtocolType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for origin_poolProtocolType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/origin_pool_protocol_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -24666,7 +24666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.748172+00:00"
+                "validatedAt": "2026-05-09T01:34:03.082825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24763,7 +24763,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.748462+00:00"
+                "validatedAt": "2026-05-09T01:34:03.082961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24825,7 +24825,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.748624+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24898,7 +24898,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.748816+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24974,8 +24974,8 @@
           "description": "Minimum configuration for viewsSiteNetwork",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_networks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -24997,8 +24997,8 @@
           "description": "Minimum configuration for viewsSiteNetworkSpecifiedVIP",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_network_specified_v_i_ps\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25063,7 +25063,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.748909+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25136,7 +25136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.748966+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083176+00:00"
               },
               "deterministic": true
             },
@@ -25183,7 +25183,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.749050+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25306,7 +25306,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.749166+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25341,7 +25341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.749243+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25436,7 +25436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.749319+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25606,7 +25606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:48.749451+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083387+00:00"
               },
               "deterministic": true
             },
@@ -25619,7 +25619,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.011843+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.310596+00:00"
           },
           "origin_servers": {
             "$ref": "#/components/schemas/bigip_http_proxyOriginServers"
@@ -25649,7 +25649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:48.749502+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25678,7 +25678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:48.749542+00:00"
+                "validatedAt": "2026-05-09T01:34:03.083426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25844,8 +25844,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for iruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for iruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/irules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -25911,7 +25911,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.831175+00:00"
+                "validatedAt": "2026-05-09T01:34:18.632926+00:00"
               },
               "deterministic": true
             },
@@ -25924,7 +25924,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014398+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.791929+00:00"
           },
           "irule": {
             "type": "string",
@@ -25951,7 +25951,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.831250+00:00"
+                "validatedAt": "2026-05-09T01:34:18.632965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26026,7 +26026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.831299+00:00"
+                "validatedAt": "2026-05-09T01:34:18.632991+00:00"
               },
               "deterministic": true
             },
@@ -26039,7 +26039,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014450+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.791956+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26069,7 +26069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.831336+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633010+00:00"
               },
               "deterministic": true
             },
@@ -26082,7 +26082,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014480+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.791972+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26222,7 +26222,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.831510+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633102+00:00"
               },
               "deterministic": true
             },
@@ -26235,7 +26235,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014604+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.792030+00:00"
           },
           "irule": {
             "type": "string",
@@ -26262,7 +26262,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.831597+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26328,7 +26328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:23.831660+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26390,7 +26390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:23.831730+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26402,7 +26402,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014683+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.792070+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26468,7 +26468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.831783+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633261+00:00"
               },
               "deterministic": true
             },
@@ -26481,7 +26481,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014753+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.792107+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26510,7 +26510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.831820+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633280+00:00"
               },
               "deterministic": true
             },
@@ -26523,7 +26523,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014781+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.792123+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26546,7 +26546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:23.831872+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26559,7 +26559,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014829+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.792149+00:00"
           },
           "uid": {
             "type": "string",
@@ -26576,7 +26576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:23.831905+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26590,7 +26590,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014860+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.792171+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of irule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -26639,8 +26639,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for iruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for iruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/irule_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -26652,8 +26652,8 @@
           "description": "Minimum configuration for iruleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for iruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for iruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/irule_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -26691,7 +26691,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.832009+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633388+00:00"
               },
               "deterministic": true
             },
@@ -26704,7 +26704,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.014914+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.792199+00:00"
           },
           "irule": {
             "type": "string",
@@ -26731,7 +26731,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:23.832078+00:00"
+                "validatedAt": "2026-05-09T01:34:18.633430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26916,8 +26916,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for data_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for data_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/data_groups\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -27000,7 +27000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:33.389471+00:00"
+                "validatedAt": "2026-05-09T01:34:49.387872+00:00"
               },
               "deterministic": true
             },
@@ -27013,7 +27013,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.615900+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.548017+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27043,7 +27043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:33.389544+00:00"
+                "validatedAt": "2026-05-09T01:34:49.387894+00:00"
               },
               "deterministic": true
             },
@@ -27056,7 +27056,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.615932+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.548034+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27245,7 +27245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:33.389778+00:00"
+                "validatedAt": "2026-05-09T01:34:49.387951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27308,7 +27308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:33.389851+00:00"
+                "validatedAt": "2026-05-09T01:34:49.387981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27320,7 +27320,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.616094+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.548118+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27386,7 +27386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:33.389907+00:00"
+                "validatedAt": "2026-05-09T01:34:49.388003+00:00"
               },
               "deterministic": true
             },
@@ -27399,7 +27399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.616164+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.548160+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27428,7 +27428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:33.389948+00:00"
+                "validatedAt": "2026-05-09T01:34:49.388021+00:00"
               },
               "deterministic": true
             },
@@ -27441,7 +27441,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.616193+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.548176+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27464,7 +27464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:33.390000+00:00"
+                "validatedAt": "2026-05-09T01:34:49.388042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27477,7 +27477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.616241+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.548202+00:00"
           },
           "uid": {
             "type": "string",
@@ -27494,7 +27494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:33.390033+00:00"
+                "validatedAt": "2026-05-09T01:34:49.388056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27508,7 +27508,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.616272+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.548219+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of data_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27557,8 +27557,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for data_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for data_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/data_group_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"
@@ -27570,8 +27570,8 @@
           "description": "Minimum configuration for data_groupReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for data_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for data_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/data_group_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bigip"

--- a/docs/specifications/api/billing_and_usage.json
+++ b/docs/specifications/api/billing_and_usage.json
@@ -5741,7 +5741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:30.082859+00:00"
+                "validatedAt": "2026-05-09T01:32:35.238839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5768,7 +5768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:30.082954+00:00"
+                "validatedAt": "2026-05-09T01:32:35.238872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5780,7 +5780,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.175055+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.004223+00:00"
           }
         },
         "x-f5xc-description-short": "Billing Metric Data represents billing metric metadata like unit as well as converted metric value.",
@@ -5827,7 +5827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:30.083049+00:00"
+                "validatedAt": "2026-05-09T01:32:35.238898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5860,7 +5860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:30.083147+00:00"
+                "validatedAt": "2026-05-09T01:32:35.238920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5944,7 +5944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:30.083249+00:00"
+                "validatedAt": "2026-05-09T01:32:35.238948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6009,7 +6009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:30.083302+00:00"
+                "validatedAt": "2026-05-09T01:32:35.238971+00:00"
               },
               "deterministic": true
             },
@@ -6022,7 +6022,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.175157+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.004275+00:00"
           },
           "service": {
             "type": "string",
@@ -6040,7 +6040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:30.083347+00:00"
+                "validatedAt": "2026-05-09T01:32:35.238991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6108,7 +6108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:30.083413+00:00"
+                "validatedAt": "2026-05-09T01:32:35.239019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6120,7 +6120,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.175218+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.004308+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Billing Metrics query.",
@@ -6160,7 +6160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:04.561927+00:00"
+                "validatedAt": "2026-05-09T01:36:23.442966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6205,8 +6205,8 @@
           "description": "Minimum configuration for invoiceInvoiceStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for invoiceInvoiceStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for invoiceInvoiceStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/invoice_invoice_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6251,7 +6251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:04.562046+00:00"
+                "validatedAt": "2026-05-09T01:36:23.443006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6276,7 +6276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:04.562129+00:00"
+                "validatedAt": "2026-05-09T01:36:23.443026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6315,7 +6315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:04.562205+00:00"
+                "validatedAt": "2026-05-09T01:36:23.443047+00:00"
               },
               "deterministic": true
             },
@@ -6328,7 +6328,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.732271+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.481453+00:00"
           },
           "period_end": {
             "type": "string",
@@ -6347,7 +6347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:04.562298+00:00"
+                "validatedAt": "2026-05-09T01:36:23.443067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6374,7 +6374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:04.562356+00:00"
+                "validatedAt": "2026-05-09T01:36:23.443089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6460,8 +6460,8 @@
           "description": "Minimum configuration for contactContactType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for contactContactType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for contactContactType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/contact_contact_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -6488,7 +6488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:52.894811+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6513,7 +6513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:52.894918+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6538,7 +6538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:52.895003+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6566,7 +6566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:52.895092+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6591,7 +6591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:52.895152+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6617,7 +6617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:52.895208+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6642,7 +6642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:52.895249+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6667,7 +6667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:52.895298+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6692,7 +6692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:52.895343+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6765,7 +6765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:52.895396+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748350+00:00"
               },
               "deterministic": true
             },
@@ -6778,7 +6778,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.940067+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.961959+00:00"
           },
           "role": {
             "$ref": "#/components/schemas/payment_methodPaymentMethodRole"
@@ -6801,7 +6801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:21:52.895450+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6861,7 +6861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:52.895491+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748392+00:00"
               },
               "deterministic": true
             },
@@ -6874,7 +6874,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.940125+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.961987+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6926,7 +6926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:52.895528+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748410+00:00"
               },
               "deterministic": true
             },
@@ -6939,7 +6939,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.940157+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.962004+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6969,7 +6969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:52.895564+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748426+00:00"
               },
               "deterministic": true
             },
@@ -6982,7 +6982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.940187+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.962020+00:00"
           }
         },
         "x-f5xc-description-short": "Changes a payment method role to primary.",
@@ -7018,8 +7018,8 @@
           "description": "Minimum configuration for payment_methodPaymentMethodRole",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for payment_methodPaymentMethodRole\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for payment_methodPaymentMethodRole\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/payment_method_payment_method_roles\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -7061,7 +7061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:52.895621+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748444+00:00"
               },
               "deterministic": true
             },
@@ -7074,7 +7074,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.940221+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.962037+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7104,7 +7104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:52.895659+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748461+00:00"
               },
               "deterministic": true
             },
@@ -7117,7 +7117,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.940250+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.962052+00:00"
           }
         },
         "x-f5xc-description-short": "Changes a payment method role (from/to primary or backup).",
@@ -7171,7 +7171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:52.895697+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748478+00:00"
               },
               "deterministic": true
             },
@@ -7184,7 +7184,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.940281+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.962069+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7214,7 +7214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:52.895735+00:00"
+                "validatedAt": "2026-05-09T01:37:39.748495+00:00"
               },
               "deterministic": true
             },
@@ -7227,7 +7227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.940310+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.962084+00:00"
           }
         },
         "x-f5xc-description-short": "Changes a payment method role to secondary.",
@@ -7303,7 +7303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:05.778795+00:00"
+                "validatedAt": "2026-05-09T01:37:45.536777+00:00"
               },
               "deterministic": true
             },
@@ -7316,7 +7316,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.136192+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.051279+00:00"
           },
           "new_plan": {
             "type": "string",
@@ -7334,7 +7334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.778897+00:00"
+                "validatedAt": "2026-05-09T01:37:45.536806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7388,7 +7388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.778966+00:00"
+                "validatedAt": "2026-05-09T01:37:45.536823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7448,8 +7448,8 @@
           "description": "Minimum configuration for plan_transitionState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for plan_transitionState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for plan_transitionState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/plan_transition_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -7481,7 +7481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779098+00:00"
+                "validatedAt": "2026-05-09T01:37:45.536855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7522,7 +7522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779201+00:00"
+                "validatedAt": "2026-05-09T01:37:45.536879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7550,7 +7550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779254+00:00"
+                "validatedAt": "2026-05-09T01:37:45.536902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7563,7 +7563,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.136324+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.051344+00:00"
           },
           "payment_address": {
             "$ref": "#/components/schemas/schemacontactGlobalSpecType"
@@ -7584,7 +7584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779315+00:00"
+                "validatedAt": "2026-05-09T01:37:45.536927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7628,7 +7628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779391+00:00"
+                "validatedAt": "2026-05-09T01:37:45.536959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7654,7 +7654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779445+00:00"
+                "validatedAt": "2026-05-09T01:37:45.536983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7730,7 +7730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779515+00:00"
+                "validatedAt": "2026-05-09T01:37:45.537012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7755,7 +7755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779560+00:00"
+                "validatedAt": "2026-05-09T01:37:45.537034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7780,7 +7780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779618+00:00"
+                "validatedAt": "2026-05-09T01:37:45.537052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7808,7 +7808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779668+00:00"
+                "validatedAt": "2026-05-09T01:37:45.537074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7833,7 +7833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779712+00:00"
+                "validatedAt": "2026-05-09T01:37:45.537093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7859,7 +7859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779762+00:00"
+                "validatedAt": "2026-05-09T01:37:45.537114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7884,7 +7884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779804+00:00"
+                "validatedAt": "2026-05-09T01:37:45.537133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7909,7 +7909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779853+00:00"
+                "validatedAt": "2026-05-09T01:37:45.537161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7934,7 +7934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:05.779899+00:00"
+                "validatedAt": "2026-05-09T01:37:45.537181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7988,8 +7988,8 @@
           "description": "Minimum configuration for tenantDeletionReason",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenantDeletionReason\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenantDeletionReason\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_deletion_reasons\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -8011,7 +8011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.487630+00:00"
+                "validatedAt": "2026-05-09T01:38:00.658867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8034,7 +8034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.487737+00:00"
+                "validatedAt": "2026-05-09T01:38:00.658901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8046,7 +8046,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.738921+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325506+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -8085,8 +8085,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for quotaCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for quotaCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/quotas\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -8169,7 +8169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.487816+00:00"
+                "validatedAt": "2026-05-09T01:38:00.658936+00:00"
               },
               "deterministic": true
             },
@@ -8182,7 +8182,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739022+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325556+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8212,7 +8212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.487856+00:00"
+                "validatedAt": "2026-05-09T01:38:00.658958+00:00"
               },
               "deterministic": true
             },
@@ -8225,7 +8225,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739053+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325572+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8463,7 +8463,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739244+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325666+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8669,7 +8669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:22:39.488094+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8731,7 +8731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:22:39.488164+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8743,7 +8743,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739405+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325748+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8809,7 +8809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.488218+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659116+00:00"
               },
               "deterministic": true
             },
@@ -8822,7 +8822,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739475+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325784+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8851,7 +8851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.488255+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659134+00:00"
               },
               "deterministic": true
             },
@@ -8864,7 +8864,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739504+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325800+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8903,7 +8903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.488323+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8916,7 +8916,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739562+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325830+00:00"
           },
           "uid": {
             "type": "string",
@@ -8933,7 +8933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.488358+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8947,7 +8947,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739607+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325846+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of quota is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9023,7 +9023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.488422+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9071,8 +9071,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for quotaReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for quotaReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/quota_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -9084,8 +9084,8 @@
           "description": "Minimum configuration for quotaReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for quotaReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for quotaReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/quota_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -9173,7 +9173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:22:39.488512+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659257+00:00"
               },
               "deterministic": true
             },
@@ -9199,7 +9199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.488565+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9226,7 +9226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.488641+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9238,7 +9238,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739747+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325917+00:00"
           },
           "service_name": {
             "type": "string",
@@ -9255,7 +9255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.488696+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9288,7 +9288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.488749+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9300,7 +9300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739786+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325937+00:00"
           },
           "type": {
             "type": "string",
@@ -9325,7 +9325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.488791+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9379,8 +9379,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9413,7 +9413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.488846+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9475,7 +9475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.488886+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659411+00:00"
               },
               "deterministic": true
             },
@@ -9488,7 +9488,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739860+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.325976+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -9606,7 +9606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489016+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659470+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -9622,7 +9622,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739926+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326009+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -9692,7 +9692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489069+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659493+00:00"
               },
               "deterministic": true
             },
@@ -9705,7 +9705,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.739977+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326036+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9736,7 +9736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489106+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659510+00:00"
               },
               "deterministic": true
             },
@@ -9749,7 +9749,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740007+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326052+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -9831,7 +9831,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489204+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659559+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -9847,7 +9847,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740052+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326074+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -9919,7 +9919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489253+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659582+00:00"
               },
               "deterministic": true
             },
@@ -9932,7 +9932,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740102+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326101+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9963,7 +9963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489288+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659599+00:00"
               },
               "deterministic": true
             },
@@ -9976,7 +9976,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740132+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326116+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -10021,7 +10021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.489330+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10034,7 +10034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740164+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326133+00:00"
           },
           "name": {
             "type": "string",
@@ -10067,7 +10067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489365+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659634+00:00"
               },
               "deterministic": true
             },
@@ -10080,7 +10080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740194+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326148+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10111,7 +10111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489401+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659651+00:00"
               },
               "deterministic": true
             },
@@ -10124,7 +10124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740223+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326169+00:00"
           },
           "tenant": {
             "type": "string",
@@ -10143,7 +10143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.489444+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10157,7 +10157,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740252+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326184+00:00"
           },
           "uid": {
             "type": "string",
@@ -10176,7 +10176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.489476+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10191,7 +10191,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740283+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326201+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -10273,7 +10273,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489575+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659735+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10289,7 +10289,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740328+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326223+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -10359,7 +10359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489642+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659757+00:00"
               },
               "deterministic": true
             },
@@ -10372,7 +10372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740378+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326250+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10403,7 +10403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.489678+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659774+00:00"
               },
               "deterministic": true
             },
@@ -10416,7 +10416,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740407+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326265+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -10461,7 +10461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.489735+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10489,7 +10489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.489786+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10517,7 +10517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.489834+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10546,7 +10546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.489885+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10573,7 +10573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.489917+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10587,7 +10587,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740488+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326307+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -10603,7 +10603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.489962+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10666,8 +10666,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10712,7 +10712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490022+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10724,7 +10724,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740551+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326340+00:00"
           },
           "status": {
             "type": "string",
@@ -10742,7 +10742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490066+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10754,7 +10754,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740580+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326355+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -10796,7 +10796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490123+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10823,7 +10823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490173+00:00"
+                "validatedAt": "2026-05-09T01:38:00.659990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10850,7 +10850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490220+00:00"
+                "validatedAt": "2026-05-09T01:38:00.660011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10878,7 +10878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490274+00:00"
+                "validatedAt": "2026-05-09T01:38:00.660034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10943,7 +10943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490355+00:00"
+                "validatedAt": "2026-05-09T01:38:00.660067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10992,7 +10992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490420+00:00"
+                "validatedAt": "2026-05-09T01:38:00.660094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11005,7 +11005,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740725+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326423+00:00"
           },
           "uid": {
             "type": "string",
@@ -11024,7 +11024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490453+00:00"
+                "validatedAt": "2026-05-09T01:38:00.660108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11038,7 +11038,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740756+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326439+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -11088,7 +11088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490492+00:00"
+                "validatedAt": "2026-05-09T01:38:00.660129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11100,7 +11100,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740788+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326456+00:00"
           },
           "name": {
             "type": "string",
@@ -11133,7 +11133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.490529+00:00"
+                "validatedAt": "2026-05-09T01:38:00.660146+00:00"
               },
               "deterministic": true
             },
@@ -11146,7 +11146,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740817+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326471+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11177,7 +11177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:39.490564+00:00"
+                "validatedAt": "2026-05-09T01:38:00.660170+00:00"
               },
               "deterministic": true
             },
@@ -11190,7 +11190,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740846+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326486+00:00"
           },
           "uid": {
             "type": "string",
@@ -11207,7 +11207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:39.490610+00:00"
+                "validatedAt": "2026-05-09T01:38:00.660184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11221,7 +11221,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.740877+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.326502+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -11689,7 +11689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231171+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11717,7 +11717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231284+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11745,7 +11745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231392+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11804,7 +11804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231527+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11843,7 +11843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231568+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11857,7 +11857,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.583728+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.614205+00:00"
           }
         },
         "x-f5xc-description-short": "Response to call to GET list of tenant subscriptions.",
@@ -11906,7 +11906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231647+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11962,7 +11962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231716+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11990,7 +11990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231777+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12031,7 +12031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:42.231821+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099950+00:00"
               },
               "deterministic": true
             },
@@ -12044,7 +12044,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.583817+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.614248+00:00"
           },
           "plan_name": {
             "type": "string",
@@ -12061,7 +12061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231871+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12086,7 +12086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231925+00:00"
+                "validatedAt": "2026-05-09T01:39:23.099994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12128,7 +12128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:42.231992+00:00"
+                "validatedAt": "2026-05-09T01:39:23.100025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12171,8 +12171,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12260,8 +12260,8 @@
           "description": "Minimum configuration for subscriptionSubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_subscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -12349,8 +12349,8 @@
           "description": "Minimum configuration for subscriptionUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -12374,8 +12374,8 @@
           "description": "Minimum configuration for schemausageStatusType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemausageStatusType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemausageStatusType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemausage_status_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -12404,7 +12404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.945715+00:00"
+                "validatedAt": "2026-05-09T01:40:13.291928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12429,7 +12429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.945793+00:00"
+                "validatedAt": "2026-05-09T01:40:13.291961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12456,7 +12456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.945846+00:00"
+                "validatedAt": "2026-05-09T01:40:13.291984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12532,7 +12532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.945943+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12559,7 +12559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.945996+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12587,7 +12587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946050+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12612,7 +12612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946104+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12637,7 +12637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946152+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12721,7 +12721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946227+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12733,7 +12733,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.617995+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.555837+00:00"
           }
         },
         "x-f5xc-description-short": "Coupon details, discount type, amount and name.",
@@ -12769,8 +12769,8 @@
           "description": "Minimum configuration for usageDiscountType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for usageDiscountType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for usageDiscountType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/usage_discount_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -12798,7 +12798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946282+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12831,7 +12831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946336+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12858,7 +12858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946387+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12900,7 +12900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946455+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12925,7 +12925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946502+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12979,7 +12979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946544+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13016,7 +13016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:33.946603+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292307+00:00"
               },
               "deterministic": true
             },
@@ -13029,7 +13029,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.618102+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.555891+00:00"
           },
           "to": {
             "type": "string",
@@ -13048,7 +13048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946639+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13113,7 +13113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946706+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13140,7 +13140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946755+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13217,7 +13217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:33.946814+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292395+00:00"
               },
               "deterministic": true
             },
@@ -13230,7 +13230,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.618186+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.555935+00:00"
           },
           "query": {
             "type": "string",
@@ -13249,7 +13249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:27:33.946870+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13345,7 +13345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:33.946931+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292444+00:00"
               },
               "deterministic": true
             },
@@ -13358,7 +13358,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.618240+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.555963+00:00"
           }
         },
         "x-f5xc-description-short": "Request message to GET mon thly usage details.",
@@ -13436,7 +13436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.946991+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13473,7 +13473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:33.947029+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292486+00:00"
               },
               "deterministic": true
             },
@@ -13486,7 +13486,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.618293+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.555991+00:00"
           },
           "to": {
             "type": "string",
@@ -13505,7 +13505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947062+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13590,7 +13590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947129+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13615,7 +13615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947179+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13642,7 +13642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947232+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13669,7 +13669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947284+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13720,7 +13720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947336+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13771,7 +13771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947415+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13802,7 +13802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947467+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13839,7 +13839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:33.947504+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292687+00:00"
               },
               "deterministic": true
             },
@@ -13852,7 +13852,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.618427+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.556061+00:00"
           },
           "object_name": {
             "type": "string",
@@ -13870,7 +13870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947556+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13912,7 +13912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947639+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13937,7 +13937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947687+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13962,7 +13962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:33.947735+00:00"
+                "validatedAt": "2026-05-09T01:40:13.292778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14021,7 +14021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:37.981902+00:00"
+                "validatedAt": "2026-05-09T01:40:15.068336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14060,7 +14060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:37.981981+00:00"
+                "validatedAt": "2026-05-09T01:40:15.068363+00:00"
               },
               "deterministic": true
             },
@@ -14073,7 +14073,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.672350+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.580598+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14146,7 +14146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:37.982107+00:00"
+                "validatedAt": "2026-05-09T01:40:15.068393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14206,8 +14206,8 @@
           "description": "Minimum configuration for planPeriodUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for planPeriodUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for planPeriodUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/plan_period_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14285,7 +14285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:37.982300+00:00"
+                "validatedAt": "2026-05-09T01:40:15.068437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14297,7 +14297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.672462+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.580654+00:00"
           },
           "flat_price": {
             "type": "integer",
@@ -14359,7 +14359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:37.982380+00:00"
+                "validatedAt": "2026-05-09T01:40:15.068468+00:00"
               },
               "deterministic": true
             },
@@ -14372,7 +14372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.672512+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.580680+00:00"
           },
           "renewal_period_unit": {
             "$ref": "#/components/schemas/planPeriodUnitType"
@@ -14396,7 +14396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:37.982435+00:00"
+                "validatedAt": "2026-05-09T01:40:15.068491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14424,7 +14424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:37.982481+00:00"
+                "validatedAt": "2026-05-09T01:40:15.068510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14436,7 +14436,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.672594+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.580716+00:00"
           },
           "transition_flow": {
             "$ref": "#/components/schemas/planUsagePlanTransitionFlow"
@@ -14512,8 +14512,8 @@
           "description": "Minimum configuration for planPlanState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for planPlanState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for planPlanState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/plan_plan_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14537,8 +14537,8 @@
           "description": "Minimum configuration for planPlanTransitionMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for planPlanTransitionMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for planPlanTransitionMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/plan_plan_transition_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14562,8 +14562,8 @@
           "description": "Minimum configuration for planPlanTransitionRequiredField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for planPlanTransitionRequiredField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for planPlanTransitionRequiredField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/plan_plan_transition_required_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14728,8 +14728,8 @@
           "description": "Minimum configuration for rate_limiterLeakyBucketRateLimiter",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterLeakyBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterLeakyBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_leaky_bucket_rate_limiters\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -14782,8 +14782,8 @@
           "description": "Minimum configuration for rate_limiterRateLimitPeriodUnit",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_rate_limit_period_units\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -14798,8 +14798,8 @@
           "description": "Minimum configuration for rate_limiterTokenBucketRateLimiter",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterTokenBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterTokenBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_token_bucket_rate_limiters\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -14823,8 +14823,8 @@
           "description": "Minimum configuration for schemaPlanType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaPlanType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaPlanType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_plan_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14847,8 +14847,8 @@
           "description": "Minimum configuration for schemaTenantType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTenantType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTenantType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tenant_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"

--- a/docs/specifications/api/blindfold.json
+++ b/docs/specifications/api/blindfold.json
@@ -7347,7 +7347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:38.444690+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7393,7 +7393,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:38.444809+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7431,7 +7431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:38.444918+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7476,8 +7476,8 @@
           "description": "Minimum configuration for policyRuleAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyRuleAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyRuleAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_rule_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7500,8 +7500,8 @@
           "description": "Minimum configuration for policyRuleCombiningAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyRuleCombiningAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyRuleCombiningAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_rule_combining_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7529,8 +7529,8 @@
           "description": "Minimum configuration for policyTransformer",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_transformers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7579,7 +7579,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:38.445012+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7642,7 +7642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:38.445115+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7767,7 +7767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:38.445212+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7793,7 +7793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:38.445269+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7818,7 +7818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:38.445312+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7831,7 +7831,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.937501+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.171597+00:00"
           }
         },
         "x-f5xc-description-short": "F5XC Secret Management uses asymmetric cryptography for securing secrets.",
@@ -7887,7 +7887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:38.445359+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321908+00:00"
               },
               "deterministic": true
             },
@@ -7900,7 +7900,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.937536+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.171614+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7929,7 +7929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:38.445401+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321928+00:00"
               },
               "deterministic": true
             },
@@ -7942,7 +7942,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.937566+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.171630+00:00"
           },
           "policy_id": {
             "type": "string",
@@ -7971,7 +7971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:38.445454+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8000,7 +8000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:38.445500+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8013,7 +8013,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.937639+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.171656+00:00"
           }
         },
         "x-f5xc-description-short": "Policy_data contains the information about the secret policy and all the secret policy rules for the policy.",
@@ -8064,7 +8064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:38.445548+00:00"
+                "validatedAt": "2026-05-09T01:35:18.321995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8108,7 +8108,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.019466+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208511+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -8144,7 +8144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195297+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8193,7 +8193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195376+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8250,7 +8250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195431+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8289,7 +8289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:16:43.195493+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427550+00:00"
               },
               "deterministic": true
             },
@@ -8356,7 +8356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195566+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8439,7 +8439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195649+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8462,7 +8462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195684+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8474,7 +8474,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.019672+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208605+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -8567,7 +8567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195758+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8591,7 +8591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195792+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8603,7 +8603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.019761+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208650+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -8645,7 +8645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195841+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8669,7 +8669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195875+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8681,7 +8681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.019816+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208677+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -8719,7 +8719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195918+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8776,7 +8776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195965+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8800,7 +8800,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.195998+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8812,7 +8812,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.019883+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208712+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -8867,8 +8867,8 @@
           "description": "Minimum configuration for logKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/log_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -8892,7 +8892,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.019928+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208735+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -8949,7 +8949,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.019973+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208758+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -8985,7 +8985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196081+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9096,7 +9096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196154+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9162,7 +9162,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020091+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208817+00:00"
           },
           "value": {
             "type": "number",
@@ -9178,7 +9178,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020119+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208832+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -9215,7 +9215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196226+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9319,7 +9319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196307+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9344,7 +9344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196354+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9369,7 +9369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196397+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9395,7 +9395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196447+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9441,8 +9441,8 @@
           "description": "Minimum configuration for metricsVoltShareMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for metricsVoltShareMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for metricsVoltShareMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/metrics_volt_share_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -9475,7 +9475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196497+00:00"
+                "validatedAt": "2026-05-09T01:35:20.427996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9487,7 +9487,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020262+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208903+00:00"
           }
         },
         "x-f5xc-description-short": "VoltShare Access metric is tagged with labels mentioned in MetricLabel.",
@@ -9522,8 +9522,8 @@
           "description": "Minimum configuration for metricsVoltShareMetricLabelOp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for metricsVoltShareMetricLabelOp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for metricsVoltShareMetricLabelOp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/metrics_volt_share_metric_label_ops\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -9565,7 +9565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196556+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9577,7 +9577,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020307+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208926+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a VoltShare Access Metrics query.",
@@ -9610,8 +9610,8 @@
           "description": "Minimum configuration for schemaSortOrder",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_sort_orders\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9632,8 +9632,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9661,7 +9661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:43.196637+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9673,7 +9673,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020343+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208944+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -9688,7 +9688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196689+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9714,7 +9714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196737+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9726,7 +9726,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020395+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208971+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -9790,7 +9790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196799+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9828,7 +9828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:43.196840+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428146+00:00"
               },
               "deterministic": true
             },
@@ -9841,7 +9841,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020450+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.208999+00:00"
           },
           "query": {
             "type": "string",
@@ -9861,7 +9861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:16:43.196894+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9894,7 +9894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.196944+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9961,7 +9961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197000+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10030,7 +10030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197055+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10059,7 +10059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:16:43.197098+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10097,7 +10097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:43.197138+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428288+00:00"
               },
               "deterministic": true
             },
@@ -10110,7 +10110,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020559+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.209055+00:00"
           },
           "query": {
             "type": "string",
@@ -10130,7 +10130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:16:43.197191+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10183,7 +10183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197249+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10270,7 +10270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197316+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10299,7 +10299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197364+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10361,7 +10361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:43.197403+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428411+00:00"
               },
               "deterministic": true
             },
@@ -10374,7 +10374,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020690+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.209116+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -10392,7 +10392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197450+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10449,7 +10449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197515+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10485,7 +10485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197597+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10533,7 +10533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197656+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10598,7 +10598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197733+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10629,7 +10629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197785+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10655,7 +10655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197837+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10715,7 +10715,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:43.197908+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10741,7 +10741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.197965+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10809,7 +10809,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:43.198061+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10860,7 +10860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.198127+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10897,7 +10897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:16:43.198185+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428770+00:00"
               },
               "deterministic": true
             },
@@ -10967,7 +10967,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:43.198270+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428812+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11012,7 +11012,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:43.198346+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11024,7 +11024,7 @@
             "x-field-mutability": "read-only",
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020924+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.209260+00:00"
           }
         },
         "x-f5xc-description-short": "UserRecordType contains information about a user.",
@@ -11071,7 +11071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.198400+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11143,7 +11143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:43.198469+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428900+00:00"
               },
               "deterministic": true
             },
@@ -11156,7 +11156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.020986+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.209293+00:00"
           },
           "start_time": {
             "type": "string",
@@ -11181,7 +11181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.198520+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11214,7 +11214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.198560+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11291,7 +11291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:43.198630+00:00"
+                "validatedAt": "2026-05-09T01:35:20.428964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11340,7 +11340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:10.158376+00:00"
+                "validatedAt": "2026-05-09T01:35:32.378238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11392,8 +11392,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11415,7 +11415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.560208+00:00"
+                "validatedAt": "2026-05-09T01:38:28.046860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11438,7 +11438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.560315+00:00"
+                "validatedAt": "2026-05-09T01:38:28.046896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11450,7 +11450,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.091462+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959343+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -11490,7 +11490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.560400+00:00"
+                "validatedAt": "2026-05-09T01:38:28.046918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11551,7 +11551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.560490+00:00"
+                "validatedAt": "2026-05-09T01:38:28.046943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11690,7 +11690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.560612+00:00"
+                "validatedAt": "2026-05-09T01:38:28.046975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11728,7 +11728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.560703+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11740,7 +11740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.091596+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959403+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -11759,7 +11759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.560757+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11810,7 +11810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.560805+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11822,7 +11822,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.091641+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959425+00:00"
           },
           "url": {
             "type": "string",
@@ -11860,7 +11860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.560888+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047103+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11917,7 +11917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:23:40.560934+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047124+00:00"
               },
               "deterministic": true
             },
@@ -11943,7 +11943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.560987+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11970,7 +11970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.561031+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11982,7 +11982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.091703+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959458+00:00"
           },
           "service_name": {
             "type": "string",
@@ -11999,7 +11999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.561082+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12032,7 +12032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.561129+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12044,7 +12044,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.091743+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959478+00:00"
           },
           "type": {
             "type": "string",
@@ -12069,7 +12069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.561170+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12123,8 +12123,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12157,7 +12157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.561222+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12201,8 +12201,8 @@
           "description": "Minimum configuration for schemaHashAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_hash_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12248,7 +12248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561296+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12316,7 +12316,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561393+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12386,7 +12386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561443+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047369+00:00"
               },
               "deterministic": true
             },
@@ -12399,7 +12399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.091880+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959549+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -12491,7 +12491,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561523+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12609,7 +12609,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561657+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047458+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12625,7 +12625,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.091989+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959605+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12695,7 +12695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561711+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047480+00:00"
               },
               "deterministic": true
             },
@@ -12708,7 +12708,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092041+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959631+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12739,7 +12739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561750+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047497+00:00"
               },
               "deterministic": true
             },
@@ -12752,7 +12752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092070+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959647+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -12834,7 +12834,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561850+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047543+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12850,7 +12850,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092113+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959669+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12922,7 +12922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561899+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047564+00:00"
               },
               "deterministic": true
             },
@@ -12935,7 +12935,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092163+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959696+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12966,7 +12966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.561936+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047581+00:00"
               },
               "deterministic": true
             },
@@ -12979,7 +12979,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092193+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959711+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -13024,7 +13024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.561976+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13037,7 +13037,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092224+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959728+00:00"
           },
           "name": {
             "type": "string",
@@ -13070,7 +13070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.562012+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047615+00:00"
               },
               "deterministic": true
             },
@@ -13083,7 +13083,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092253+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959743+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13114,7 +13114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.562048+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047631+00:00"
               },
               "deterministic": true
             },
@@ -13127,7 +13127,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092282+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959758+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13146,7 +13146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562090+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13160,7 +13160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092311+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959774+00:00"
           },
           "uid": {
             "type": "string",
@@ -13179,7 +13179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562124+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13194,7 +13194,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092342+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959790+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -13276,7 +13276,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.562224+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047710+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -13292,7 +13292,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092385+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959813+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -13362,7 +13362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.562274+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047731+00:00"
               },
               "deterministic": true
             },
@@ -13375,7 +13375,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092435+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959839+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13406,7 +13406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.562312+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047748+00:00"
               },
               "deterministic": true
             },
@@ -13419,7 +13419,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092464+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959855+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -13488,8 +13488,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13566,7 +13566,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.562404+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13617,7 +13617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562460+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13645,7 +13645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562510+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13673,7 +13673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562557+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13702,7 +13702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562620+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13729,7 +13729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562654+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13743,7 +13743,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092659+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959945+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -13759,7 +13759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562698+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13822,8 +13822,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13868,7 +13868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562762+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13880,7 +13880,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092721+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959978+00:00"
           },
           "status": {
             "type": "string",
@@ -13898,7 +13898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562805+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13910,7 +13910,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092750+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.959993+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -13952,7 +13952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562860+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13979,7 +13979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562910+00:00"
+                "validatedAt": "2026-05-09T01:38:28.047997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14006,7 +14006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.562957+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14034,7 +14034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.563010+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14099,7 +14099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.563090+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14148,7 +14148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.563152+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14161,7 +14161,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092878+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960061+00:00"
           },
           "uid": {
             "type": "string",
@@ -14180,7 +14180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.563186+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14194,7 +14194,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092908+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960077+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -14267,7 +14267,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.563276+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14299,7 +14299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:40.563340+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14311,7 +14311,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.092959+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960103+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -14376,7 +14376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.563410+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14449,8 +14449,8 @@
           "description": "Minimum configuration for schemaTlsProtocol",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tls_protocols\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14508,7 +14508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.563534+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14588,7 +14588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.563631+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14627,8 +14627,8 @@
           "description": "Minimum configuration for schemaURLSchemeType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaURLSchemeType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaURLSchemeType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_u_r_l_scheme_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14696,7 +14696,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.563709+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14811,7 +14811,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.563828+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14893,7 +14893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.563897+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14970,7 +14970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.563947+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14982,7 +14982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093307+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960292+00:00"
           },
           "name": {
             "type": "string",
@@ -15015,7 +15015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.563985+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048473+00:00"
               },
               "deterministic": true
             },
@@ -15028,7 +15028,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093336+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960308+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15059,7 +15059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.564021+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048489+00:00"
               },
               "deterministic": true
             },
@@ -15072,7 +15072,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093366+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960324+00:00"
           },
           "uid": {
             "type": "string",
@@ -15089,7 +15089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.564055+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15103,7 +15103,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093396+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960340+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -15150,8 +15150,8 @@
           "description": "Minimum configuration for schemaVirtualNetworkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_virtual_network_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -15177,8 +15177,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_management_accessCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_management_accessCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_management_accesses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -15252,7 +15252,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.564166+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15331,7 +15331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.564213+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048573+00:00"
               },
               "deterministic": true
             },
@@ -15344,7 +15344,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093521+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960404+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15374,7 +15374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.564249+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048589+00:00"
               },
               "deterministic": true
             },
@@ -15387,7 +15387,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093550+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960420+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -15490,7 +15490,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093660+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960471+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -15557,7 +15557,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.564427+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15628,7 +15628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:40.564485+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15691,7 +15691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:40.564550+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15703,7 +15703,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093767+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960526+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15770,7 +15770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.564616+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048739+00:00"
               },
               "deterministic": true
             },
@@ -15783,7 +15783,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093836+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960562+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15812,7 +15812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.564653+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048754+00:00"
               },
               "deterministic": true
             },
@@ -15825,7 +15825,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093865+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960577+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -15864,7 +15864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.564719+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15877,7 +15877,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093923+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960608+00:00"
           },
           "uid": {
             "type": "string",
@@ -15895,7 +15895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:40.564752+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15909,7 +15909,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.093953+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.960624+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of secret_management_access is returned in 'List'.",
@@ -15959,8 +15959,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_management_accessReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_management_accessReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_management_access_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -15972,8 +15972,8 @@
           "description": "Minimum configuration for secret_management_accessReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_management_accessReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_management_accessReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_management_access_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -16019,7 +16019,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:40.564852+00:00"
+                "validatedAt": "2026-05-09T01:38:28.048842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16129,7 +16129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.052876+00:00"
+                "validatedAt": "2026-05-09T01:38:29.157646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16142,7 +16142,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.144575+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985043+00:00"
           },
           "name": {
             "type": "string",
@@ -16175,7 +16175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.052977+00:00"
+                "validatedAt": "2026-05-09T01:38:29.157682+00:00"
               },
               "deterministic": true
             },
@@ -16188,7 +16188,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.144624+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985061+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16219,7 +16219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.053043+00:00"
+                "validatedAt": "2026-05-09T01:38:29.157705+00:00"
               },
               "deterministic": true
             },
@@ -16232,7 +16232,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.144655+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985077+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16251,7 +16251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.053120+00:00"
+                "validatedAt": "2026-05-09T01:38:29.157723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16265,7 +16265,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.144684+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985093+00:00"
           },
           "uid": {
             "type": "string",
@@ -16284,7 +16284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.053182+00:00"
+                "validatedAt": "2026-05-09T01:38:29.157739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16299,7 +16299,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.144715+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985109+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -16352,7 +16352,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.054102+00:00"
+                "validatedAt": "2026-05-09T01:38:29.158144+00:00"
               },
               "deterministic": true
             },
@@ -16365,7 +16365,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.145030+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985280+00:00"
           },
           "name": {
             "type": "string",
@@ -16409,7 +16409,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.054168+00:00"
+                "validatedAt": "2026-05-09T01:38:29.158184+00:00"
               },
               "deterministic": true
             },
@@ -16421,7 +16421,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.145059+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985295+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -16479,7 +16479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.055737+00:00"
+                "validatedAt": "2026-05-09T01:38:29.158902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16548,7 +16548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.055803+00:00"
+                "validatedAt": "2026-05-09T01:38:29.158931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16575,7 +16575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.055854+00:00"
+                "validatedAt": "2026-05-09T01:38:29.158954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16665,7 +16665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.055926+00:00"
+                "validatedAt": "2026-05-09T01:38:29.158987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16719,8 +16719,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -16803,7 +16803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.056095+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159069+00:00"
               },
               "deterministic": true
             },
@@ -16816,7 +16816,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146158+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985899+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16846,7 +16846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.056132+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159090+00:00"
               },
               "deterministic": true
             },
@@ -16859,7 +16859,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146187+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985915+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16962,7 +16962,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146284+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.985966+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -17022,7 +17022,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.056293+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159181+00:00"
               },
               "deterministic": true
             },
@@ -17090,7 +17090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:43.056345+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17153,7 +17153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:43.056411+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17165,7 +17165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146370+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986012+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17231,7 +17231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.056461+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159256+00:00"
               },
               "deterministic": true
             },
@@ -17244,7 +17244,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146438+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986048+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17273,7 +17273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.056496+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159272+00:00"
               },
               "deterministic": true
             },
@@ -17286,7 +17286,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146467+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986064+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -17306,7 +17306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.056543+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17319,7 +17319,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146505+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986084+00:00"
           },
           "uid": {
             "type": "string",
@@ -17336,7 +17336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.056576+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17350,7 +17350,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146535+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986100+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17417,7 +17417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:43.056644+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17480,7 +17480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:43.056708+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17492,7 +17492,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146612+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986135+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17558,7 +17558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.056759+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159404+00:00"
               },
               "deterministic": true
             },
@@ -17571,7 +17571,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146680+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986176+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17600,7 +17600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.056795+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159422+00:00"
               },
               "deterministic": true
             },
@@ -17613,7 +17613,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146709+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986192+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -17652,7 +17652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.056860+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17665,7 +17665,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146766+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986223+00:00"
           },
           "uid": {
             "type": "string",
@@ -17682,7 +17682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.056892+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17696,7 +17696,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146796+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986239+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of secret_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -17769,7 +17769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.056933+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159496+00:00"
               },
               "deterministic": true
             },
@@ -17782,7 +17782,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146827+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986255+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17819,7 +17819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.056972+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159518+00:00"
               },
               "deterministic": true
             },
@@ -17832,7 +17832,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146856+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986271+00:00"
           }
         },
         "x-f5xc-description-short": "Input message of the 'RecoverPolicy' RPC.",
@@ -17872,7 +17872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.057017+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17884,7 +17884,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146887+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986287+00:00"
           }
         },
         "x-f5xc-description-short": "Response message of the 'RecoverPolicy' RPC.",
@@ -17921,8 +17921,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -17934,8 +17934,8 @@
           "description": "Minimum configuration for secret_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -17963,8 +17963,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_policyRule\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_policyRule\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_policy_rules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -18005,7 +18005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.057106+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159581+00:00"
               },
               "deterministic": true
             },
@@ -18074,7 +18074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.057145+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159598+00:00"
               },
               "deterministic": true
             },
@@ -18087,7 +18087,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.146973+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986336+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18124,7 +18124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:43.057183+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159615+00:00"
               },
               "deterministic": true
             },
@@ -18137,7 +18137,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.147001+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986352+00:00"
           }
         },
         "x-f5xc-description-short": "Input message of the 'DeletePolicy' RPC.",
@@ -18177,7 +18177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:43.057227+00:00"
+                "validatedAt": "2026-05-09T01:38:29.159635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18189,7 +18189,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.147032+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.986373+00:00"
           }
         },
         "x-f5xc-description-short": "Response message of the 'DeletePolicy' RPC.",
@@ -18302,7 +18302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:50.567407+00:00"
+                "validatedAt": "2026-05-09T01:38:32.483127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18348,7 +18348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:50.567474+00:00"
+                "validatedAt": "2026-05-09T01:38:32.483164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18411,7 +18411,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:50.569734+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18485,7 +18485,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:50.569832+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18559,7 +18559,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:50.569928+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18617,8 +18617,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_policy_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_policy_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_policy_rules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -18701,7 +18701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:50.570004+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484254+00:00"
               },
               "deterministic": true
             },
@@ -18714,7 +18714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.315108+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.067741+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18744,7 +18744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:50.570042+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484272+00:00"
               },
               "deterministic": true
             },
@@ -18757,7 +18757,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.315138+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.067757+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18860,7 +18860,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.315237+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.067809+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -18928,7 +18928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:50.570185+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18991,7 +18991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:50.570252+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19003,7 +19003,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.315314+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.067848+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -19069,7 +19069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:50.570305+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484384+00:00"
               },
               "deterministic": true
             },
@@ -19082,7 +19082,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.315384+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.067885+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19111,7 +19111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:50.570341+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484401+00:00"
               },
               "deterministic": true
             },
@@ -19124,7 +19124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.315413+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.067900+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -19163,7 +19163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:50.570408+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19176,7 +19176,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.315470+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.067931+00:00"
           },
           "uid": {
             "type": "string",
@@ -19194,7 +19194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:50.570442+00:00"
+                "validatedAt": "2026-05-09T01:38:32.484445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19208,7 +19208,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.315501+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.067947+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of secret_policy_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19258,8 +19258,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_policy_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_policy_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_policy_rule_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -19271,8 +19271,8 @@
           "description": "Minimum configuration for secret_policy_ruleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for secret_policy_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for secret_policy_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/secret_policy_rule_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -19360,7 +19360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:29.458322+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19394,7 +19394,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.458392+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19447,7 +19447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:29.458454+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19481,7 +19481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.458518+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19548,7 +19548,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.458627+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19592,7 +19592,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.458717+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19648,7 +19648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:29.458779+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19682,7 +19682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.458842+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19730,8 +19730,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for voltshare_admin_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for voltshare_admin_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/voltshare_admin_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -19799,7 +19799,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.458926+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19873,7 +19873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.458974+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501517+00:00"
               },
               "deterministic": true
             },
@@ -19886,7 +19886,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.701118+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.055596+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19916,7 +19916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.459013+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501535+00:00"
               },
               "deterministic": true
             },
@@ -19929,7 +19929,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.701148+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.055614+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20032,7 +20032,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.701246+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.055673+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -20100,7 +20100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:28:29.459161+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20163,7 +20163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:28:29.459229+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20175,7 +20175,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.701321+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.055717+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20242,7 +20242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.459282+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501643+00:00"
               },
               "deterministic": true
             },
@@ -20255,7 +20255,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.701389+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.055754+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20284,7 +20284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.459320+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501659+00:00"
               },
               "deterministic": true
             },
@@ -20297,7 +20297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.701418+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.055770+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -20336,7 +20336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:29.459386+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20349,7 +20349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.701475+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.055801+00:00"
           },
           "uid": {
             "type": "string",
@@ -20367,7 +20367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:29.459420+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20381,7 +20381,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.701505+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.055817+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of voltshare_admin_policy is returned in 'List'.",
@@ -20431,8 +20431,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for voltshare_admin_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for voltshare_admin_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/voltshare_admin_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -20444,8 +20444,8 @@
           "description": "Minimum configuration for voltshare_admin_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for voltshare_admin_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for voltshare_admin_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/voltshare_admin_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "blindfold"
@@ -20590,7 +20590,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:29.459571+00:00"
+                "validatedAt": "2026-05-09T01:40:37.501765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20602,7 +20602,7 @@
             "x-field-mutability": "read-only",
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.701659+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:15.055891+00:00",
             "x-f5xc-conflicts-with": [
               "all_tenants",
               "individual_users"

--- a/docs/specifications/api/bot_and_threat_defense.json
+++ b/docs/specifications/api/bot_and_threat_defense.json
@@ -4677,8 +4677,8 @@
           "description": "Minimum configuration for bot_defense_app_infrastructureBotDefenseAdvancedRegion",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bot_defense_app_infrastructureBotDefenseAdvancedRegion\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bot_defense_app_infrastructureBotDefenseAdvancedRegion\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bot_defense_app_infrastructure_bot_defense_advanced_regions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -4704,8 +4704,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bot_defense_app_infrastructureCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bot_defense_app_infrastructureCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bot_defense_app_infrastructures\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -4825,7 +4825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.271179+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200649+00:00"
               },
               "deterministic": true
             },
@@ -4838,7 +4838,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.192540+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012105+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4868,7 +4868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.271240+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200675+00:00"
               },
               "deterministic": true
             },
@@ -4881,7 +4881,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.192572+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012121+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4933,7 +4933,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.271330+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200718+00:00"
               },
               "deterministic": true
             },
@@ -4977,8 +4977,8 @@
           "description": "Minimum configuration for bot_defense_app_infrastructureEnvironmentType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bot_defense_app_infrastructureEnvironmentType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bot_defense_app_infrastructureEnvironmentType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bot_defense_app_infrastructure_environment_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -5146,7 +5146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.271496+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5182,7 +5182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.271580+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5225,7 +5225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.271687+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5285,7 +5285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.271775+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5323,7 +5323,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.271852+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200937+00:00"
               },
               "deterministic": true
             },
@@ -5397,7 +5397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:10:32.271909+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5460,7 +5460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:10:32.271985+00:00"
+                "validatedAt": "2026-05-09T01:32:36.200995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5472,7 +5472,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.192871+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012274+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -5539,7 +5539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272038+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201018+00:00"
               },
               "deterministic": true
             },
@@ -5552,7 +5552,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.192942+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012311+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5581,7 +5581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272074+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201035+00:00"
               },
               "deterministic": true
             },
@@ -5594,7 +5594,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.192972+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012326+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -5617,7 +5617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.272125+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5630,7 +5630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193020+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012352+00:00"
           },
           "uid": {
             "type": "string",
@@ -5648,7 +5648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.272160+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5662,7 +5662,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193052+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012369+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bot_defense_app_infrastructure is returned in 'List'.",
@@ -5711,8 +5711,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bot_defense_app_infrastructureReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bot_defense_app_infrastructureReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bot_defense_app_infrastructure_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -5724,8 +5724,8 @@
           "description": "Minimum configuration for bot_defense_app_infrastructureReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bot_defense_app_infrastructureReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bot_defense_app_infrastructureReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bot_defense_app_infrastructure_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -5783,8 +5783,8 @@
           "description": "Minimum configuration for bot_defense_app_infrastructureTrafficType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bot_defense_app_infrastructureTrafficType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bot_defense_app_infrastructureTrafficType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bot_defense_app_infrastructure_traffic_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -5813,7 +5813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.272226+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5826,7 +5826,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193148+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012419+00:00"
           },
           "name": {
             "type": "string",
@@ -5859,7 +5859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272262+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201114+00:00"
               },
               "deterministic": true
             },
@@ -5872,7 +5872,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193178+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012435+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5903,7 +5903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272297+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201131+00:00"
               },
               "deterministic": true
             },
@@ -5916,7 +5916,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193207+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012450+00:00"
           },
           "tenant": {
             "type": "string",
@@ -5935,7 +5935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.272340+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5949,7 +5949,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193236+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012466+00:00"
           },
           "uid": {
             "type": "string",
@@ -5968,7 +5968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.272372+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5983,7 +5983,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193266+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012482+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -6021,7 +6021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.272419+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6044,7 +6044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.272461+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6056,7 +6056,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193310+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012505+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -6098,8 +6098,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6132,7 +6132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.272514+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6194,7 +6194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272550+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201250+00:00"
               },
               "deterministic": true
             },
@@ -6207,7 +6207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193374+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012539+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -6325,7 +6325,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272687+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201308+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6341,7 +6341,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193439+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012573+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6411,7 +6411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272737+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201331+00:00"
               },
               "deterministic": true
             },
@@ -6424,7 +6424,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193490+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012600+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6455,7 +6455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272773+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201349+00:00"
               },
               "deterministic": true
             },
@@ -6468,7 +6468,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193519+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012616+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -6550,7 +6550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272870+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201395+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6566,7 +6566,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193562+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012639+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6638,7 +6638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272917+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201417+00:00"
               },
               "deterministic": true
             },
@@ -6651,7 +6651,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193627+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012666+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6682,7 +6682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.272951+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201433+00:00"
               },
               "deterministic": true
             },
@@ -6695,7 +6695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193657+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012682+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -6777,7 +6777,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.273045+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201478+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6793,7 +6793,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193700+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012705+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6863,7 +6863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.273091+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201498+00:00"
               },
               "deterministic": true
             },
@@ -6876,7 +6876,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193750+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012732+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6907,7 +6907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.273124+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201514+00:00"
               },
               "deterministic": true
             },
@@ -6920,7 +6920,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193780+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012748+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -6981,7 +6981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273182+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6993,7 +6993,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193820+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012770+00:00"
           },
           "status": {
             "type": "string",
@@ -7011,7 +7011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273226+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7023,7 +7023,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193849+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012785+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7065,7 +7065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273281+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7092,7 +7092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273331+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7119,7 +7119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273377+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7147,7 +7147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273429+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7212,7 +7212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273507+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7261,7 +7261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273569+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7274,7 +7274,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.193978+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012854+00:00"
           },
           "uid": {
             "type": "string",
@@ -7293,7 +7293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273615+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7307,7 +7307,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.194008+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012870+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -7357,7 +7357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273656+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7369,7 +7369,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.194039+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012887+00:00"
           },
           "name": {
             "type": "string",
@@ -7402,7 +7402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.273692+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201757+00:00"
               },
               "deterministic": true
             },
@@ -7415,7 +7415,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.194068+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012903+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7446,7 +7446,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:32.273727+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201774+00:00"
               },
               "deterministic": true
             },
@@ -7459,7 +7459,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.194097+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012919+00:00"
           },
           "uid": {
             "type": "string",
@@ -7476,7 +7476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:32.273759+00:00"
+                "validatedAt": "2026-05-09T01:32:36.201788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7490,7 +7490,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.194127+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.012935+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -7561,8 +7561,8 @@
           "description": "Minimum configuration for viewsbot_defense_app_infrastructureLocation",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsbot_defense_app_infrastructureLocation\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsbot_defense_app_infrastructureLocation\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/viewsbot_defense_app_infrastructure_locations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -7578,8 +7578,8 @@
           "description": "Minimum configuration for schemashape_bot_defense_instanceGetSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemashape_bot_defense_instanceGetSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemashape_bot_defense_instanceGetSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemashape_bot_defense_instances\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -7708,7 +7708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:24:29.337715+00:00"
+                "validatedAt": "2026-05-09T01:38:49.587211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7771,7 +7771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:24:29.337783+00:00"
+                "validatedAt": "2026-05-09T01:38:49.587240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7783,7 +7783,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:48.140203+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.455466+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7850,7 +7850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:29.337836+00:00"
+                "validatedAt": "2026-05-09T01:38:49.587262+00:00"
               },
               "deterministic": true
             },
@@ -7863,7 +7863,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:48.140273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.455502+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7892,7 +7892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:29.337873+00:00"
+                "validatedAt": "2026-05-09T01:38:49.587279+00:00"
               },
               "deterministic": true
             },
@@ -7905,7 +7905,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:48.140302+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.455518+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7928,7 +7928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:29.337923+00:00"
+                "validatedAt": "2026-05-09T01:38:49.587300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7941,7 +7941,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:48.140350+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.455543+00:00"
           },
           "uid": {
             "type": "string",
@@ -7959,7 +7959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:29.337956+00:00"
+                "validatedAt": "2026-05-09T01:38:49.587315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7973,7 +7973,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:48.140382+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.455559+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of shape_bot_defense_instance is returned in 'List'.",
@@ -8029,7 +8029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:26:00.010293+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038004+00:00"
               },
               "deterministic": true
             },
@@ -8055,7 +8055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.010383+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8082,7 +8082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.010430+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8094,7 +8094,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.887922+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.755924+00:00"
           },
           "service_name": {
             "type": "string",
@@ -8111,7 +8111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.010485+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8144,7 +8144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.010543+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8156,7 +8156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.887964+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.755945+00:00"
           },
           "type": {
             "type": "string",
@@ -8181,7 +8181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.010604+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8235,7 +8235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.011170+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8248,7 +8248,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.888412+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756144+00:00"
           },
           "name": {
             "type": "string",
@@ -8281,7 +8281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:00.011209+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038397+00:00"
               },
               "deterministic": true
             },
@@ -8294,7 +8294,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.888442+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756165+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8325,7 +8325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:00.011246+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038414+00:00"
               },
               "deterministic": true
             },
@@ -8338,7 +8338,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.888472+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756180+00:00"
           },
           "tenant": {
             "type": "string",
@@ -8357,7 +8357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.011290+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8371,7 +8371,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.888504+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756196+00:00"
           },
           "uid": {
             "type": "string",
@@ -8390,7 +8390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.011324+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8405,7 +8405,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.888537+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756213+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -8450,7 +8450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.011570+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8478,7 +8478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.011639+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8506,7 +8506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.011688+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8535,7 +8535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.011738+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8562,7 +8562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.011772+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8576,7 +8576,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.888770+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756320+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -8592,7 +8592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.011817+00:00"
+                "validatedAt": "2026-05-09T01:39:31.038676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8655,8 +8655,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -8682,8 +8682,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tpm_api_keyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tpm_api_keyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tpm_api_keies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -8755,7 +8755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:00.012560+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8883,7 +8883,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.889336+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756606+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8948,7 +8948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:00.012735+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9007,7 +9007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.012795+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9034,7 +9034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.012848+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9103,7 +9103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:00.012910+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9166,7 +9166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:00.012979+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9178,7 +9178,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.889465+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756671+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9244,7 +9244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:00.013031+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039211+00:00"
               },
               "deterministic": true
             },
@@ -9257,7 +9257,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.889535+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756707+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9286,7 +9286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:00.013067+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039228+00:00"
               },
               "deterministic": true
             },
@@ -9299,7 +9299,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.889565+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756723+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9338,7 +9338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.013134+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9351,7 +9351,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.889637+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756753+00:00"
           },
           "uid": {
             "type": "string",
@@ -9368,7 +9368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.013167+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9382,7 +9382,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.889669+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.756769+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tpm_api_key is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9432,8 +9432,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tpm_api_keyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tpm_api_keyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tpm_api_key_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -9445,8 +9445,8 @@
           "description": "Minimum configuration for tpm_api_keyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tpm_api_keyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tpm_api_keyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tpm_api_key_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -9491,7 +9491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.013235+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9518,7 +9518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:00.013289+00:00"
+                "validatedAt": "2026-05-09T01:39:31.039324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9624,8 +9624,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tpm_categoryCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tpm_categoryCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tpm_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -9714,7 +9714,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:04.602916+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9825,7 +9825,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.972288+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.795938+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9874,7 +9874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:04.603061+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9900,7 +9900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:04.603113+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9926,7 +9926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:04.603161+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9952,7 +9952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:04.603209+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10011,7 +10011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:04.603291+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10081,7 +10081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:04.603347+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10144,7 +10144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:04.603413+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10156,7 +10156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.972423+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.796020+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10222,7 +10222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:04.603464+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050442+00:00"
               },
               "deterministic": true
             },
@@ -10235,7 +10235,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.972492+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.796056+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10264,7 +10264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:04.603500+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050460+00:00"
               },
               "deterministic": true
             },
@@ -10277,7 +10277,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.972521+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.796072+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10316,7 +10316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:04.603566+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10329,7 +10329,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.972578+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.796102+00:00"
           },
           "uid": {
             "type": "string",
@@ -10346,7 +10346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:04.603613+00:00"
+                "validatedAt": "2026-05-09T01:39:33.050508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10360,7 +10360,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.972624+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.796121+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tpm_category is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -10410,8 +10410,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tpm_categoryReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tpm_categoryReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tpm_category_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -10423,8 +10423,8 @@
           "description": "Minimum configuration for tpm_categoryReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tpm_categoryReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tpm_categoryReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tpm_category_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -10548,8 +10548,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tpm_managerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tpm_managerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tpm_managers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -10592,8 +10592,8 @@
           "description": "Minimum configuration for tpm_managerCreateSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tpm_managerCreateSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tpm_managerCreateSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tpm_managers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -10681,7 +10681,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.010061+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.813482+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -10728,7 +10728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:06.772452+00:00"
+                "validatedAt": "2026-05-09T01:39:34.020048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10755,7 +10755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:06.772506+00:00"
+                "validatedAt": "2026-05-09T01:39:34.020075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10821,7 +10821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:06.772562+00:00"
+                "validatedAt": "2026-05-09T01:39:34.020103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10884,7 +10884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:06.772643+00:00"
+                "validatedAt": "2026-05-09T01:39:34.020140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10896,7 +10896,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.010160+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.813531+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10962,7 +10962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:06.772695+00:00"
+                "validatedAt": "2026-05-09T01:39:34.020178+00:00"
               },
               "deterministic": true
             },
@@ -10975,7 +10975,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.010233+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.813567+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11004,7 +11004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:06.772732+00:00"
+                "validatedAt": "2026-05-09T01:39:34.020196+00:00"
               },
               "deterministic": true
             },
@@ -11017,7 +11017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.010263+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.813582+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -11056,7 +11056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:06.772799+00:00"
+                "validatedAt": "2026-05-09T01:39:34.020225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11069,7 +11069,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.010320+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.813612+00:00"
           },
           "uid": {
             "type": "string",
@@ -11086,7 +11086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:06.772832+00:00"
+                "validatedAt": "2026-05-09T01:39:34.020240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11100,7 +11100,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.010350+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.813628+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tpm_manager is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11230,7 +11230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:12.391932+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134263+00:00"
               },
               "deterministic": true
             },
@@ -11243,7 +11243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.063493+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.837445+00:00"
           },
           "serial": {
             "type": "string",
@@ -11267,7 +11267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.391993+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11299,7 +11299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392091+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11331,7 +11331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392165+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11343,7 +11343,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.063547+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.837482+00:00"
           }
         },
         "x-f5xc-description-short": "DeviceInfo defines device parameters like Serial-Number to include in the TPM provisioning data.",
@@ -11397,7 +11397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392231+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11468,8 +11468,8 @@
           "description": "Minimum configuration for tpm_provisionPreauthResponseStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tpm_provisionPreauthResponseStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tpm_provisionPreauthResponseStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tpm_provision_preauth_response_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "bot_and_threat_defense"
@@ -11504,7 +11504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392297+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11542,7 +11542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392356+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11575,7 +11575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392393+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11611,7 +11611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392444+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11644,7 +11644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392498+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11695,7 +11695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392553+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11721,7 +11721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392627+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11747,7 +11747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:12.392670+00:00"
+                "validatedAt": "2026-05-09T01:39:37.134566+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/cdn.json
+++ b/docs/specifications/api/cdn.json
@@ -7485,8 +7485,8 @@
           "description": "Minimum configuration for app_firewallAppFirewallViolationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_firewallAppFirewallViolationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_firewallAppFirewallViolationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_firewall_app_firewall_violation_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -7533,8 +7533,8 @@
           "description": "Minimum configuration for app_firewallAttackType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_firewallAttackType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_firewallAttackType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_firewall_attack_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -7569,7 +7569,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.259853+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7593,7 +7593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.259945+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7658,7 +7658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260033+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943630+00:00"
               },
               "deterministic": true
             },
@@ -7671,7 +7671,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052031+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465550+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7701,7 +7701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260089+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943648+00:00"
               },
               "deterministic": true
             },
@@ -7714,7 +7714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052064+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465566+00:00"
           },
           "path": {
             "type": "string",
@@ -7745,7 +7745,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260178+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943688+00:00"
               },
               "deterministic": true
             },
@@ -7830,7 +7830,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260277+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7893,7 +7893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260381+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7933,7 +7933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260423+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943799+00:00"
               },
               "deterministic": true
             },
@@ -7946,7 +7946,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052160+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465614+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7976,7 +7976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260460+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943815+00:00"
               },
               "deterministic": true
             },
@@ -7989,7 +7989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052190+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465630+00:00"
           },
           "user_id": {
             "type": "string",
@@ -8013,7 +8013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260537+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8083,7 +8083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260580+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943870+00:00"
               },
               "deterministic": true
             },
@@ -8096,7 +8096,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052243+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465657+00:00"
           },
           "rule": {
             "$ref": "#/components/schemas/common_wafSimpleClientSrcRule"
@@ -8154,7 +8154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260679+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8200,7 +8200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260725+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943929+00:00"
               },
               "deterministic": true
             },
@@ -8213,7 +8213,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052322+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465698+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8243,7 +8243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260762+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943946+00:00"
               },
               "deterministic": true
             },
@@ -8256,7 +8256,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052352+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465714+00:00"
           },
           "tls_fingerprint_matcher": {
             "$ref": "#/components/schemas/policyTlsFingerprintMatcherType"
@@ -8310,7 +8310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.260831+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8393,7 +8393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260891+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944004+00:00"
               },
               "deterministic": true
             },
@@ -8406,7 +8406,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052442+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465762+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8436,7 +8436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260927+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944022+00:00"
               },
               "deterministic": true
             },
@@ -8449,7 +8449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052471+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465778+00:00"
           },
           "path": {
             "type": "string",
@@ -8480,7 +8480,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261012+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944065+00:00"
               },
               "deterministic": true
             },
@@ -8582,7 +8582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261063+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944089+00:00"
               },
               "deterministic": true
             },
@@ -8595,7 +8595,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052553+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465835+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8625,7 +8625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261099+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944106+00:00"
               },
               "deterministic": true
             },
@@ -8638,7 +8638,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052608+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465851+00:00"
           },
           "path": {
             "type": "string",
@@ -8669,7 +8669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261180+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944145+00:00"
               },
               "deterministic": true
             },
@@ -8765,7 +8765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261226+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944174+00:00"
               },
               "deterministic": true
             },
@@ -8778,7 +8778,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052697+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465895+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8808,7 +8808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261261+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944190+00:00"
               },
               "deterministic": true
             },
@@ -8821,7 +8821,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052727+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465911+00:00"
           },
           "path": {
             "type": "string",
@@ -8852,7 +8852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261341+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944228+00:00"
               },
               "deterministic": true
             },
@@ -8937,7 +8937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261431+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9000,7 +9000,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261530+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9056,7 +9056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261574+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944333+00:00"
               },
               "deterministic": true
             },
@@ -9069,7 +9069,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052831+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465965+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9099,7 +9099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261628+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944351+00:00"
               },
               "deterministic": true
             },
@@ -9112,7 +9112,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052861+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465980+00:00"
           },
           "sec_event_name": {
             "type": "string",
@@ -9129,7 +9129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.261683+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9168,7 +9168,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261748+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9216,7 +9216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261829+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9290,7 +9290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261871+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944460+00:00"
               },
               "deterministic": true
             },
@@ -9303,7 +9303,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052943+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466023+00:00"
           },
           "rule": {
             "$ref": "#/components/schemas/common_wafSimpleClientSrcRule"
@@ -9359,7 +9359,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261956+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9372,7 +9372,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052997+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466050+00:00"
           },
           "exclude_bot_names": {
             "type": "array",
@@ -9403,7 +9403,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262021+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9442,7 +9442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262085+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9481,7 +9481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262148+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9521,7 +9521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262184+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944609+00:00"
               },
               "deterministic": true
             },
@@ -9534,7 +9534,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053057+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466081+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9564,7 +9564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262222+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944626+00:00"
               },
               "deterministic": true
             },
@@ -9577,7 +9577,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053086+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466097+00:00"
           },
           "req_path": {
             "type": "string",
@@ -9601,7 +9601,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262297+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9635,7 +9635,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262392+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9707,7 +9707,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262437+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944725+00:00"
               },
               "deterministic": true
             },
@@ -9720,7 +9720,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053148+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466129+00:00"
           },
           "waf_exclusion_policy": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -9781,7 +9781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262483+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944746+00:00"
               },
               "deterministic": true
             },
@@ -9794,7 +9794,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053199+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466160+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9823,7 +9823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262518+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944762+00:00"
               },
               "deterministic": true
             },
@@ -9836,7 +9836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053229+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466176+00:00"
           },
           "request_data": {
             "$ref": "#/components/schemas/app_securityRequestData"
@@ -9884,7 +9884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.262570+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9912,7 +9912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.262630+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9940,7 +9940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.262677+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10003,7 +10003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262744+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10015,7 +10015,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053330+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466229+00:00"
           }
         },
         "x-f5xc-description-short": "Metric label filter can be specified to query specific metrics based on label match.",
@@ -10049,8 +10049,8 @@
           "description": "Minimum configuration for app_securitySearchLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securitySearchLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securitySearchLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_security_search_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -10071,8 +10071,8 @@
           "description": "Minimum configuration for app_securitySearchLabelOperator",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securitySearchLabelOperator\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securitySearchLabelOperator\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_security_search_label_operators\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -10109,7 +10109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262808+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10147,7 +10147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262849+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944902+00:00"
               },
               "deterministic": true
             },
@@ -10160,7 +10160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053375+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466252+00:00"
           }
         },
         "x-f5xc-description-short": "GET a list of virtual hosts in all the namespaces matching filter provided in the request.",
@@ -10241,8 +10241,8 @@
           "description": "Minimum configuration for app_securitySecEventType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securitySecEventType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securitySecEventType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_security_sec_event_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -10291,7 +10291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.262928+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10329,7 +10329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262966+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944950+00:00"
               },
               "deterministic": true
             },
@@ -10342,7 +10342,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053443+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466287+00:00"
           },
           "query": {
             "type": "string",
@@ -10362,7 +10362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.263020+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10395,7 +10395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263072+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10462,7 +10462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263130+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10517,7 +10517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263182+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10589,7 +10589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.263252+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945072+00:00"
               },
               "deterministic": true
             },
@@ -10602,7 +10602,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053547+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466341+00:00"
           },
           "start_time": {
             "type": "string",
@@ -10627,7 +10627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263303+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10660,7 +10660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263345+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10735,7 +10735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263401+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10784,7 +10784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263443+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10812,7 +10812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263488+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10840,7 +10840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263533+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10909,7 +10909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263600+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10938,7 +10938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.263647+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10976,7 +10976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.263685+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945261+00:00"
               },
               "deterministic": true
             },
@@ -10989,7 +10989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053700+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466411+00:00"
           },
           "query": {
             "type": "string",
@@ -11009,7 +11009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.263738+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11054,7 +11054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263790+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11087,7 +11087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263847+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11174,7 +11174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263916+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11203,7 +11203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263965+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11265,7 +11265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264003+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945395+00:00"
               },
               "deterministic": true
             },
@@ -11278,7 +11278,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053823+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466475+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -11296,7 +11296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264050+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11367,7 +11367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264105+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11405,7 +11405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264141+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945456+00:00"
               },
               "deterministic": true
             },
@@ -11418,7 +11418,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053886+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466507+00:00"
           },
           "query": {
             "type": "string",
@@ -11438,7 +11438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.264192+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11471,7 +11471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264243+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11538,7 +11538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264298+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11607,7 +11607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264354+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11636,7 +11636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.264395+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11674,7 +11674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264430+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945582+00:00"
               },
               "deterministic": true
             },
@@ -11687,7 +11687,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053992+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466562+00:00"
           },
           "query": {
             "type": "string",
@@ -11707,7 +11707,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.264482+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11752,7 +11752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264534+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11785,7 +11785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264598+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11872,7 +11872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264671+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11901,7 +11901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264719+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11963,7 +11963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264758+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945717+00:00"
               },
               "deterministic": true
             },
@@ -11976,7 +11976,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054115+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466626+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -11994,7 +11994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264804+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12065,7 +12065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264859+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12103,7 +12103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264895+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945788+00:00"
               },
               "deterministic": true
             },
@@ -12116,7 +12116,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054178+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466658+00:00"
           },
           "query": {
             "type": "string",
@@ -12136,7 +12136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.264945+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12169,7 +12169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264995+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12236,7 +12236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265050+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12305,7 +12305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265118+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12334,7 +12334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.265164+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12372,7 +12372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.265202+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945925+00:00"
               },
               "deterministic": true
             },
@@ -12385,7 +12385,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054282+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466722+00:00"
           },
           "query": {
             "type": "string",
@@ -12405,7 +12405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.265258+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12450,7 +12450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265315+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12483,7 +12483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265370+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12570,7 +12570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265442+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12599,7 +12599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265494+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12661,7 +12661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.265534+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946060+00:00"
               },
               "deterministic": true
             },
@@ -12674,7 +12674,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054404+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466786+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -12692,7 +12692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265597+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12741,7 +12741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265655+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12770,7 +12770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:37.265716+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12782,7 +12782,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054456+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466812+00:00"
           },
           "id": {
             "type": "string",
@@ -12808,7 +12808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265752+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12833,7 +12833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265795+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12866,7 +12866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265847+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12937,7 +12937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.265908+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946220+00:00"
               },
               "deterministic": true
             },
@@ -12950,7 +12950,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054525+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466848+00:00"
           },
           "references": {
             "type": "array",
@@ -12991,7 +12991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265971+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13092,7 +13092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.266043+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13209,8 +13209,8 @@
           "description": "Minimum configuration for app_securityincidentsKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securityincidentsKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securityincidentsKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_securityincidents_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -13229,8 +13229,8 @@
           "description": "Minimum configuration for app_securityincidentsMetricField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securityincidentsMetricField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securityincidentsMetricField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_securityincidents_metric_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -13328,8 +13328,8 @@
           "description": "Minimum configuration for app_securityincidentsMultiKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securityincidentsMultiKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securityincidentsMultiKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_securityincidents_multi_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -13414,7 +13414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.266180+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13515,8 +13515,8 @@
           "description": "Minimum configuration for app_securitysuspicious_user_logKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securitysuspicious_user_logKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securitysuspicious_user_logKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_securitysuspicious_user_log_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -13623,7 +13623,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266305+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13696,7 +13696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.266385+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13775,7 +13775,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266493+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13820,7 +13820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266604+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13920,7 +13920,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266681+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13958,7 +13958,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266767+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946580+00:00"
               },
               "deterministic": true
             },
@@ -14025,7 +14025,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266863+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14071,7 +14071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266963+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14127,8 +14127,8 @@
           "description": "Minimum configuration for common_wafClientSrcRuleAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for common_wafClientSrcRuleAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for common_wafClientSrcRuleAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_waf_client_src_rule_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -14169,7 +14169,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267029+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14236,7 +14236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267125+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14275,7 +14275,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267205+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14348,7 +14348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267287+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946816+00:00"
               },
               "deterministic": true
             },
@@ -14412,7 +14412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.267340+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14636,7 +14636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267473+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14710,7 +14710,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267550+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14773,7 +14773,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267657+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14812,7 +14812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267739+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14853,7 +14853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267831+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14927,7 +14927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267900+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14996,7 +14996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.267987+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15031,7 +15031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268045+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15069,7 +15069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268103+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15113,7 +15113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268197+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15263,7 +15263,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268280+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15360,7 +15360,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268374+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15431,7 +15431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268454+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947333+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -15447,7 +15447,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055773+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467481+00:00"
           },
           "presence": {
             "type": "boolean",
@@ -15492,7 +15492,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268545+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947375+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -15553,7 +15553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268599+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15566,7 +15566,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055827+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467508+00:00"
           },
           "name": {
             "type": "string",
@@ -15599,7 +15599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268636+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947408+00:00"
               },
               "deterministic": true
             },
@@ -15612,7 +15612,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055857+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467524+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15643,7 +15643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268672+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947425+00:00"
               },
               "deterministic": true
             },
@@ -15656,7 +15656,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055886+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467540+00:00"
           },
           "tenant": {
             "type": "string",
@@ -15675,7 +15675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268716+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15689,7 +15689,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055915+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467555+00:00"
           },
           "uid": {
             "type": "string",
@@ -15708,7 +15708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268750+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15723,7 +15723,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055946+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467571+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -15763,7 +15763,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055978+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467588+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -15799,7 +15799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268811+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15848,7 +15848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268859+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15887,7 +15887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:09:37.268914+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947526+00:00"
               },
               "deterministic": true
             },
@@ -15954,7 +15954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268977+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15999,7 +15999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269020+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16022,7 +16022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269055+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16034,7 +16034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056111+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467655+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -16127,7 +16127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269130+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16151,7 +16151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269165+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16163,7 +16163,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056196+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467698+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -16205,7 +16205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269214+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16229,7 +16229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269248+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16241,7 +16241,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056249+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467725+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -16279,7 +16279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269292+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16336,7 +16336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269340+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16360,7 +16360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269374+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16372,7 +16372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056315+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467759+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -16422,7 +16422,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056358+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467781+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -16479,7 +16479,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056402+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467803+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -16515,7 +16515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269458+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16626,7 +16626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269532+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16692,7 +16692,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056516+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467862+00:00"
           },
           "value": {
             "type": "number",
@@ -16708,7 +16708,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056544+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467876+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -16745,7 +16745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269619+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16860,7 +16860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.269696+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947848+00:00"
               },
               "deterministic": true
             },
@@ -16873,7 +16873,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056635+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467915+00:00"
           },
           "sec_event_type": {
             "type": "string",
@@ -16890,7 +16890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269749+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16915,7 +16915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269800+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16940,7 +16940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269845+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16965,7 +16965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269890+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17013,8 +17013,8 @@
           "description": "Minimum configuration for metricsSecurityMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for metricsSecurityMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for metricsSecurityMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/metrics_security_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "label"
@@ -17046,7 +17046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269940+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17058,7 +17058,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056726+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467962+00:00"
           }
         },
         "x-f5xc-description-short": "Label based filtering for Security Events metrics. Security Events metrics are tagged with labels mentioned in MetricLabel.",
@@ -17093,8 +17093,8 @@
           "description": "Minimum configuration for metricsSecurityMetricLabelOp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for metricsSecurityMetricLabelOp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for metricsSecurityMetricLabelOp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/metrics_security_metric_label_ops\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "label"
@@ -17136,7 +17136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.270000+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17148,7 +17148,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056770+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467985+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Security Events Metrics query.",
@@ -17199,7 +17199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270093+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17262,7 +17262,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270165+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17300,7 +17300,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270229+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17337,7 +17337,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270296+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17374,7 +17374,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270359+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17436,7 +17436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270447+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17525,7 +17525,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270555+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17599,7 +17599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270641+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17658,7 +17658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270701+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17711,7 +17711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.270755+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17862,7 +17862,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270883+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948384+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17878,7 +17878,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057097+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468157+00:00"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -18166,8 +18166,8 @@
           "description": "Minimum configuration for policyCountryCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyCountryCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyCountryCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_country_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18196,8 +18196,8 @@
           "description": "Minimum configuration for policyDetectionContext",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyDetectionContext\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyDetectionContext\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_detection_contexts\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18253,7 +18253,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270951+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18306,8 +18306,8 @@
           "description": "Minimum configuration for policyIPThreatCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_i_p_threat_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18359,7 +18359,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271018+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18421,7 +18421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271081+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18515,7 +18515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271169+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948519+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18531,7 +18531,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057227+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468224+00:00"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -18581,8 +18581,8 @@
           "description": "Minimum configuration for policyKnownTlsFingerprintClass",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyKnownTlsFingerprintClass\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyKnownTlsFingerprintClass\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_known_tls_fingerprint_classes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18628,7 +18628,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271232+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18674,7 +18674,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271291+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18712,7 +18712,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271351+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18791,7 +18791,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271419+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18848,7 +18848,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271482+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18885,7 +18885,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271555+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948711+00:00"
               },
               "deterministic": true
             },
@@ -18921,7 +18921,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271626+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18956,7 +18956,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271687+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19032,7 +19032,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271789+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19065,7 +19065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.271845+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19108,7 +19108,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271914+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19144,7 +19144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271997+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19187,7 +19187,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272078+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19232,7 +19232,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272162+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19309,7 +19309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272227+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19350,7 +19350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272289+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19392,7 +19392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272350+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19442,8 +19442,8 @@
           "description": "Minimum configuration for policyTransformer",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_transformers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19466,8 +19466,8 @@
           "description": "Minimum configuration for rate_limiterRateLimitPeriodUnit",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_rate_limit_period_units\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -19482,8 +19482,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19513,8 +19513,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19563,7 +19563,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272414+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19620,7 +19620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272508+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949157+00:00"
               },
               "deterministic": true
             },
@@ -19633,7 +19633,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057510+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468370+00:00"
           },
           "name": {
             "type": "string",
@@ -19677,7 +19677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272574+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949190+00:00"
               },
               "deterministic": true
             },
@@ -19689,7 +19689,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057539+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468385+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -19730,8 +19730,8 @@
           "description": "Minimum configuration for schemaOpenApiValidationProperties",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_open_api_validation_propertieses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19752,8 +19752,8 @@
           "description": "Minimum configuration for schemaSortOrder",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_sort_orders\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19774,8 +19774,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19803,7 +19803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:37.272653+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19815,7 +19815,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468404+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -19830,7 +19830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.272705+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19856,7 +19856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.272754+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19868,7 +19868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057639+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468430+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -19931,7 +19931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.272803+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20099,8 +20099,8 @@
           "description": "Minimum configuration for schemaapp_securityKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaapp_securityKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaapp_securityKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaapp_security_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -20119,8 +20119,8 @@
           "description": "Minimum configuration for schemaapp_securityMetricField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaapp_securityMetricField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaapp_securityMetricField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaapp_security_metric_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -20231,8 +20231,8 @@
           "description": "Minimum configuration for schemaapp_securityMultiKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaapp_securityMultiKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaapp_securityMultiKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaapp_security_multi_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -20346,7 +20346,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272982+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949355+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -20362,7 +20362,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057867+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468546+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -20422,7 +20422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273046+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20505,7 +20505,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273133+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20517,7 +20517,7 @@
             "x-original-maxLength": 256,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057949+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468589+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -20588,7 +20588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273206+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949458+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -20604,7 +20604,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057981+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468605+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20641,7 +20641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273273+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949491+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -20657,7 +20657,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.058011+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468621+00:00"
           },
           "tenant": {
             "type": "string",
@@ -20686,7 +20686,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273347+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20700,7 +20700,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.058041+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468637+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -20816,8 +20816,8 @@
           "description": "Minimum configuration for suspicious_user_logNumKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for suspicious_user_logNumKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for suspicious_user_logNumKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/suspicious_user_log_num_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -20845,7 +20845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:43.639801+00:00"
+                "validatedAt": "2026-05-09T01:32:14.743275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20922,8 +20922,8 @@
           "description": "Minimum configuration for access_logCDNAccessLogTag",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for access_logCDNAccessLogTag\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for access_logCDNAccessLogTag\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/access_log_c_d_n_access_log_tags\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -20948,7 +20948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320120+00:00"
+                "validatedAt": "2026-05-09T01:32:51.604768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21023,7 +21023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.320223+00:00"
+                "validatedAt": "2026-05-09T01:32:51.604809+00:00"
               },
               "deterministic": true
             },
@@ -21036,7 +21036,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.898731+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.339792+00:00"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -21091,7 +21091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320298+00:00"
+                "validatedAt": "2026-05-09T01:32:51.604839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21116,7 +21116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320346+00:00"
+                "validatedAt": "2026-05-09T01:32:51.604861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21149,7 +21149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320409+00:00"
+                "validatedAt": "2026-05-09T01:32:51.604887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21273,7 +21273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320492+00:00"
+                "validatedAt": "2026-05-09T01:32:51.604920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21362,7 +21362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320580+00:00"
+                "validatedAt": "2026-05-09T01:32:51.604957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21386,7 +21386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320650+00:00"
+                "validatedAt": "2026-05-09T01:32:51.604979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21457,7 +21457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320712+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21481,7 +21481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320764+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21642,7 +21642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320867+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21680,7 +21680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.320909+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605089+00:00"
               },
               "deterministic": true
             },
@@ -21693,7 +21693,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.899181+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340021+00:00"
           },
           "query": {
             "type": "array",
@@ -21728,7 +21728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.320972+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21803,7 +21803,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.321048+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21843,8 +21843,8 @@
           "description": "Minimum configuration for cdn_loadbalancerCDNAccessLogOperatorType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerCDNAccessLogOperatorType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerCDNAccessLogOperatorType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_c_d_n_access_log_operator_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -21897,7 +21897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.321108+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21934,7 +21934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:11:07.321159+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21972,7 +21972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.321197+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605223+00:00"
               },
               "deterministic": true
             },
@@ -21985,7 +21985,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.899301+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340081+00:00"
           },
           "query": {
             "type": "array",
@@ -22011,7 +22011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.321257+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22041,7 +22041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.321309+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22087,7 +22087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.321365+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22131,7 +22131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.321406+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22372,7 +22372,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.321530+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22434,7 +22434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.321600+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22517,7 +22517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.321670+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22633,7 +22633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.321758+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22657,7 +22657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.321817+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22849,8 +22849,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -22933,7 +22933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.321996+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605555+00:00"
               },
               "deterministic": true
             },
@@ -22946,7 +22946,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.899951+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340428+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22976,7 +22976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.322034+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605572+00:00"
               },
               "deterministic": true
             },
@@ -22989,7 +22989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.899982+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340444+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23074,7 +23074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.322090+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605595+00:00"
               },
               "deterministic": true
             },
@@ -23087,7 +23087,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.900054+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340482+00:00"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -23191,7 +23191,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.900154+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340534+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -23265,7 +23265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322235+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23290,7 +23290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322282+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23315,7 +23315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322326+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23341,7 +23341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322374+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23366,7 +23366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322426+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23390,7 +23390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322470+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23414,7 +23414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322521+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23440,7 +23440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322559+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23465,7 +23465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322622+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23490,7 +23490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322674+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23515,7 +23515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322717+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23540,7 +23540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322761+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23565,7 +23565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322815+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23590,7 +23590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322860+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23616,7 +23616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322906+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23641,7 +23641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.322957+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23666,7 +23666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323002+00:00"
+                "validatedAt": "2026-05-09T01:32:51.605991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23691,7 +23691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323054+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23716,7 +23716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323106+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23743,7 +23743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323150+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23768,7 +23768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323195+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23793,7 +23793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323242+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23818,7 +23818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323284+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23859,7 +23859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:11:07.323344+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606141+00:00"
               },
               "deterministic": true
             },
@@ -23885,7 +23885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323391+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23910,7 +23910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323441+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23934,7 +23934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323491+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23958,7 +23958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323548+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23983,7 +23983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323616+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24008,7 +24008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323669+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24038,7 +24038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323706+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24063,7 +24063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323754+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24133,8 +24133,8 @@
           "description": "Minimum configuration for cdn_loadbalancerLilacCDNMetricUnit",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerLilacCDNMetricUnit\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerLilacCDNMetricUnit\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_lilac_c_d_n_metric_units\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -24163,8 +24163,8 @@
           "description": "Minimum configuration for cdn_loadbalancerLilacCDNMetricsFieldSelector",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerLilacCDNMetricsFieldSelector\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerLilacCDNMetricsFieldSelector\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_lilac_c_d_n_metrics_field_selectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -24236,8 +24236,8 @@
           "description": "Minimum configuration for cdn_loadbalancerLilacCDNMetricsOperatorType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerLilacCDNMetricsOperatorType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerLilacCDNMetricsOperatorType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_lilac_c_d_n_metrics_operator_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -24272,7 +24272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.323834+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24309,7 +24309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.323897+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24384,7 +24384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.323970+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606411+00:00"
               },
               "deterministic": true
             },
@@ -24397,7 +24397,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.900608+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340767+00:00"
           },
           "start_time": {
             "type": "string",
@@ -24422,7 +24422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.324021+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24449,7 +24449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.324061+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24504,7 +24504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:07.324103+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24531,7 +24531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.324142+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24623,7 +24623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.324213+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24635,7 +24635,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.900723+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340827+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24690,7 +24690,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.900766+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340850+00:00"
           }
         },
         "x-f5xc-description-short": "CDN Metrics response series. Each series instance has data for a combination of group-by tag values.",
@@ -24737,7 +24737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:11:07.324302+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606565+00:00"
               },
               "deterministic": true
             },
@@ -24761,7 +24761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.324343+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24773,7 +24773,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.900808+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340872+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24811,8 +24811,8 @@
           "description": "Minimum configuration for cdn_loadbalancerLilacCDNMetricsTag",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerLilacCDNMetricsTag\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerLilacCDNMetricsTag\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_lilac_c_d_n_metrics_tags\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -24859,7 +24859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:07.324397+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24922,7 +24922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:07.324464+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24934,7 +24934,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.900877+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340907+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -25000,7 +25000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.324520+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606656+00:00"
               },
               "deterministic": true
             },
@@ -25013,7 +25013,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.900947+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340944+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25042,7 +25042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.324556+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606673+00:00"
               },
               "deterministic": true
             },
@@ -25055,7 +25055,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.900976+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340960+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -25094,7 +25094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.324635+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25107,7 +25107,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.901033+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.340990+00:00"
           },
           "uid": {
             "type": "string",
@@ -25125,7 +25125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.324669+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25139,7 +25139,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.901065+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.341007+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cdn_loadbalancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -25189,8 +25189,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -25202,8 +25202,8 @@
           "description": "Minimum configuration for cdn_loadbalancerReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -25331,8 +25331,8 @@
           "description": "Minimum configuration for cdn_loadbalancerSubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerSubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerSubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_subscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -25348,8 +25348,8 @@
           "description": "Minimum configuration for cdn_loadbalancerSubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerSubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerSubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_subscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -25393,8 +25393,8 @@
           "description": "Minimum configuration for cdn_loadbalancerUnsubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_unsubscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -25410,8 +25410,8 @@
           "description": "Minimum configuration for cdn_loadbalancerUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_loadbalancerUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_loadbalancerUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_loadbalancer_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -25608,7 +25608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.324940+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25654,7 +25654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.324985+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25678,7 +25678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.325025+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25751,7 +25751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.325071+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606880+00:00"
               },
               "deterministic": true
             },
@@ -25764,7 +25764,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.901424+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.341197+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25801,7 +25801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.325111+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606898+00:00"
               },
               "deterministic": true
             },
@@ -25814,7 +25814,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.901454+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.341213+00:00"
           },
           "service_op_id": {
             "type": "integer",
@@ -25884,7 +25884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:07.325175+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25948,7 +25948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.325251+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606960+00:00"
               },
               "deterministic": true
             },
@@ -25994,7 +25994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.325332+00:00"
+                "validatedAt": "2026-05-09T01:32:51.606997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26039,7 +26039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:11:07.325377+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607017+00:00"
               },
               "deterministic": true
             },
@@ -26164,7 +26164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.325448+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607047+00:00"
               },
               "deterministic": true
             },
@@ -26177,7 +26177,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.901612+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.341288+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26214,7 +26214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.325488+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607065+00:00"
               },
               "deterministic": true
             },
@@ -26227,7 +26227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.901643+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.341304+00:00"
           },
           "time_range": {
             "$ref": "#/components/schemas/common_cdnServiceOperationsTimeRange"
@@ -26277,7 +26277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:07.325533+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26324,7 +26324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.325602+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26350,7 +26350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.325653+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26382,7 +26382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.325707+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26427,7 +26427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.325765+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26452,7 +26452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.325810+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26476,7 +26476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.325849+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26507,7 +26507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.325900+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26580,7 +26580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.325967+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26592,7 +26592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.901806+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.341389+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26635,7 +26635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.326022+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26664,7 +26664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.326075+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26752,7 +26752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.326163+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26787,7 +26787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.326215+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26863,7 +26863,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.326308+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607427+00:00"
               },
               "deterministic": true
             },
@@ -26911,7 +26911,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.326372+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26964,7 +26964,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.326456+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27067,7 +27067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.326537+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27125,7 +27125,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.326613+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27169,7 +27169,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.326688+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607606+00:00"
               },
               "deterministic": true
             },
@@ -27330,7 +27330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.326925+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607706+00:00"
               },
               "deterministic": true
             },
@@ -27343,7 +27343,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.902276+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.341635+00:00"
           }
         },
         "x-f5xc-description-short": "Response of DELETE DoS Auto-Mitigation Rule API.",
@@ -27530,8 +27530,8 @@
           "description": "Minimum configuration for common_securityMobileIdentifier",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for common_securityMobileIdentifier\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for common_securityMobileIdentifier\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_security_mobile_identifiers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -27594,7 +27594,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.327132+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607794+00:00"
               },
               "deterministic": true
             },
@@ -27681,7 +27681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.327211+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27739,7 +27739,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.327295+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27790,8 +27790,8 @@
           "description": "Minimum configuration for common_securityShapeBotDefenseRegion",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for common_securityShapeBotDefenseRegion\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for common_securityShapeBotDefenseRegion\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_security_shape_bot_defense_regions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -27842,7 +27842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:11:07.327356+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607891+00:00"
               },
               "deterministic": true
             },
@@ -27966,7 +27966,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.327444+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28028,7 +28028,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.327511+00:00"
+                "validatedAt": "2026-05-09T01:32:51.607993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28072,7 +28072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.327595+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608039+00:00"
               },
               "deterministic": true
             },
@@ -28157,8 +28157,8 @@
           "description": "Minimum configuration for common_securityURLScheme",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for common_securityURLScheme\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for common_securityURLScheme\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_security_u_r_l_schemes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28212,7 +28212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.327811+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28237,7 +28237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.327858+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28270,7 +28270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.327922+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28339,7 +28339,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.327987+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28449,7 +28449,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.328099+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28497,7 +28497,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.328174+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28672,7 +28672,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.328291+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608356+00:00"
               },
               "deterministic": true
             },
@@ -28755,7 +28755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.328361+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28871,7 +28871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.328811+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28935,7 +28935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.328873+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29003,7 +29003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.328968+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29050,7 +29050,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.329059+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29116,7 +29116,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.329125+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29162,8 +29162,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for common_wafChallengeRule\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for common_wafChallengeRule\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_waf_challenge_rules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -29204,7 +29204,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.329205+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608780+00:00"
               },
               "deterministic": true
             },
@@ -29298,7 +29298,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.329357+00:00"
+                "validatedAt": "2026-05-09T01:32:51.608849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29391,7 +29391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.329765+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29496,7 +29496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.329858+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29593,7 +29593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.330421+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29669,7 +29669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.330523+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29707,7 +29707,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.330623+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29753,7 +29753,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.330729+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29828,7 +29828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.330800+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29886,7 +29886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.331248+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609684+00:00"
               },
               "deterministic": true
             },
@@ -30008,7 +30008,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.331334+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30100,7 +30100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.331438+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609768+00:00"
               },
               "deterministic": true
             },
@@ -30193,7 +30193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.331521+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30245,7 +30245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.331567+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609821+00:00"
               },
               "deterministic": true
             },
@@ -30258,7 +30258,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.904505+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.342789+00:00"
           },
           "uid": {
             "type": "string",
@@ -30277,7 +30277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.331615+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30291,7 +30291,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.904537+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.342805+00:00"
           }
         },
         "x-f5xc-description-short": "DoS Mitigation Object to auto-configure rules to block attackers.",
@@ -30360,7 +30360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.331665+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609857+00:00"
               },
               "deterministic": true
             },
@@ -30406,7 +30406,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.331754+00:00"
+                "validatedAt": "2026-05-09T01:32:51.609897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30444,8 +30444,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -30485,7 +30485,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.332283+00:00"
+                "validatedAt": "2026-05-09T01:32:51.610137+00:00"
               },
               "deterministic": true
             },
@@ -30525,7 +30525,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.332357+00:00"
+                "validatedAt": "2026-05-09T01:32:51.610176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30566,7 +30566,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.332447+00:00"
+                "validatedAt": "2026-05-09T01:32:51.610219+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -30633,7 +30633,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.333394+00:00"
+                "validatedAt": "2026-05-09T01:32:51.610611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30705,7 +30705,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.333474+00:00"
+                "validatedAt": "2026-05-09T01:32:51.610650+00:00"
               },
               "deterministic": true
             },
@@ -30792,7 +30792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.333564+00:00"
+                "validatedAt": "2026-05-09T01:32:51.610689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30894,7 +30894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.333701+00:00"
+                "validatedAt": "2026-05-09T01:32:51.610741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30994,7 +30994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.333853+00:00"
+                "validatedAt": "2026-05-09T01:32:51.610807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31093,7 +31093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.334538+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611096+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -31109,7 +31109,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.905908+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.343486+00:00"
           }
         },
         "x-f5xc-description-short": "Argument matcher specifies the name of a single argument in the body and the criteria to match it.",
@@ -31220,7 +31220,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.334976+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31260,7 +31260,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.335059+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31317,7 +31317,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.335156+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31523,7 +31523,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.335314+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611433+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -31539,7 +31539,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.906313+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.343697+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -31592,7 +31592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.335350+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611449+00:00"
               },
               "deterministic": true
             },
@@ -31605,7 +31605,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.906347+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.343715+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Name of the cookie field\" Specifies the name of the cookie field.",
@@ -31654,7 +31654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.335401+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611466+00:00"
               },
               "deterministic": true
             },
@@ -31667,7 +31667,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.906380+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.343732+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Name of the field\" Specifies the name of the field.",
@@ -31702,7 +31702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.335568+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31714,7 +31714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.906435+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.343761+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Key name of the query parameter\" Specifies the key name of the query parameter.",
@@ -31813,7 +31813,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.336085+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31859,7 +31859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.336145+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31919,7 +31919,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.336545+00:00"
+                "validatedAt": "2026-05-09T01:32:51.611954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32013,7 +32013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.336666+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32054,7 +32054,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.336755+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32144,7 +32144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.336809+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32213,7 +32213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.336905+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32267,7 +32267,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.336999+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32318,7 +32318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.337715+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32341,7 +32341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.337759+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32353,7 +32353,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.907084+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344092+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -32505,8 +32505,8 @@
           "description": "Minimum configuration for rate_limiterLeakyBucketRateLimiter",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterLeakyBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterLeakyBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_leaky_bucket_rate_limiters\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -32674,8 +32674,8 @@
           "description": "Minimum configuration for rate_limiterTokenBucketRateLimiter",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterTokenBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterTokenBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_token_bucket_rate_limiters\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -32714,7 +32714,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.337983+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32790,7 +32790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.338050+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32828,7 +32828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.338128+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32840,7 +32840,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.907308+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344212+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -32859,7 +32859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.338180+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33268,7 +33268,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.338412+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612770+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -33284,7 +33284,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.907731+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344432+00:00"
           },
           "regex_values": {
             "type": "array",
@@ -33322,7 +33322,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.338472+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33385,7 +33385,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.338543+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33421,7 +33421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.338619+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33467,8 +33467,8 @@
           "description": "Minimum configuration for schemaBotHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaBotHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaBotHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_bot_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -33498,7 +33498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.338670+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33510,7 +33510,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.907806+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344477+00:00"
           },
           "url": {
             "type": "string",
@@ -33548,7 +33548,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.338751+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612923+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -33605,7 +33605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:11:07.338795+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612942+00:00"
               },
               "deterministic": true
             },
@@ -33631,7 +33631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.338849+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33658,7 +33658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.338896+00:00"
+                "validatedAt": "2026-05-09T01:32:51.612986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33670,7 +33670,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.907868+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344509+00:00"
           },
           "service_name": {
             "type": "string",
@@ -33687,7 +33687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.338950+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33720,7 +33720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.339000+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33732,7 +33732,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.907907+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344530+00:00"
           },
           "type": {
             "type": "string",
@@ -33757,7 +33757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.339046+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33886,7 +33886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.339176+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613108+00:00"
               },
               "deterministic": true
             },
@@ -33899,7 +33899,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908034+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344597+00:00"
           },
           "samesite_lax": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -33973,7 +33973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.339251+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34005,7 +34005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.339313+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34051,7 +34051,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.339383+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34099,7 +34099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.339448+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34141,7 +34141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.339506+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34178,7 +34178,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.339578+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34295,7 +34295,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.339685+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613334+00:00"
               },
               "deterministic": true
             },
@@ -34358,7 +34358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.339773+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34401,7 +34401,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.339856+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34446,7 +34446,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.339941+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34499,8 +34499,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -34533,7 +34533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.339997+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34577,8 +34577,8 @@
           "description": "Minimum configuration for schemaHashAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_hash_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -34624,7 +34624,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340067+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34709,7 +34709,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340144+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613545+00:00"
               },
               "deterministic": true
             },
@@ -34722,7 +34722,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908307+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344736+00:00"
           },
           "secret_value": {
             "$ref": "#/components/schemas/schemaSecretType"
@@ -34748,7 +34748,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340222+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34760,7 +34760,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908345+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:04.344757+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -34801,8 +34801,8 @@
           "description": "Minimum configuration for schemaHttpSections",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpSections\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpSections\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_sectionses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -34879,8 +34879,8 @@
           "description": "Minimum configuration for schemaHttpStatusCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpStatusCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpStatusCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_status_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -34921,7 +34921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340263+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613600+00:00"
               },
               "deterministic": true
             },
@@ -34934,7 +34934,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908383+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344776+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -35010,8 +35010,8 @@
           "description": "Minimum configuration for schemaJavaScriptMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaJavaScriptMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaJavaScriptMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_java_script_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -35076,7 +35076,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340626+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613761+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -35092,7 +35092,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908524+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344848+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -35162,7 +35162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340680+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613783+00:00"
               },
               "deterministic": true
             },
@@ -35175,7 +35175,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908574+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344875+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35206,7 +35206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340719+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613802+00:00"
               },
               "deterministic": true
             },
@@ -35219,7 +35219,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908616+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344891+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -35301,7 +35301,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340820+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613849+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -35317,7 +35317,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908661+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344913+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -35389,7 +35389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340872+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613871+00:00"
               },
               "deterministic": true
             },
@@ -35402,7 +35402,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908713+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344940+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35433,7 +35433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.340909+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613890+00:00"
               },
               "deterministic": true
             },
@@ -35446,7 +35446,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908743+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344956+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -35528,7 +35528,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.341010+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613936+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -35544,7 +35544,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908788+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.344979+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -35614,7 +35614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.341062+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613959+00:00"
               },
               "deterministic": true
             },
@@ -35627,7 +35627,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908839+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345005+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35658,7 +35658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.341100+00:00"
+                "validatedAt": "2026-05-09T01:32:51.613977+00:00"
               },
               "deterministic": true
             },
@@ -35671,7 +35671,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908869+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345021+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -35707,8 +35707,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -35766,7 +35766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341168+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35794,7 +35794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341221+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35822,7 +35822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341271+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35851,7 +35851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341324+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35878,7 +35878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341360+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35892,7 +35892,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.908976+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345076+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -35908,7 +35908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341407+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35971,8 +35971,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -36017,7 +36017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341472+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36029,7 +36029,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.909039+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345108+00:00"
           },
           "status": {
             "type": "string",
@@ -36047,7 +36047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341517+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36059,7 +36059,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.909069+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345124+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -36101,7 +36101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341576+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36128,7 +36128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341643+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36155,7 +36155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341694+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36183,7 +36183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341751+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36248,7 +36248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341835+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36297,7 +36297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341901+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36310,7 +36310,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.909198+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345196+00:00"
           },
           "uid": {
             "type": "string",
@@ -36329,7 +36329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.341939+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36343,7 +36343,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.909229+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345212+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -36416,7 +36416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.342035+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36448,7 +36448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:07.342101+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36460,7 +36460,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.909281+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345239+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -36509,8 +36509,8 @@
           "description": "Minimum configuration for schemaTlsProtocol",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tls_protocols\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -36537,7 +36537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.342321+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36549,7 +36549,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.909426+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345315+00:00"
           },
           "name": {
             "type": "string",
@@ -36582,7 +36582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.342360+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614522+00:00"
               },
               "deterministic": true
             },
@@ -36595,7 +36595,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.909456+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345331+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36626,7 +36626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.342399+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614539+00:00"
               },
               "deterministic": true
             },
@@ -36639,7 +36639,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.909485+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345347+00:00"
           },
           "uid": {
             "type": "string",
@@ -36656,7 +36656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.342434+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36670,7 +36670,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.909515+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345362+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -36710,8 +36710,8 @@
           "description": "Minimum configuration for schemaXfccElement",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_xfcc_elements\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -36757,7 +36757,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.342504+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36793,7 +36793,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.342568+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36825,7 +36825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.342648+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36898,7 +36898,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.342739+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36941,7 +36941,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.342800+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36981,7 +36981,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.342866+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37033,8 +37033,8 @@
           "description": "Minimum configuration for schemados_mitigationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemados_mitigationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemados_mitigationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemados_mitigation_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -37082,7 +37082,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.343095+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37141,7 +37141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.343164+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37187,7 +37187,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.343227+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37231,7 +37231,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.343290+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37269,7 +37269,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.343353+00:00"
+                "validatedAt": "2026-05-09T01:32:51.614976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37342,7 +37342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.343516+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37418,7 +37418,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.343838+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37463,7 +37463,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.343916+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37501,7 +37501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.343992+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37536,7 +37536,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.344069+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615321+00:00"
               },
               "deterministic": true
             },
@@ -37582,7 +37582,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.344145+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37668,7 +37668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.344210+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37738,7 +37738,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.344285+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37839,7 +37839,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.344409+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37916,7 +37916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.344481+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38069,7 +38069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.344610+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38202,7 +38202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.344745+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38245,8 +38245,8 @@
           "description": "Minimum configuration for viewscdn_loadbalancerCDNLoadbalancerDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewscdn_loadbalancerCDNLoadbalancerDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewscdn_loadbalancerCDNLoadbalancerDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/viewscdn_loadbalancer_c_d_n_loadbalancer_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -38286,7 +38286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.344792+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615654+00:00"
               },
               "deterministic": true
             },
@@ -38358,8 +38358,8 @@
           "description": "Minimum configuration for viewscdn_loadbalancerCDNSiteDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewscdn_loadbalancerCDNSiteDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewscdn_loadbalancerCDNSiteDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/viewscdn_loadbalancer_c_d_n_site_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -38397,7 +38397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.344846+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615678+00:00"
               },
               "deterministic": true
             },
@@ -38410,7 +38410,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.910554+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.345934+00:00"
           },
           "operator": {
             "$ref": "#/components/schemas/viewscdn_loadbalancerCacheOperator"
@@ -38518,7 +38518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.344932+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38541,7 +38541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.344988+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38564,7 +38564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345042+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38587,7 +38587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345097+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38610,7 +38610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345153+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38633,7 +38633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345204+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38656,7 +38656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345253+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38679,7 +38679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345311+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38702,7 +38702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345364+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38753,7 +38753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345404+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38765,7 +38765,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.910775+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.346044+00:00"
           },
           "operator": {
             "$ref": "#/components/schemas/viewscdn_loadbalancerCacheOperator"
@@ -38819,7 +38819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345466+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38899,7 +38899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.345548+00:00"
+                "validatedAt": "2026-05-09T01:32:51.615985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38942,7 +38942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.345635+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39037,7 +39037,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.345727+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39092,7 +39092,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.345814+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39128,7 +39128,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.345878+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39213,7 +39213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.345990+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616201+00:00"
               },
               "deterministic": true
             },
@@ -39266,7 +39266,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.346070+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39343,7 +39343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.346187+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39394,7 +39394,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.346271+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39581,7 +39581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.346386+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39639,7 +39639,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.346476+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39675,7 +39675,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.346541+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39774,7 +39774,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.346682+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616510+00:00"
               },
               "deterministic": true
             },
@@ -39827,7 +39827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.346761+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39852,7 +39852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.346815+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39929,7 +39929,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.346928+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39997,7 +39997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347035+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40123,7 +40123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347112+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40170,7 +40170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347179+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40208,7 +40208,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347242+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40249,7 +40249,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347311+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40293,8 +40293,8 @@
           "description": "Minimum configuration for viewscdn_loadbalancerHeaderOptions",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewscdn_loadbalancerHeaderOptions\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewscdn_loadbalancerHeaderOptions\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/viewscdn_loadbalancer_header_optionses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -40334,7 +40334,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347376+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40541,7 +40541,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347491+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40596,7 +40596,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347575+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40632,7 +40632,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347654+00:00"
+                "validatedAt": "2026-05-09T01:32:51.616967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40717,7 +40717,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347765+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617017+00:00"
               },
               "deterministic": true
             },
@@ -40770,7 +40770,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347845+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40847,7 +40847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.347958+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40898,7 +40898,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.348040+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41015,7 +41015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.348120+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41049,7 +41049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.348182+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41097,8 +41097,8 @@
           "description": "Minimum configuration for viewscommon_cdnCDNLoadbalancerDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewscommon_cdnCDNLoadbalancerDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewscommon_cdnCDNLoadbalancerDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/viewscommon_cdn_c_d_n_loadbalancer_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -41119,8 +41119,8 @@
           "description": "Minimum configuration for viewscommon_cdnCDNSiteDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewscommon_cdnCDNSiteDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewscommon_cdnCDNSiteDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/viewscommon_cdn_c_d_n_site_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -41143,8 +41143,8 @@
           "description": "Minimum configuration for viewscommon_securityJavaScriptLocation",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewscommon_securityJavaScriptLocation\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewscommon_securityJavaScriptLocation\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/viewscommon_security_java_script_locations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -41184,7 +41184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.348268+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41197,7 +41197,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.912648+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.347039+00:00"
           },
           "simple_login": {
             "$ref": "#/components/schemas/common_wafSimpleLogin"
@@ -41255,7 +41255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.348341+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41373,7 +41373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.348448+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41396,7 +41396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.348505+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41422,7 +41422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.348569+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41526,7 +41526,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.348716+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41585,8 +41585,8 @@
           "description": "Minimum configuration for virtual_hostCertificationState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_hostCertificationState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_hostCertificationState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_host_certification_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -41626,7 +41626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.348761+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617462+00:00"
               },
               "deterministic": true
             },
@@ -41639,7 +41639,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.912891+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.347184+00:00"
           },
           "type": {
             "type": "string",
@@ -41656,7 +41656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.348804+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41679,7 +41679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.348849+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41691,7 +41691,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.912932+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.347206+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41731,7 +41731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.348912+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41756,7 +41756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.348975+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41787,7 +41787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.349038+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41873,7 +41873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.349152+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41943,7 +41943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.349223+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41956,7 +41956,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:30.913047+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.347267+00:00"
           },
           "service_domain": {
             "type": "string",
@@ -41973,7 +41973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:07.349281+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42111,7 +42111,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.349422+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42159,8 +42159,8 @@
           "description": "Minimum configuration for virtual_hostVirtualHostState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_hostVirtualHostState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_hostVirtualHostState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_host_virtual_host_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -42197,7 +42197,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:07.349503+00:00"
+                "validatedAt": "2026-05-09T01:32:51.617793+00:00"
               },
               "deterministic": true
             },
@@ -42273,7 +42273,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.912601+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42308,7 +42308,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.912712+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42369,7 +42369,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.912782+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42407,7 +42407,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.912845+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42446,7 +42446,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.912915+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42514,7 +42514,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.912984+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42550,7 +42550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.913067+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42644,7 +42644,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.913150+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764275+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -42660,7 +42660,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.096646+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.438678+00:00"
           },
           "operator": {
             "$ref": "#/components/schemas/cdn_cache_ruleCacheOperator"
@@ -42760,7 +42760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.913218+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42795,7 +42795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.913272+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42830,7 +42830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.913321+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42865,7 +42865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.913371+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42900,7 +42900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.913424+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42935,7 +42935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.913467+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42970,7 +42970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.913510+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43018,7 +43018,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.913616+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43053,7 +43053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.913668+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43135,7 +43135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.913745+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43146,7 +43146,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.096824+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.438768+00:00"
           },
           "operator": {
             "$ref": "#/components/schemas/cdn_cache_ruleCacheOperator"
@@ -43213,7 +43213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.913807+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43274,8 +43274,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_cache_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_cache_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_cache_rules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -43358,7 +43358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.913878+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764590+00:00"
               },
               "deterministic": true
             },
@@ -43371,7 +43371,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.096960+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.438838+00:00"
           },
           "namespace": {
             "type": "string",
@@ -43401,7 +43401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.913915+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764608+00:00"
               },
               "deterministic": true
             },
@@ -43414,7 +43414,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.096990+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.438854+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -43540,8 +43540,8 @@
           "description": "Minimum configuration for cdn_cache_ruleHeaderOptions",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_cache_ruleHeaderOptions\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_cache_ruleHeaderOptions\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_cache_rule_header_optionses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -43588,7 +43588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:09.914042+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43651,7 +43651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:09.914111+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43663,7 +43663,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.097137+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.438929+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -43729,7 +43729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.914163+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764714+00:00"
               },
               "deterministic": true
             },
@@ -43742,7 +43742,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.097207+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.438965+00:00"
           },
           "namespace": {
             "type": "string",
@@ -43771,7 +43771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:09.914200+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764731+00:00"
               },
               "deterministic": true
             },
@@ -43784,7 +43784,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.097236+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.438981+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -43807,7 +43807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.914252+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43820,7 +43820,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.097284+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.439006+00:00"
           },
           "uid": {
             "type": "string",
@@ -43837,7 +43837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:09.914285+00:00"
+                "validatedAt": "2026-05-09T01:32:52.764767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43851,7 +43851,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.097315+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.439022+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cdn_cache_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -43900,8 +43900,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_cache_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_cache_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_cache_rule_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -43913,8 +43913,8 @@
           "description": "Minimum configuration for cdn_cache_ruleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_cache_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_cache_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_cache_rule_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -44057,8 +44057,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cdn_purge_commandCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cdn_purge_commandCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cdn_purge_commands\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -44141,7 +44141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:22.098490+00:00"
+                "validatedAt": "2026-05-09T01:32:58.163913+00:00"
               },
               "deterministic": true
             },
@@ -44154,7 +44154,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.465786+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.616561+00:00"
           },
           "namespace": {
             "type": "string",
@@ -44184,7 +44184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:22.098568+00:00"
+                "validatedAt": "2026-05-09T01:32:58.163937+00:00"
               },
               "deterministic": true
             },
@@ -44197,7 +44197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.465820+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.616578+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -44297,7 +44297,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.465912+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.616625+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -44364,7 +44364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:22.098771+00:00"
+                "validatedAt": "2026-05-09T01:32:58.163995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44427,7 +44427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:22.098851+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44439,7 +44439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.465996+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.616664+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -44505,7 +44505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:22.098907+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164047+00:00"
               },
               "deterministic": true
             },
@@ -44518,7 +44518,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.466070+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.616701+00:00"
           },
           "namespace": {
             "type": "string",
@@ -44547,7 +44547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:22.098947+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164065+00:00"
               },
               "deterministic": true
             },
@@ -44560,7 +44560,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.466100+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.616717+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -44599,7 +44599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099015+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44612,7 +44612,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.466159+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.616747+00:00"
           },
           "uid": {
             "type": "string",
@@ -44630,7 +44630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099050+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44644,7 +44644,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.466191+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.616763+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cdn_purge_command is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -44693,7 +44693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099106+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44719,7 +44719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099158+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44751,7 +44751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099214+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44790,7 +44790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099260+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44821,7 +44821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099312+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44846,7 +44846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099355+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44871,7 +44871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099393+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44902,7 +44902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.099445+00:00"
+                "validatedAt": "2026-05-09T01:32:58.164290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45028,7 +45028,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:22.101601+00:00"
+                "validatedAt": "2026-05-09T01:32:58.165216+00:00"
               },
               "deterministic": true
             },
@@ -45071,7 +45071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:22.101681+00:00"
+                "validatedAt": "2026-05-09T01:32:58.165251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45113,7 +45113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.101739+00:00"
+                "validatedAt": "2026-05-09T01:32:58.165275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45190,7 +45190,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:22.101821+00:00"
+                "validatedAt": "2026-05-09T01:32:58.165312+00:00"
               },
               "deterministic": true
             },
@@ -45233,7 +45233,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:22.101903+00:00"
+                "validatedAt": "2026-05-09T01:32:58.165347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45275,7 +45275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:22.101959+00:00"
+                "validatedAt": "2026-05-09T01:32:58.165370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45335,7 +45335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.262523+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45370,7 +45370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.262574+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45405,7 +45405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.262644+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45440,7 +45440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.262694+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45475,7 +45475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.262745+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45510,7 +45510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.262789+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45545,7 +45545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.262833+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45591,7 +45591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:26.262916+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45626,7 +45626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.262966+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45689,7 +45689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.263188+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45724,7 +45724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.263239+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45759,7 +45759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.263289+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45794,7 +45794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.263340+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45829,7 +45829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.263391+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45864,7 +45864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.263434+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45899,7 +45899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.263476+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45945,7 +45945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:26.263557+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45980,7 +45980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.263620+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46043,7 +46043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.263968+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46078,7 +46078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.264017+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46113,7 +46113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.264066+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46148,7 +46148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.264115+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46183,7 +46183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.264166+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46218,7 +46218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.264209+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46253,7 +46253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.264252+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46299,7 +46299,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:26.264333+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46334,7 +46334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:26.264383+00:00"
+                "validatedAt": "2026-05-09T01:33:00.008936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46391,7 +46391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.657102+00:00"
+                "validatedAt": "2026-05-09T01:34:01.703827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46416,7 +46416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.657193+00:00"
+                "validatedAt": "2026-05-09T01:34:01.703860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46478,8 +46478,8 @@
           "description": "Minimum configuration for app_typeAPIEPCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -46504,8 +46504,8 @@
           "description": "Minimum configuration for app_typeAPIEPSecurityRisk",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPSecurityRisk\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPSecurityRisk\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_security_risks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -46573,8 +46573,8 @@
           "description": "Minimum configuration for app_typeSensitiveDataType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeSensitiveDataType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeSensitiveDataType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_sensitive_data_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -46684,7 +46684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.658093+00:00"
+                "validatedAt": "2026-05-09T01:34:01.704219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46731,8 +46731,8 @@
           "description": "Minimum configuration for clusterEndpointSelectionPolicy",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for clusterEndpointSelectionPolicy\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for clusterEndpointSelectionPolicy\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cluster_endpoint_selection_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -46775,7 +46775,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.658161+00:00"
+                "validatedAt": "2026-05-09T01:34:01.704251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46856,8 +46856,8 @@
           "description": "Minimum configuration for clusterLoadbalancerAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for clusterLoadbalancerAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for clusterLoadbalancerAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cluster_loadbalancer_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -46964,7 +46964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:13:45.658278+00:00"
+                "validatedAt": "2026-05-09T01:34:01.704301+00:00"
               },
               "deterministic": true
             },
@@ -47036,8 +47036,8 @@
           "description": "Minimum configuration for common_cdnCDNLoadbalancerDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for common_cdnCDNLoadbalancerDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for common_cdnCDNLoadbalancerDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_cdn_c_d_n_loadbalancer_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -47058,8 +47058,8 @@
           "description": "Minimum configuration for common_cdnCDNSiteDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for common_cdnCDNSiteDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for common_cdnCDNSiteDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_cdn_c_d_n_site_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -47159,7 +47159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.660634+00:00"
+                "validatedAt": "2026-05-09T01:34:01.705314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47220,7 +47220,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.660702+00:00"
+                "validatedAt": "2026-05-09T01:34:01.705345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47299,7 +47299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:45.665491+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47502,7 +47502,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.665690+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47545,7 +47545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.665757+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47583,7 +47583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.665820+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47628,7 +47628,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.665887+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47666,7 +47666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.665951+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47710,7 +47710,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666016+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47748,7 +47748,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666080+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47793,7 +47793,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666145+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47850,8 +47850,8 @@
           "description": "Minimum configuration for http_loadbalancerApiInventorySchemaQueryType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for http_loadbalancerApiInventorySchemaQueryType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for http_loadbalancerApiInventorySchemaQueryType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/http_loadbalancer_api_inventory_schema_query_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -47886,7 +47886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666211+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47898,7 +47898,7 @@
             "x-original-maxLength": 128,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.768716+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.188975+00:00"
           },
           "value": {
             "$ref": "#/components/schemas/schemaSecretType"
@@ -47945,7 +47945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666301+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47983,7 +47983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666370+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707971+00:00"
               },
               "deterministic": true
             },
@@ -48073,7 +48073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666431+00:00"
+                "validatedAt": "2026-05-09T01:34:01.707997+00:00"
               },
               "deterministic": true
             },
@@ -48086,7 +48086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.768828+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189039+00:00"
           },
           "namespace": {
             "type": "string",
@@ -48115,7 +48115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666469+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708013+00:00"
               },
               "deterministic": true
             },
@@ -48128,7 +48128,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.768858+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189055+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -48157,8 +48157,8 @@
           "description": "Minimum configuration for http_loadbalancerAssignAPIDefinitionResp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for http_loadbalancerAssignAPIDefinitionResp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for http_loadbalancerAssignAPIDefinitionResp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/http_loadbalancer_assign_a_p_i_definition_resps\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -48200,7 +48200,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666545+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708047+00:00"
               },
               "deterministic": true
             },
@@ -48649,7 +48649,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666760+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48735,7 +48735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666814+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708163+00:00"
               },
               "deterministic": true
             },
@@ -48748,7 +48748,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769087+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189186+00:00"
           },
           "namespace": {
             "type": "string",
@@ -48778,7 +48778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666853+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708180+00:00"
               },
               "deterministic": true
             },
@@ -48791,7 +48791,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769117+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189205+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -48845,7 +48845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666892+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708197+00:00"
               },
               "deterministic": true
             },
@@ -48858,7 +48858,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769150+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189221+00:00"
           },
           "namespace": {
             "type": "string",
@@ -48888,7 +48888,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.666927+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708213+00:00"
               },
               "deterministic": true
             },
@@ -48901,7 +48901,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769180+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189237+00:00"
           }
         },
         "x-f5xc-description-short": "Request shape for GET API Endpoints For Groups.",
@@ -48959,7 +48959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.667004+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49016,7 +49016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.667068+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49056,7 +49056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.667106+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708293+00:00"
               },
               "deterministic": true
             },
@@ -49069,7 +49069,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769245+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189271+00:00"
           },
           "namespace": {
             "type": "string",
@@ -49099,7 +49099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.667143+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708309+00:00"
               },
               "deterministic": true
             },
@@ -49112,7 +49112,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769275+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189286+00:00"
           },
           "query_type": {
             "$ref": "#/components/schemas/http_loadbalancerApiInventorySchemaQueryType"
@@ -49299,7 +49299,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769416+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189369+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -49367,7 +49367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.667333+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708384+00:00"
               },
               "deterministic": true
             },
@@ -49380,7 +49380,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769477+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189404+00:00"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -49442,7 +49442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.667400+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49503,7 +49503,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.667463+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49688,7 +49688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:13:45.667610+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49751,7 +49751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:45.667682+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49763,7 +49763,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769689+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189507+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -49829,7 +49829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.667736+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708551+00:00"
               },
               "deterministic": true
             },
@@ -49842,7 +49842,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769759+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189543+00:00"
           },
           "namespace": {
             "type": "string",
@@ -49871,7 +49871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.667773+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708567+00:00"
               },
               "deterministic": true
             },
@@ -49884,7 +49884,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769789+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189559+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -49923,7 +49923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.667840+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49936,7 +49936,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769847+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189593+00:00"
           },
           "uid": {
             "type": "string",
@@ -49954,7 +49954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.667874+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49968,7 +49968,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.769878+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.189609+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of http_loadbalancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -50036,7 +50036,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.667970+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708653+00:00"
               },
               "deterministic": true
             },
@@ -50068,7 +50068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.668028+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50129,7 +50129,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.668093+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50202,7 +50202,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.668320+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50304,7 +50304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.668421+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708859+00:00"
               },
               "deterministic": true
             },
@@ -50350,7 +50350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.668507+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50386,7 +50386,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.668603+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50487,7 +50487,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.668706+00:00"
+                "validatedAt": "2026-05-09T01:34:01.708979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50591,7 +50591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.668812+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709022+00:00"
               },
               "deterministic": true
             },
@@ -50637,7 +50637,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.668895+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50673,7 +50673,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.668974+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51032,8 +51032,8 @@
           "description": "Minimum configuration for http_loadbalancerReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for http_loadbalancerReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for http_loadbalancerReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/http_loadbalancer_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -51178,7 +51178,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669166+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51226,7 +51226,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669238+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51269,7 +51269,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669303+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51306,7 +51306,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669365+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51351,7 +51351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669433+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51389,7 +51389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669499+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51433,7 +51433,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669566+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51470,7 +51470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669646+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51515,7 +51515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669710+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51561,7 +51561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:13:45.669767+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709466+00:00"
               },
               "deterministic": true
             },
@@ -51689,7 +51689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669860+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709509+00:00"
               },
               "deterministic": true
             },
@@ -51766,7 +51766,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.669954+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709551+00:00"
               },
               "deterministic": true
             },
@@ -51853,7 +51853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.670058+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709596+00:00"
               },
               "deterministic": true
             },
@@ -51889,7 +51889,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.670141+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51943,7 +51943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.670217+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52019,7 +52019,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.670298+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52088,7 +52088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.670361+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709729+00:00"
               },
               "deterministic": true
             },
@@ -52101,7 +52101,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.771002+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.190192+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52138,7 +52138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.670403+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709748+00:00"
               },
               "deterministic": true
             },
@@ -52151,7 +52151,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.771032+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.190208+00:00"
           },
           "rps_threshold": {
             "type": "integer",
@@ -52204,8 +52204,8 @@
           "description": "Minimum configuration for http_loadbalancerSetL7DDoSRPSThresholdRsp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for http_loadbalancerSetL7DDoSRPSThresholdRsp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for http_loadbalancerSetL7DDoSRPSThresholdRsp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/http_loadbalancer_set_l7_d_do_s_r_p_s_threshold_rsps\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -52357,7 +52357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.670570+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52397,7 +52397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.670624+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709837+00:00"
               },
               "deterministic": true
             },
@@ -52410,7 +52410,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.771185+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.190295+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52440,7 +52440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.670662+00:00"
+                "validatedAt": "2026-05-09T01:34:01.709854+00:00"
               },
               "deterministic": true
             },
@@ -52453,7 +52453,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.771215+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.190310+00:00"
           }
         },
         "x-f5xc-description-short": "Request shape for Update API Endpoints Schemas.",
@@ -52547,7 +52547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.671477+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710238+00:00"
               },
               "deterministic": true
             },
@@ -52591,7 +52591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.671565+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52874,7 +52874,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.671818+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52935,7 +52935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.671883+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52998,7 +52998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.671953+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53099,7 +53099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.672042+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53174,7 +53174,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.672131+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53257,7 +53257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:13:45.672202+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710529+00:00"
               },
               "deterministic": true
             },
@@ -53435,7 +53435,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.672541+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53504,7 +53504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:13:45.672608+00:00"
+                "validatedAt": "2026-05-09T01:34:01.710695+00:00"
               },
               "deterministic": true
             },
@@ -53549,8 +53549,8 @@
           "description": "Minimum configuration for origin_poolProtocolType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for origin_poolProtocolType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for origin_poolProtocolType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/origin_pool_protocol_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -53609,7 +53609,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.675076+00:00"
+                "validatedAt": "2026-05-09T01:34:01.711800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53694,7 +53694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.675161+00:00"
+                "validatedAt": "2026-05-09T01:34:01.711838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53775,7 +53775,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.677101+00:00"
+                "validatedAt": "2026-05-09T01:34:01.712710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53868,7 +53868,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.677194+00:00"
+                "validatedAt": "2026-05-09T01:34:01.712752+00:00"
               },
               "deterministic": true
             },
@@ -53880,7 +53880,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.773981+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.191725+00:00"
           },
           "path": {
             "type": "string",
@@ -53901,7 +53901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:45.677245+00:00"
+                "validatedAt": "2026-05-09T01:34:01.712773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54001,7 +54001,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.677357+00:00"
+                "validatedAt": "2026-05-09T01:34:01.712823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54107,7 +54107,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.677463+00:00"
+                "validatedAt": "2026-05-09T01:34:01.712870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54144,7 +54144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.677528+00:00"
+                "validatedAt": "2026-05-09T01:34:01.712901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54204,7 +54204,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.677636+00:00"
+                "validatedAt": "2026-05-09T01:34:01.712943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54274,7 +54274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.677738+00:00"
+                "validatedAt": "2026-05-09T01:34:01.712988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54348,7 +54348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.677814+00:00"
+                "validatedAt": "2026-05-09T01:34:01.713021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54383,7 +54383,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.677900+00:00"
+                "validatedAt": "2026-05-09T01:34:01.713061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54422,7 +54422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.677985+00:00"
+                "validatedAt": "2026-05-09T01:34:01.713101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54458,7 +54458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.678043+00:00"
+                "validatedAt": "2026-05-09T01:34:01.713125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54496,7 +54496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.678135+00:00"
+                "validatedAt": "2026-05-09T01:34:01.713172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54591,7 +54591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.678250+00:00"
+                "validatedAt": "2026-05-09T01:34:01.713224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54637,8 +54637,8 @@
           "description": "Minimum configuration for routeTagAttributeName",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for routeTagAttributeName\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for routeTagAttributeName\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/route_tag_attribute_names\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -54793,7 +54793,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.679612+00:00"
+                "validatedAt": "2026-05-09T01:34:01.713831+00:00"
               },
               "deterministic": true
             },
@@ -54806,7 +54806,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.775137+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.192332+00:00"
           },
           "overwrite": {
             "type": "boolean",
@@ -54847,7 +54847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.679697+00:00"
+                "validatedAt": "2026-05-09T01:34:01.713869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54859,7 +54859,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.775186+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:06.192358+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -54899,8 +54899,8 @@
           "description": "Minimum configuration for schemaDenominatorType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaDenominatorType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaDenominatorType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_denominator_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -55057,7 +55057,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.681780+00:00"
+                "validatedAt": "2026-05-09T01:34:01.714825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55091,7 +55091,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.681863+00:00"
+                "validatedAt": "2026-05-09T01:34:01.714863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55265,7 +55265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.682017+00:00"
+                "validatedAt": "2026-05-09T01:34:01.714929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55314,7 +55314,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.682088+00:00"
+                "validatedAt": "2026-05-09T01:34:01.714961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55359,8 +55359,8 @@
           "description": "Minimum configuration for schemaRoutingPriority",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaRoutingPriority\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaRoutingPriority\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_routing_priorities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -55409,7 +55409,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.682185+00:00"
+                "validatedAt": "2026-05-09T01:34:01.715004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55443,7 +55443,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.682268+00:00"
+                "validatedAt": "2026-05-09T01:34:01.715041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55485,7 +55485,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.682354+00:00"
+                "validatedAt": "2026-05-09T01:34:01.715080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55592,7 +55592,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.682480+00:00"
+                "validatedAt": "2026-05-09T01:34:01.715136+00:00"
               },
               "deterministic": true
             },
@@ -55605,7 +55605,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.776374+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.192970+00:00"
           },
           "overwrite": {
             "type": "boolean",
@@ -55655,7 +55655,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.682572+00:00"
+                "validatedAt": "2026-05-09T01:34:01.715183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55667,7 +55667,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.776450+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:06.193011+00:00",
             "x-f5xc-conflicts-with": [
               "ignore_value",
               "secret_value"
@@ -55810,8 +55810,8 @@
           "description": "Minimum configuration for schemarouteJavaScriptLocation",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemarouteJavaScriptLocation\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemarouteJavaScriptLocation\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaroute_java_script_locations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -55878,7 +55878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.685174+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55961,7 +55961,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.685664+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56049,7 +56049,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.685762+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56116,7 +56116,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.685857+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716654+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -56168,7 +56168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686171+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56218,7 +56218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:45.686227+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56246,7 +56246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.686269+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716837+00:00"
               },
               "deterministic": true
             },
@@ -56270,7 +56270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686315+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56293,7 +56293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686364+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56305,7 +56305,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.778064+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.193856+00:00"
           },
           "status": {
             "type": "string",
@@ -56321,7 +56321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686412+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56333,7 +56333,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.778096+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.193872+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -56374,7 +56374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:45.686460+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56412,7 +56412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.686500+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716963+00:00"
               },
               "deterministic": true
             },
@@ -56425,7 +56425,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.778139+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.193894+00:00"
           },
           "nlb_cname": {
             "type": "string",
@@ -56441,7 +56441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686549+00:00"
+                "validatedAt": "2026-05-09T01:34:01.716996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56464,7 +56464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686614+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56487,7 +56487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686665+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56499,7 +56499,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.778189+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.193921+00:00"
           },
           "target_group_status": {
             "type": "array",
@@ -56553,7 +56553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:45.686734+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56606,7 +56606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.686791+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717115+00:00"
               },
               "deterministic": true
             },
@@ -56619,7 +56619,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.778251+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.193953+00:00"
           },
           "protocol": {
             "type": "string",
@@ -56634,7 +56634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686838+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56657,7 +56657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686887+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56669,7 +56669,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.778291+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.193974+00:00"
           },
           "status": {
             "type": "string",
@@ -56685,7 +56685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.686936+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56697,7 +56697,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.778322+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.193990+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -56750,7 +56750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.687011+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717255+00:00"
               },
               "deterministic": true
             },
@@ -56835,7 +56835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:45.687076+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56863,7 +56863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:45.687117+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56942,8 +56942,8 @@
           "description": "Minimum configuration for viewsSiteNetwork",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_networks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -56965,8 +56965,8 @@
           "description": "Minimum configuration for viewsSiteNetworkSpecifiedVIP",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_network_specified_v_i_ps\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -57031,7 +57031,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.687282+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57104,7 +57104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.687339+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717410+00:00"
               },
               "deterministic": true
             },
@@ -57151,7 +57151,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.687428+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57274,7 +57274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.687554+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57309,7 +57309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.687651+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57404,7 +57404,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.687730+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57535,7 +57535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.688208+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57596,7 +57596,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.688301+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57632,7 +57632,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.688366+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57674,7 +57674,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.688440+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57772,7 +57772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.688572+00:00"
+                "validatedAt": "2026-05-09T01:34:01.717964+00:00"
               },
               "deterministic": true
             },
@@ -57828,7 +57828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.688756+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57917,7 +57917,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.688904+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57966,7 +57966,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.688985+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58023,7 +58023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.689073+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58403,7 +58403,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.689197+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58416,7 +58416,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.779762+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.194751+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -58534,7 +58534,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.689310+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58598,7 +58598,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.689408+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58634,7 +58634,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.689473+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58676,7 +58676,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.689547+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58788,7 +58788,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.689714+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718424+00:00"
               },
               "deterministic": true
             },
@@ -58844,7 +58844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.689799+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58869,7 +58869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:45.689853+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58972,7 +58972,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690000+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59021,7 +59021,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690077+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59081,7 +59081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690172+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59515,7 +59515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690297+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59576,7 +59576,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690391+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59612,7 +59612,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690456+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59654,7 +59654,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690529+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59752,7 +59752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690676+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718887+00:00"
               },
               "deterministic": true
             },
@@ -59808,7 +59808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690760+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59897,7 +59897,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690892+00:00"
+                "validatedAt": "2026-05-09T01:34:01.718981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59946,7 +59946,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.690969+00:00"
+                "validatedAt": "2026-05-09T01:34:01.719019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60003,7 +60003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.691060+00:00"
+                "validatedAt": "2026-05-09T01:34:01.719059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60390,7 +60390,7 @@
                 "confidence": 0.99,
                 "category": "networking",
                 "note": "Asymmetry: port enforces [1,65535], health_check_port allows 0",
-                "validatedAt": "2026-05-08T20:13:45.691135+00:00"
+                "validatedAt": "2026-05-09T01:34:01.719090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60427,7 +60427,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.691207+00:00"
+                "validatedAt": "2026-05-09T01:34:01.719125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60482,7 +60482,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.691292+00:00"
+                "validatedAt": "2026-05-09T01:34:01.719169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60520,7 +60520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.691338+00:00"
+                "validatedAt": "2026-05-09T01:34:01.719189+00:00"
               },
               "deterministic": true
             },
@@ -60637,7 +60637,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.691764+00:00"
+                "validatedAt": "2026-05-09T01:34:01.719379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60725,7 +60725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:45.691853+00:00"
+                "validatedAt": "2026-05-09T01:34:01.719420+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/ce_management.json
+++ b/docs/specifications/api/ce_management.json
@@ -7298,8 +7298,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7406,8 +7406,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fleetCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fleetCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fleets\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -7490,7 +7490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.773375+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548125+00:00"
               },
               "deterministic": true
             },
@@ -7503,7 +7503,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.394957+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377169+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7533,7 +7533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.773422+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548147+00:00"
               },
               "deterministic": true
             },
@@ -7546,7 +7546,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.394991+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377186+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7602,7 +7602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.773460+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548172+00:00"
               },
               "deterministic": true
             },
@@ -7615,7 +7615,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.395025+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377203+00:00"
           },
           "network_device": {
             "$ref": "#/components/schemas/fleetNetworkingDeviceInstanceType"
@@ -7680,7 +7680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.773578+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7717,7 +7717,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.773688+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7763,8 +7763,8 @@
           "description": "Minimum configuration for fleetDeviceOwnerType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fleetDeviceOwnerType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fleetDeviceOwnerType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fleet_device_owner_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -7836,7 +7836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.773792+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7873,7 +7873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.773867+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7937,7 +7937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.773957+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7972,7 +7972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.774013+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8011,7 +8011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774082+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8068,7 +8068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774151+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8130,7 +8130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.774223+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8228,7 +8228,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774318+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8265,7 +8265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774391+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8305,7 +8305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774479+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8342,7 +8342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774558+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8420,7 +8420,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774668+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8464,7 +8464,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774737+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8540,7 +8540,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774803+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8646,7 +8646,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774920+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548815+00:00"
               },
               "deterministic": true
             },
@@ -8659,7 +8659,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.395385+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377388+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8719,7 +8719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.774983+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8777,7 +8777,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.775046+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8842,7 +8842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.775113+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8887,7 +8887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.775174+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8943,7 +8943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.775237+00:00"
+                "validatedAt": "2026-05-09T01:35:29.548962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9058,7 +9058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.775352+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549013+00:00"
               },
               "deterministic": true
             },
@@ -9071,7 +9071,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.395521+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377458+00:00"
           },
           "hpe_storage": {
             "$ref": "#/components/schemas/fleetStorageClassHpeStorageType"
@@ -9105,7 +9105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.775442+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9140,7 +9140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.775501+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9184,7 +9184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.775602+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9250,7 +9250,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.775668+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9348,7 +9348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.775770+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9417,7 +9417,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.775835+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9526,7 +9526,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.395782+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377586+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9594,7 +9594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:17:03.775976+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9656,7 +9656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:17:03.776044+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9668,7 +9668,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.395861+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377625+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9734,7 +9734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.776097+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549335+00:00"
               },
               "deterministic": true
             },
@@ -9747,7 +9747,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.395932+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377662+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9776,7 +9776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.776133+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549351+00:00"
               },
               "deterministic": true
             },
@@ -9789,7 +9789,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.395961+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377678+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9828,7 +9828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776200+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9841,7 +9841,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.396019+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377708+00:00"
           },
           "uid": {
             "type": "string",
@@ -9858,7 +9858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776233+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9872,7 +9872,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.396050+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377724+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of fleet is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9936,7 +9936,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.776295+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9983,8 +9983,8 @@
           "description": "Minimum configuration for fleetNetworkingDeviceInstanceUseType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fleetNetworkingDeviceInstanceUseType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fleetNetworkingDeviceInstanceUseType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fleet_networking_device_instance_use_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -10044,7 +10044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776349+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10102,7 +10102,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.776438+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10147,7 +10147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776495+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10185,7 +10185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.776579+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10214,7 +10214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776646+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10253,7 +10253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776703+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10279,7 +10279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776754+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10311,7 +10311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776808+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10353,7 +10353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776866+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10454,8 +10454,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fleetReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fleetReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fleet_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -10467,8 +10467,8 @@
           "description": "Minimum configuration for fleetReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fleetReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fleetReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fleet_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -10503,7 +10503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.776957+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10599,7 +10599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777057+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10719,7 +10719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777189+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549797+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -10776,7 +10776,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777271+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10808,7 +10808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777354+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10861,7 +10861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777448+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549915+00:00"
               },
               "deterministic": true
             },
@@ -10874,7 +10874,7 @@
             "x-original-maxLength": 512,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.396437+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.377924+00:00"
           },
           "destroy_on_delete": {
             "type": "boolean",
@@ -10932,7 +10932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777528+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10959,7 +10959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.777578+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10986,7 +10986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.777640+00:00"
+                "validatedAt": "2026-05-09T01:35:29.549991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11019,7 +11019,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777724+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11052,7 +11052,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777794+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11085,7 +11085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777879+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11119,7 +11119,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.777959+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11152,7 +11152,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778038+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11271,7 +11271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778140+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11326,7 +11326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.778188+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11360,7 +11360,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778269+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11465,7 +11465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778400+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11501,7 +11501,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778491+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11534,7 +11534,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778572+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11578,7 +11578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778656+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550460+00:00"
               },
               "deterministic": true
             },
@@ -11661,7 +11661,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778748+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11694,7 +11694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778832+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11734,7 +11734,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.778930+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11772,7 +11772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.779009+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11830,7 +11830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.779071+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11856,7 +11856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.779125+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11893,7 +11893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.779213+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11931,7 +11931,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.779294+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11960,7 +11960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.779349+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11988,7 +11988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.779395+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12026,7 +12026,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.779456+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12061,7 +12061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.779515+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12087,7 +12087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.779566+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12124,7 +12124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.779646+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12158,7 +12158,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.779731+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12202,7 +12202,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.779801+00:00"
+                "validatedAt": "2026-05-09T01:35:29.550971+00:00"
               },
               "deterministic": true
             },
@@ -12284,7 +12284,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.779890+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12324,7 +12324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.779979+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12362,7 +12362,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780056+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12402,7 +12402,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780136+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12508,7 +12508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780272+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12546,7 +12546,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780351+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12580,7 +12580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.780402+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12618,7 +12618,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780462+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12653,7 +12653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.780522+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12690,7 +12690,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780620+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12727,7 +12727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780688+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12761,7 +12761,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780772+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12808,7 +12808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780846+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551463+00:00"
               },
               "deterministic": true
             },
@@ -12929,7 +12929,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.780962+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13016,7 +13016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781032+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13084,8 +13084,8 @@
           "description": "Minimum configuration for fleetVGPUFeatureType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fleetVGPUFeatureType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fleetVGPUFeatureType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fleet_v_g_p_u_feature_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -13100,8 +13100,8 @@
           "description": "Minimum configuration for fleetVMConfiguration",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fleetVMConfiguration\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fleetVMConfiguration\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fleet_v_m_configurations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -13116,8 +13116,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13146,7 +13146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781095+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13159,7 +13159,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397244+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378345+00:00"
           },
           "name": {
             "type": "string",
@@ -13192,7 +13192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.781132+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551589+00:00"
               },
               "deterministic": true
             },
@@ -13205,7 +13205,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397275+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378361+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13236,7 +13236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.781169+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551606+00:00"
               },
               "deterministic": true
             },
@@ -13249,7 +13249,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397305+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378376+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13268,7 +13268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781211+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13282,7 +13282,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397334+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378392+00:00"
           },
           "uid": {
             "type": "string",
@@ -13301,7 +13301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781244+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13316,7 +13316,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397365+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378408+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -13354,7 +13354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781290+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13377,7 +13377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781333+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13389,7 +13389,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397409+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378431+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -13432,7 +13432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781389+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13470,7 +13470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.781464+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13482,7 +13482,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397451+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378453+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -13501,7 +13501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781523+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13552,7 +13552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781569+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13564,7 +13564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397493+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378475+00:00"
           },
           "url": {
             "type": "string",
@@ -13602,7 +13602,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.781657+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551818+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13659,7 +13659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:17:03.781699+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551836+00:00"
               },
               "deterministic": true
             },
@@ -13685,7 +13685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781751+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13712,7 +13712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781794+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13724,7 +13724,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397554+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378507+00:00"
           },
           "service_name": {
             "type": "string",
@@ -13741,7 +13741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781844+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13774,7 +13774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781889+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13786,7 +13786,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397606+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378527+00:00"
           },
           "type": {
             "type": "string",
@@ -13811,7 +13811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781931+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13865,8 +13865,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13899,7 +13899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.781988+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13961,7 +13961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782026+00:00"
+                "validatedAt": "2026-05-09T01:35:29.551976+00:00"
               },
               "deterministic": true
             },
@@ -13974,7 +13974,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397682+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378566+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -14123,7 +14123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782133+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14199,7 +14199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782223+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14255,7 +14255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782293+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14333,7 +14333,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782383+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14389,7 +14389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782444+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14438,8 +14438,8 @@
           "description": "Minimum configuration for schemaNextHopTypes",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaNextHopTypes\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaNextHopTypes\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_next_hop_typeses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14504,7 +14504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782550+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552231+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14520,7 +14520,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397894+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378673+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14590,7 +14590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782613+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552254+00:00"
               },
               "deterministic": true
             },
@@ -14603,7 +14603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397945+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378700+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14634,7 +14634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782649+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552271+00:00"
               },
               "deterministic": true
             },
@@ -14647,7 +14647,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.397974+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378715+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -14729,7 +14729,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782748+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552320+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14745,7 +14745,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398019+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378738+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14817,7 +14817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782797+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552344+00:00"
               },
               "deterministic": true
             },
@@ -14830,7 +14830,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398070+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378764+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14861,7 +14861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782832+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552361+00:00"
               },
               "deterministic": true
             },
@@ -14874,7 +14874,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398099+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378780+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -14956,7 +14956,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782929+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552405+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14972,7 +14972,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398143+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378802+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15042,7 +15042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.782978+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552428+00:00"
               },
               "deterministic": true
             },
@@ -15055,7 +15055,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398194+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378834+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15086,7 +15086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.783013+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552444+00:00"
               },
               "deterministic": true
             },
@@ -15099,7 +15099,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398223+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378854+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -15140,8 +15140,8 @@
           "description": "Minimum configuration for schemaRouteAttrType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaRouteAttrType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaRouteAttrType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_route_attr_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -15161,8 +15161,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -15228,7 +15228,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.783081+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15282,7 +15282,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.783147+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15333,7 +15333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783203+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15361,7 +15361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783253+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15389,7 +15389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783305+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15418,7 +15418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783364+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15445,7 +15445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783401+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15459,7 +15459,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398370+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378938+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -15475,7 +15475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783448+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15538,8 +15538,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -15584,7 +15584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783515+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15596,7 +15596,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398433+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378970+00:00"
           },
           "status": {
             "type": "string",
@@ -15614,7 +15614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783560+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15626,7 +15626,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398462+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.378985+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -15668,7 +15668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783634+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15695,7 +15695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783688+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15722,7 +15722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783738+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15750,7 +15750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783793+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15815,7 +15815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783876+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15864,7 +15864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783948+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15877,7 +15877,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398603+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.379053+00:00"
           },
           "uid": {
             "type": "string",
@@ -15896,7 +15896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.783983+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15910,7 +15910,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398636+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.379069+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -15960,7 +15960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.784026+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15972,7 +15972,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398668+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.379086+00:00"
           },
           "name": {
             "type": "string",
@@ -16005,7 +16005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784064+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552901+00:00"
               },
               "deterministic": true
             },
@@ -16018,7 +16018,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398698+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.379101+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16049,7 +16049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784102+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552918+00:00"
               },
               "deterministic": true
             },
@@ -16062,7 +16062,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398728+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.379117+00:00"
           },
           "uid": {
             "type": "string",
@@ -16079,7 +16079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.784136+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16093,7 +16093,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.398758+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.379132+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -16140,8 +16140,8 @@
           "description": "Minimum configuration for schemaVirtualNetworkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_virtual_network_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -16192,7 +16192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784210+00:00"
+                "validatedAt": "2026-05-09T01:35:29.552967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16279,7 +16279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.784322+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16312,7 +16312,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784389+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16358,7 +16358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784468+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16392,7 +16392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784528+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16440,7 +16440,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784652+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16473,7 +16473,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784719+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16527,7 +16527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784838+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16635,7 +16635,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.784908+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16722,7 +16722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:03.785018+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16755,7 +16755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785083+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16801,7 +16801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785160+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16835,7 +16835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785220+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16883,7 +16883,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785330+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16916,7 +16916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785393+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16970,7 +16970,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785509+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17078,7 +17078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785577+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17163,7 +17163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785710+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17209,7 +17209,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785789+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17243,7 +17243,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785850+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17291,7 +17291,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.785960+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17324,7 +17324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.786024+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17378,7 +17378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.786140+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17489,7 +17489,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.786218+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553912+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17505,7 +17505,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.399895+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.379733+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17542,7 +17542,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.786288+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553945+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17558,7 +17558,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.399927+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.379748+00:00"
           },
           "tenant": {
             "type": "string",
@@ -17587,7 +17587,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.786366+00:00"
+                "validatedAt": "2026-05-09T01:35:29.553980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17601,7 +17601,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.399957+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.379764+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -17830,7 +17830,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:03.786516+00:00"
+                "validatedAt": "2026-05-09T01:35:29.554046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17902,8 +17902,8 @@
           "description": "Minimum configuration for module_managementModuleManagement",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for module_managementModuleManagement\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for module_managementModuleManagement\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/module_management_module_managements\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -17952,8 +17952,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interfaces\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -18059,7 +18059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:20.406643+00:00"
+                "validatedAt": "2026-05-09T01:37:25.087913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18099,7 +18099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.406732+00:00"
+                "validatedAt": "2026-05-09T01:37:25.087961+00:00"
               },
               "deterministic": true
             },
@@ -18157,7 +18157,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.406810+00:00"
+                "validatedAt": "2026-05-09T01:37:25.087997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18192,7 +18192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.406884+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18264,7 +18264,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.406963+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18452,7 +18452,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407073+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18491,7 +18491,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407153+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18532,7 +18532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:20.407217+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18572,7 +18572,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407294+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088238+00:00"
               },
               "deterministic": true
             },
@@ -18623,8 +18623,8 @@
           "description": "Minimum configuration for network_interfaceDHCPPoolSettingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceDHCPPoolSettingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceDHCPPoolSettingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_d_h_c_p_pool_setting_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -18660,7 +18660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407371+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18694,7 +18694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407446+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18766,7 +18766,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407521+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18866,7 +18866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407630+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18933,7 +18933,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407733+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18976,7 +18976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:20.407786+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19048,7 +19048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407868+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19106,7 +19106,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407954+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19185,7 +19185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.407999+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088582+00:00"
               },
               "deterministic": true
             },
@@ -19198,7 +19198,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.236742+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.632701+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19228,7 +19228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.408035+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088600+00:00"
               },
               "deterministic": true
             },
@@ -19241,7 +19241,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.236774+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.632728+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19305,7 +19305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.408118+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19384,7 +19384,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.408231+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19427,7 +19427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:20.408282+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19481,7 +19481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:21:20.408343+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088763+00:00"
               },
               "deterministic": true
             },
@@ -19614,7 +19614,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.237067+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.632910+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19679,7 +19679,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.408500+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19721,7 +19721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:20.408564+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19834,7 +19834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:20.408686+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19870,7 +19870,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.408753+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19912,7 +19912,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.408824+00:00"
+                "validatedAt": "2026-05-09T01:37:25.088974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20023,7 +20023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.408955+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20152,7 +20152,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.409041+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20207,7 +20207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.409127+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20311,7 +20311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:21:20.409189+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089163+00:00"
               },
               "deterministic": true
             },
@@ -20375,7 +20375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.409268+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20416,7 +20416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:21:20.409313+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089225+00:00"
               },
               "deterministic": true
             },
@@ -20483,7 +20483,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.409391+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20523,7 +20523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:21:20.409431+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089283+00:00"
               },
               "deterministic": true
             },
@@ -20588,7 +20588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.409503+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20625,7 +20625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:20.409562+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20694,7 +20694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:20.409652+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20750,7 +20750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.409737+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20827,8 +20827,8 @@
           "description": "Minimum configuration for network_interfaceLinkQualityMonitorConfig",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceLinkQualityMonitorConfig\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceLinkQualityMonitorConfig\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_link_quality_monitor_configs\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -20875,7 +20875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:21:20.409815+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20938,7 +20938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:20.409881+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20950,7 +20950,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.237755+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.633292+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21016,7 +21016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.409935+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089508+00:00"
               },
               "deterministic": true
             },
@@ -21029,7 +21029,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.237826+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.633333+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21058,7 +21058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.409971+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089527+00:00"
               },
               "deterministic": true
             },
@@ -21071,7 +21071,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.237856+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.633349+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21110,7 +21110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:20.410036+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21123,7 +21123,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.237913+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.633380+00:00"
           },
           "uid": {
             "type": "string",
@@ -21141,7 +21141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:20.410069+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21155,7 +21155,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.237945+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.633396+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_interface is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21229,8 +21229,8 @@
           "description": "Minimum configuration for network_interfaceNetworkInterfaceDHCP",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceDHCP\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceDHCP\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_network_interface_d_h_c_ps\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -21253,8 +21253,8 @@
           "description": "Minimum configuration for network_interfaceNetworkInterfaceDHCPServer",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceDHCPServer\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceDHCPServer\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_network_interface_d_h_c_p_servers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -21318,8 +21318,8 @@
           "description": "Minimum configuration for network_interfaceNetworkInterfaceDNSMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceDNSMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceDNSMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_network_interface_d_n_s_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -21342,8 +21342,8 @@
           "description": "Minimum configuration for network_interfaceNetworkInterfaceGatewayMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceGatewayMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceGatewayMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_network_interface_gateway_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -21403,7 +21403,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.410168+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21447,8 +21447,8 @@
           "description": "Minimum configuration for network_interfaceNetworkInterfaceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_network_interface_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -21471,8 +21471,8 @@
           "description": "Minimum configuration for network_interfaceNetworkInterfaceUpDown",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceUpDown\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceUpDown\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_network_interface_up_downs\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -21494,8 +21494,8 @@
           "description": "Minimum configuration for network_interfaceNetworkInterfaceVLANTagging",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceVLANTagging\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceNetworkInterfaceVLANTagging\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_network_interface_v_l_a_n_taggings\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -21521,8 +21521,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -21534,8 +21534,8 @@
           "description": "Minimum configuration for network_interfaceReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_interfaceReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_interfaceReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_interface_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -21688,7 +21688,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.410295+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21727,7 +21727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.410375+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089715+00:00"
               },
               "deterministic": true
             },
@@ -21871,7 +21871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:20.410504+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21908,7 +21908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:20.410551+00:00"
+                "validatedAt": "2026-05-09T01:37:25.089794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21989,7 +21989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.759381+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22001,7 +22001,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.734330+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.786691+00:00"
           },
           "status": {
             "type": "string",
@@ -22019,7 +22019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.759425+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22031,7 +22031,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.734361+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.786707+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -22087,7 +22087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.759598+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22114,7 +22114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.759654+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22177,7 +22177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.759707+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444418+00:00"
               },
               "deterministic": true
             },
@@ -22190,7 +22190,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.734483+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.786771+00:00"
           },
           "passport": {
             "$ref": "#/components/schemas/registrationPassport"
@@ -22211,7 +22211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.759766+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22287,7 +22287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.759812+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444463+00:00"
               },
               "deterministic": true
             },
@@ -22300,7 +22300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.734546+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.786804+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22336,7 +22336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.759854+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444483+00:00"
               },
               "deterministic": true
             },
@@ -22349,7 +22349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.734576+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.786819+00:00"
           },
           "token": {
             "type": "string",
@@ -22375,7 +22375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:23:25.759906+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22421,7 +22421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.759947+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22480,8 +22480,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for registrationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for registrationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/registrations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -22543,7 +22543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760024+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22555,7 +22555,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.734713+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.786882+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22590,7 +22590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760080+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22613,7 +22613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760137+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22666,7 +22666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760191+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22845,7 +22845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760343+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22871,7 +22871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760393+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22898,7 +22898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760436+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22911,7 +22911,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.734901+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.786980+00:00"
           },
           "hostname": {
             "type": "string",
@@ -22943,7 +22943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:23:25.760481+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444756+00:00"
               },
               "deterministic": true
             },
@@ -22973,7 +22973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760534+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23036,7 +23036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760608+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23076,7 +23076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:23:25.760670+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444832+00:00"
               },
               "deterministic": true
             },
@@ -23103,7 +23103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760708+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23164,7 +23164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760758+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23190,7 +23190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760806+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23217,7 +23217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760852+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23244,7 +23244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.760903+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23313,7 +23313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:25.760961+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23376,7 +23376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:25.761027+00:00"
+                "validatedAt": "2026-05-09T01:38:21.444988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23388,7 +23388,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.735119+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787093+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23454,7 +23454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.761078+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445010+00:00"
               },
               "deterministic": true
             },
@@ -23467,7 +23467,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.735189+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787129+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23496,7 +23496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.761114+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445027+00:00"
               },
               "deterministic": true
             },
@@ -23509,7 +23509,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.735218+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787145+00:00"
           },
           "object": {
             "$ref": "#/components/schemas/registrationObject"
@@ -23535,7 +23535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.761167+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23548,7 +23548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.735278+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787181+00:00"
           },
           "uid": {
             "type": "string",
@@ -23565,7 +23565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.761199+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23579,7 +23579,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.735309+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787197+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of registration is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23650,7 +23650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.761243+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445082+00:00"
               },
               "deterministic": true
             },
@@ -23663,7 +23663,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.735343+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787214+00:00"
           },
           "state": {
             "$ref": "#/components/schemas/registrationObjectState"
@@ -23770,8 +23770,8 @@
           "description": "Minimum configuration for registrationObjectState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for registrationObjectState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for registrationObjectState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/registration_object_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -23808,7 +23808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.761320+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23863,7 +23863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.761400+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23957,7 +23957,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.761541+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23997,7 +23997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.761644+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24031,7 +24031,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.761733+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24108,8 +24108,8 @@
           "description": "Minimum configuration for registrationProvider",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for registrationProvider\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for registrationProvider\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/registration_providers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -24136,8 +24136,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for registrationRegistrationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for registrationRegistrationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/registration_registrations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -24163,8 +24163,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for registrationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for registrationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/registration_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -24176,8 +24176,8 @@
           "description": "Minimum configuration for registrationReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for registrationReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for registrationReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/registration_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -24202,7 +24202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.761801+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24280,7 +24280,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.761889+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24314,7 +24314,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.761968+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24352,7 +24352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.762008+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445436+00:00"
               },
               "deterministic": true
             },
@@ -24365,7 +24365,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.735641+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787364+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -24447,7 +24447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.762605+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445700+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24463,7 +24463,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.736034+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787568+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24535,7 +24535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.762655+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445722+00:00"
               },
               "deterministic": true
             },
@@ -24548,7 +24548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.736085+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787595+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24579,7 +24579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.762691+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445738+00:00"
               },
               "deterministic": true
             },
@@ -24592,7 +24592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.736115+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787610+00:00"
           },
           "uid": {
             "type": "string",
@@ -24611,7 +24611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.762724+00:00"
+                "validatedAt": "2026-05-09T01:38:21.445753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24626,7 +24626,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.736145+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787627+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -24667,8 +24667,8 @@
           "description": "Minimum configuration for schemaSiteToSiteTunnelType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSiteToSiteTunnelType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSiteToSiteTunnelType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_site_to_site_tunnel_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -24697,7 +24697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763345+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24725,7 +24725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763399+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24754,7 +24754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763451+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24781,7 +24781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763498+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24810,7 +24810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763550+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24835,7 +24835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763615+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24900,7 +24900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763703+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24938,7 +24938,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.763767+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24950,7 +24950,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.736565+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787851+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -24991,7 +24991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763831+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25035,7 +25035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763878+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25049,7 +25049,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.736653+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787887+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -25068,7 +25068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763925+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25095,7 +25095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.763959+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25110,7 +25110,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.736695+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.787908+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -25125,7 +25125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.764003+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25221,7 +25221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:23:25.764214+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25284,7 +25284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:23:25.764272+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25397,7 +25397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:23:25.764373+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25439,8 +25439,8 @@
           "description": "Minimum configuration for schemaregistrationReplaceSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaregistrationReplaceSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaregistrationReplaceSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaregistration_replace_spec_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -25477,7 +25477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.764445+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25528,7 +25528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:25.764485+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25577,7 +25577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:25.764547+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25589,7 +25589,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737062+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788095+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -25607,7 +25607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.764609+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25666,7 +25666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:23:25.764874+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446775+00:00"
               },
               "deterministic": true
             },
@@ -25693,7 +25693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.764916+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25719,7 +25719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.764959+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25731,7 +25731,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737228+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788184+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25771,7 +25771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765007+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25811,7 +25811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.765042+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446868+00:00"
               },
               "deterministic": true
             },
@@ -25824,7 +25824,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737270+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788206+00:00"
           },
           "serial": {
             "type": "string",
@@ -25842,7 +25842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765084+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25868,7 +25868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765126+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25894,7 +25894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765168+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25906,7 +25906,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737319+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788232+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25948,7 +25948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765216+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25974,7 +25974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765257+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26016,7 +26016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765311+00:00"
+                "validatedAt": "2026-05-09T01:38:21.446997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26042,7 +26042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765356+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26054,7 +26054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737391+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788269+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26140,7 +26140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765436+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26195,7 +26195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765504+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26246,7 +26246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765555+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26271,7 +26271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765619+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26334,7 +26334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765669+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26359,7 +26359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765716+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26384,7 +26384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765766+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26431,7 +26431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765816+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26456,7 +26456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765860+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26481,7 +26481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765901+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26493,7 +26493,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788365+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26529,8 +26529,8 @@
           "description": "Minimum configuration for siteLinkQuality",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteLinkQuality\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteLinkQuality\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_link_qualities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -26557,8 +26557,8 @@
           "description": "Minimum configuration for siteLinkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteLinkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteLinkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_link_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -26615,7 +26615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.765968+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26662,7 +26662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766012+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26714,7 +26714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:23:25.766081+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447352+00:00"
               },
               "deterministic": true
             },
@@ -26754,7 +26754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.766117+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447369+00:00"
               },
               "deterministic": true
             },
@@ -26767,7 +26767,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737718+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788431+00:00"
           },
           "port": {
             "type": "string",
@@ -26786,7 +26786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766154+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26853,7 +26853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766219+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26892,7 +26892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.766253+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447437+00:00"
               },
               "deterministic": true
             },
@@ -26905,7 +26905,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737780+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788463+00:00"
           },
           "release": {
             "type": "string",
@@ -26922,7 +26922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766296+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26947,7 +26947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766338+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26972,7 +26972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766384+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26984,7 +26984,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737829+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788489+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27049,7 +27049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:25.766452+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27082,7 +27082,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.766514+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27190,7 +27190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.766600+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447584+00:00"
               },
               "deterministic": true
             },
@@ -27203,7 +27203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.737986+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788570+00:00"
           },
           "serial": {
             "type": "string",
@@ -27222,7 +27222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766644+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27247,7 +27247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766688+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27273,7 +27273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766730+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27285,7 +27285,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.738035+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788596+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27342,8 +27342,8 @@
           "description": "Minimum configuration for siteSiteState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteSiteState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteSiteState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_site_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -27370,7 +27370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766776+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27395,7 +27395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766817+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27434,7 +27434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.766854+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447692+00:00"
               },
               "deterministic": true
             },
@@ -27447,7 +27447,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.738087+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788624+00:00"
           },
           "serial": {
             "type": "string",
@@ -27464,7 +27464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766898+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27504,7 +27504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.766966+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27570,7 +27570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767036+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27596,7 +27596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767089+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27622,7 +27622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767143+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27662,7 +27662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767216+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27687,7 +27687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767264+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27732,7 +27732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:25.767339+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27744,7 +27744,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.738224+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.788695+00:00"
           },
           "i_manufacturer": {
             "type": "string",
@@ -27761,7 +27761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767395+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27786,7 +27786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767445+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27812,7 +27812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767495+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27838,7 +27838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767547+00:00"
+                "validatedAt": "2026-05-09T01:38:21.447985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27863,7 +27863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767611+00:00"
+                "validatedAt": "2026-05-09T01:38:21.448006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27893,7 +27893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:25.767651+00:00"
+                "validatedAt": "2026-05-09T01:38:21.448025+00:00"
               },
               "deterministic": true
             },
@@ -27920,7 +27920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767707+00:00"
+                "validatedAt": "2026-05-09T01:38:21.448049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27946,7 +27946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767751+00:00"
+                "validatedAt": "2026-05-09T01:38:21.448067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27975,7 +27975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:25.767807+00:00"
+                "validatedAt": "2026-05-09T01:38:21.448091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28035,8 +28035,8 @@
           "description": "Minimum configuration for siteUsbType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteUsbType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteUsbType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_usb_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28062,8 +28062,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for usb_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for usb_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/usb_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -28135,7 +28135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:16.525982+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28208,7 +28208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:16.526027+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674309+00:00"
               },
               "deterministic": true
             },
@@ -28221,7 +28221,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.334655+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.424613+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28251,7 +28251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:16.526064+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674325+00:00"
               },
               "deterministic": true
             },
@@ -28264,7 +28264,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.334686+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.424628+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28367,7 +28367,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.334784+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.424680+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -28432,7 +28432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:16.526218+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28497,7 +28497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:27:16.526277+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28560,7 +28560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:16.526343+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28572,7 +28572,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.334871+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.424725+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -28638,7 +28638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:16.526394+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674467+00:00"
               },
               "deterministic": true
             },
@@ -28651,7 +28651,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.334940+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.424761+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28680,7 +28680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:16.526432+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674484+00:00"
               },
               "deterministic": true
             },
@@ -28693,7 +28693,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.334969+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.424776+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -28732,7 +28732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:16.526499+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28745,7 +28745,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.335026+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.424807+00:00"
           },
           "uid": {
             "type": "string",
@@ -28762,7 +28762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:16.526533+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28776,7 +28776,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.335056+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.424822+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of usb_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -28826,8 +28826,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for usb_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for usb_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/usb_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -28839,8 +28839,8 @@
           "description": "Minimum configuration for usb_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for usb_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for usb_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/usb_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -28884,7 +28884,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:16.526626+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28930,7 +28930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:16.526683+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28956,7 +28956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:16.526735+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28982,7 +28982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:16.526789+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29008,7 +29008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:16.526834+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29034,7 +29034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:16.526881+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29059,7 +29059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:16.526927+00:00"
+                "validatedAt": "2026-05-09T01:40:05.674692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29198,7 +29198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188240+00:00"
+                "validatedAt": "2026-05-09T01:40:09.464933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29221,7 +29221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188370+00:00"
+                "validatedAt": "2026-05-09T01:40:09.464965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29243,7 +29243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188449+00:00"
+                "validatedAt": "2026-05-09T01:40:09.464984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29255,7 +29255,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482219+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493226+00:00"
           },
           "name": {
             "type": "string",
@@ -29284,7 +29284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:25.188522+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465004+00:00"
               },
               "deterministic": true
             },
@@ -29297,7 +29297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482254+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493243+00:00"
           }
         },
         "x-f5xc-description-short": "ApplicationObj shows the upgrade status of each object in a application in either site/node level upgrades.",
@@ -29337,7 +29337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188612+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29349,7 +29349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482288+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493260+00:00"
           },
           "reason": {
             "type": "string",
@@ -29366,7 +29366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188666+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29378,7 +29378,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482317+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493275+00:00"
           },
           "status": {
             "$ref": "#/components/schemas/upgrade_statusChecklistStatus"
@@ -29416,8 +29416,8 @@
           "description": "Minimum configuration for upgrade_statusChecklistStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for upgrade_statusChecklistStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for upgrade_statusChecklistStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/upgrade_status_checklist_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -29440,7 +29440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188719+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29461,7 +29461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188763+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29483,7 +29483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188802+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29603,7 +29603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188900+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29650,7 +29650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.188950+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29687,7 +29687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:25.188993+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465188+00:00"
               },
               "deterministic": true
             },
@@ -29700,7 +29700,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482461+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493348+00:00"
           },
           "status": {
             "$ref": "#/components/schemas/upgrade_statusStatus"
@@ -29717,7 +29717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.189037+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29778,7 +29778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.189107+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29837,7 +29837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:25.189150+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465255+00:00"
               },
               "deterministic": true
             },
@@ -29850,7 +29850,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482546+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493392+00:00"
           },
           "progress": {
             "$ref": "#/components/schemas/upgrade_statusUpgradeProgressCount"
@@ -29921,7 +29921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:25.189212+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465280+00:00"
               },
               "deterministic": true
             },
@@ -29934,7 +29934,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482623+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493425+00:00"
           },
           "results": {
             "type": "array",
@@ -30001,7 +30001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.189298+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30083,7 +30083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.189373+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30115,7 +30115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.189429+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30137,7 +30137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.189469+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30168,7 +30168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.189526+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30180,7 +30180,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482806+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493519+00:00"
           }
         },
         "x-f5xc-description-short": "SWStatus stores information about CE Site upgrade status.",
@@ -30242,7 +30242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.189615+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30305,7 +30305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:25.189660+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465464+00:00"
               },
               "deterministic": true
             },
@@ -30318,7 +30318,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482880+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493558+00:00"
           },
           "objects": {
             "type": "array",
@@ -30401,7 +30401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:25.189734+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465494+00:00"
               },
               "deterministic": true
             },
@@ -30414,7 +30414,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.482942+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.493590+00:00"
           },
           "status": {
             "$ref": "#/components/schemas/upgrade_statusStatus"
@@ -30457,8 +30457,8 @@
           "description": "Minimum configuration for upgrade_statusStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for upgrade_statusStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for upgrade_statusStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/upgrade_status_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ce_management"
@@ -30542,7 +30542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:25.189838+00:00"
+                "validatedAt": "2026-05-09T01:40:09.465535+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/certificates.json
+++ b/docs/specifications/api/certificates.json
@@ -4717,8 +4717,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for crlCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for crlCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/crls\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -4811,7 +4811,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.498837+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4867,7 +4867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:11:14.498917+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832657+00:00"
               },
               "deterministic": true
             },
@@ -4945,7 +4945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.498964+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832679+00:00"
               },
               "deterministic": true
             },
@@ -4958,7 +4958,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184038+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480226+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4988,7 +4988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.499001+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832707+00:00"
               },
               "deterministic": true
             },
@@ -5001,7 +5001,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184071+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480242+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5104,7 +5104,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184173+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480295+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -5190,7 +5190,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.499199+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5246,7 +5246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:11:14.499265+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832827+00:00"
               },
               "deterministic": true
             },
@@ -5305,7 +5305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.499351+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832868+00:00"
               },
               "deterministic": true
             },
@@ -5371,7 +5371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:14.499406+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5433,7 +5433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:14.499474+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5445,7 +5445,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184315+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480368+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -5510,7 +5510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.499529+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832943+00:00"
               },
               "deterministic": true
             },
@@ -5523,7 +5523,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184386+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480405+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5552,7 +5552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.499564+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832960+00:00"
               },
               "deterministic": true
             },
@@ -5565,7 +5565,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184415+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480420+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -5604,7 +5604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.499648+00:00"
+                "validatedAt": "2026-05-09T01:32:54.832988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5617,7 +5617,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184473+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480451+00:00"
           },
           "uid": {
             "type": "string",
@@ -5634,7 +5634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.499683+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5648,7 +5648,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184505+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480467+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of CRL is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -5698,8 +5698,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for crlReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for crlReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/crl_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -5711,8 +5711,8 @@
           "description": "Minimum configuration for crlReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for crlReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for crlReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/crl_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -5777,7 +5777,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.499801+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5833,7 +5833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:11:14.499865+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833083+00:00"
               },
               "deterministic": true
             },
@@ -5934,7 +5934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.499948+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5957,7 +5957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.499990+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5969,7 +5969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184670+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480544+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -6015,7 +6015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:11:14.500034+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833161+00:00"
               },
               "deterministic": true
             },
@@ -6041,7 +6041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.500088+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6068,7 +6068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.500130+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6080,7 +6080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184723+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480571+00:00"
           },
           "service_name": {
             "type": "string",
@@ -6097,7 +6097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.500180+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6130,7 +6130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.500225+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6142,7 +6142,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184763+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480592+00:00"
           },
           "type": {
             "type": "string",
@@ -6167,7 +6167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.500266+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6221,8 +6221,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6255,7 +6255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.500317+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6317,7 +6317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.500355+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833301+00:00"
               },
               "deterministic": true
             },
@@ -6330,7 +6330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184837+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480631+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -6448,7 +6448,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.500476+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833356+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6464,7 +6464,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184904+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480665+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6534,7 +6534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.500524+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833378+00:00"
               },
               "deterministic": true
             },
@@ -6547,7 +6547,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184956+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480692+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6578,7 +6578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.500563+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833394+00:00"
               },
               "deterministic": true
             },
@@ -6591,7 +6591,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.184985+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480707+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -6673,7 +6673,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.500677+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833442+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6689,7 +6689,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185030+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480730+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6761,7 +6761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.500726+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833463+00:00"
               },
               "deterministic": true
             },
@@ -6774,7 +6774,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185082+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480757+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6805,7 +6805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.500762+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833480+00:00"
               },
               "deterministic": true
             },
@@ -6818,7 +6818,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185111+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480773+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -6863,7 +6863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.500801+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6876,7 +6876,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185143+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480790+00:00"
           },
           "name": {
             "type": "string",
@@ -6909,7 +6909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.500835+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833513+00:00"
               },
               "deterministic": true
             },
@@ -6922,7 +6922,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185173+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480805+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6953,7 +6953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.500872+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833531+00:00"
               },
               "deterministic": true
             },
@@ -6966,7 +6966,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185202+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480821+00:00"
           },
           "tenant": {
             "type": "string",
@@ -6985,7 +6985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.500914+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6999,7 +6999,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185232+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480837+00:00"
           },
           "uid": {
             "type": "string",
@@ -7018,7 +7018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.500946+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7033,7 +7033,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185262+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480853+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -7115,7 +7115,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.501043+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833609+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7131,7 +7131,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185306+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480875+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7201,7 +7201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.501092+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833629+00:00"
               },
               "deterministic": true
             },
@@ -7214,7 +7214,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185356+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480904+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7245,7 +7245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.501129+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833645+00:00"
               },
               "deterministic": true
             },
@@ -7258,7 +7258,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185386+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480921+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -7303,7 +7303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501183+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7331,7 +7331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501233+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7359,7 +7359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501282+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7388,7 +7388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501332+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7415,7 +7415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501366+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7429,7 +7429,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185466+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.480967+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -7445,7 +7445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501410+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7508,8 +7508,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7554,7 +7554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501469+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7566,7 +7566,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185527+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.481007+00:00"
           },
           "status": {
             "type": "string",
@@ -7584,7 +7584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501512+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7596,7 +7596,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185556+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.481025+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7638,7 +7638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501566+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7665,7 +7665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501630+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7692,7 +7692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501677+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7720,7 +7720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501731+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7785,7 +7785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501810+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7834,7 +7834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501872+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7847,7 +7847,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185697+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.481094+00:00"
           },
           "uid": {
             "type": "string",
@@ -7866,7 +7866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501905+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7880,7 +7880,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185727+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.481110+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -7930,7 +7930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.501944+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7942,7 +7942,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185759+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.481127+00:00"
           },
           "name": {
             "type": "string",
@@ -7975,7 +7975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.501980+00:00"
+                "validatedAt": "2026-05-09T01:32:54.833999+00:00"
               },
               "deterministic": true
             },
@@ -7988,7 +7988,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185788+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.481142+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8019,7 +8019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:14.502016+00:00"
+                "validatedAt": "2026-05-09T01:32:54.834016+00:00"
               },
               "deterministic": true
             },
@@ -8032,7 +8032,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185817+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.481162+00:00"
           },
           "uid": {
             "type": "string",
@@ -8049,7 +8049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:14.502049+00:00"
+                "validatedAt": "2026-05-09T01:32:54.834029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8063,7 +8063,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.185847+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.481178+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -8185,7 +8185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.039292+00:00"
+                "validatedAt": "2026-05-09T01:33:03.887829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8275,7 +8275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.039374+00:00"
+                "validatedAt": "2026-05-09T01:33:03.887866+00:00"
               },
               "deterministic": true
             },
@@ -8288,7 +8288,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.661413+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709104+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8318,7 +8318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.039416+00:00"
+                "validatedAt": "2026-05-09T01:33:03.887885+00:00"
               },
               "deterministic": true
             },
@@ -8331,7 +8331,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.661446+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709121+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8434,7 +8434,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.661547+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709190+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8507,7 +8507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.039623+00:00"
+                "validatedAt": "2026-05-09T01:33:03.887973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8633,7 +8633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:35.039744+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8696,7 +8696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:35.039819+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8708,7 +8708,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.661729+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709276+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8774,7 +8774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.039873+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888077+00:00"
               },
               "deterministic": true
             },
@@ -8787,7 +8787,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.661799+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709313+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8816,7 +8816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.039909+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888094+00:00"
               },
               "deterministic": true
             },
@@ -8829,7 +8829,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.661829+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709329+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8868,7 +8868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.039977+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8881,7 +8881,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.661886+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709360+00:00"
           },
           "uid": {
             "type": "string",
@@ -8898,7 +8898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040012+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8912,7 +8912,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.661917+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709376+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of certificate is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -8976,8 +8976,8 @@
           "description": "Minimum configuration for certificateReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for certificateReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for certificateReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/certificate_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -9029,7 +9029,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.040116+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9136,8 +9136,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9166,7 +9166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040210+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9179,7 +9179,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.662063+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709452+00:00"
           },
           "name": {
             "type": "string",
@@ -9212,7 +9212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.040247+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888248+00:00"
               },
               "deterministic": true
             },
@@ -9225,7 +9225,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.662093+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709469+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9256,7 +9256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.040283+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888265+00:00"
               },
               "deterministic": true
             },
@@ -9269,7 +9269,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.662122+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709484+00:00"
           },
           "tenant": {
             "type": "string",
@@ -9288,7 +9288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040328+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9302,7 +9302,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.662151+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709500+00:00"
           },
           "uid": {
             "type": "string",
@@ -9321,7 +9321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040363+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9336,7 +9336,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.662181+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709517+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -9382,7 +9382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040512+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9420,7 +9420,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.040602+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9432,7 +9432,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.662266+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709562+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -9451,7 +9451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040656+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9498,7 +9498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040707+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9523,7 +9523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040751+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9546,7 +9546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040794+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9569,7 +9569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040845+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9593,7 +9593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040903+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9663,7 +9663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:35.040969+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9675,7 +9675,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.662369+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.709615+00:00"
           },
           "url": {
             "type": "string",
@@ -9713,7 +9713,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.041046+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888592+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -9760,8 +9760,8 @@
           "description": "Minimum configuration for schemaHashAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_hash_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9807,7 +9807,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.041446+00:00"
+                "validatedAt": "2026-05-09T01:33:03.888768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9846,8 +9846,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9879,7 +9879,10 @@
           "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {\n    \"blindfold_secret_info\": \"value\",\n    \"clear_secret_info\": \"value\"\n  }\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
-        "x-f5xc-cli-domain": "other"
+        "x-f5xc-cli-domain": "other",
+        "x-f5xc-recommended-oneof-variant": {
+          "secret_info_oneof": "clear_secret_info"
+        }
       },
       "schemaviewsObjectRefType": {
         "type": "object",
@@ -9931,7 +9934,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.043086+00:00"
+                "validatedAt": "2026-05-09T01:33:03.889526+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -9947,7 +9950,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.663458+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.710193+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9984,7 +9987,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.043152+00:00"
+                "validatedAt": "2026-05-09T01:33:03.889558+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -10000,7 +10003,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.663487+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.710209+00:00"
           },
           "tenant": {
             "type": "string",
@@ -10029,7 +10032,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:35.043225+00:00"
+                "validatedAt": "2026-05-09T01:33:03.889601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10043,7 +10046,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.663516+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.710225+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -10161,7 +10164,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:39.148082+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10240,7 +10243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:39.148146+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700728+00:00"
               },
               "deterministic": true
             },
@@ -10253,7 +10256,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.717066+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.735026+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10283,7 +10286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:39.148187+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700747+00:00"
               },
               "deterministic": true
             },
@@ -10296,7 +10299,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.717098+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.735042+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -10399,7 +10402,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.717198+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.735095+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -10468,7 +10471,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:39.148375+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10553,7 +10556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:39.148448+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10616,7 +10619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:39.148520+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10628,7 +10631,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.717295+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.735146+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10694,7 +10697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:39.148573+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700913+00:00"
               },
               "deterministic": true
             },
@@ -10707,7 +10710,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.717364+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.735195+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10736,7 +10739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:39.148632+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700930+00:00"
               },
               "deterministic": true
             },
@@ -10749,7 +10752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.717393+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.735211+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10788,7 +10791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:39.148701+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10801,7 +10804,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.717450+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.735242+00:00"
           },
           "uid": {
             "type": "string",
@@ -10819,7 +10822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:39.148737+00:00"
+                "validatedAt": "2026-05-09T01:33:05.700974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10833,7 +10836,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.717481+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.735258+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of certificate_chain is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -10897,8 +10900,8 @@
           "description": "Minimum configuration for certificate_chainReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for certificate_chainReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for certificate_chainReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/certificate_chain_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -11005,8 +11008,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for trusted_ca_listCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for trusted_ca_listCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/trusted_ca_lists\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -11070,7 +11073,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:15.452262+00:00"
+                "validatedAt": "2026-05-09T01:38:16.865987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11144,7 +11147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:15.452302+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866006+00:00"
               },
               "deterministic": true
             },
@@ -11157,7 +11160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.525483+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.688405+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11187,7 +11190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:15.452338+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866022+00:00"
               },
               "deterministic": true
             },
@@ -11200,7 +11203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.525511+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.688420+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -11303,7 +11306,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.525622+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.688472+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -11375,7 +11378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:15.452517+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11442,7 +11445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:15.452571+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11505,7 +11508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:15.452653+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11517,7 +11520,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.525755+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.688522+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -11583,7 +11586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:15.452704+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866179+00:00"
               },
               "deterministic": true
             },
@@ -11596,7 +11599,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.525831+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.688559+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11625,7 +11628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:15.452739+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866195+00:00"
               },
               "deterministic": true
             },
@@ -11638,7 +11641,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.525860+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.688575+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -11677,7 +11680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:15.452809+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11690,7 +11693,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.525917+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.688605+00:00"
           },
           "uid": {
             "type": "string",
@@ -11707,7 +11710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:15.452842+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11721,7 +11724,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.525947+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.688621+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of trusted_ca_list is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11771,8 +11774,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for trusted_ca_listReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for trusted_ca_listReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/trusted_ca_list_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -11784,8 +11787,8 @@
           "description": "Minimum configuration for trusted_ca_listReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for trusted_ca_listReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for trusted_ca_listReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/trusted_ca_list_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -11821,7 +11824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:15.452935+00:00"
+                "validatedAt": "2026-05-09T01:38:16.866277+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/cloud_infrastructure.json
+++ b/docs/specifications/api/cloud_infrastructure.json
@@ -7990,7 +7990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.195764+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8015,7 +8015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.195829+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8084,7 +8084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.195891+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8129,7 +8129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.195949+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8236,7 +8236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.196049+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493735+00:00"
               },
               "deterministic": true
             },
@@ -8249,7 +8249,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758650+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/certified_hardwareHardwareDeviceType"
@@ -8317,7 +8317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196114+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8421,7 +8421,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768401+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758714+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8472,8 +8472,8 @@
           "description": "Minimum configuration for certified_hardwareHardwareDeviceInstanceUseType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for certified_hardwareHardwareDeviceInstanceUseType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for certified_hardwareHardwareDeviceInstanceUseType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/certified_hardware_hardware_device_instance_use_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -8500,8 +8500,8 @@
           "description": "Minimum configuration for certified_hardwareHardwareDeviceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for certified_hardwareHardwareDeviceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for certified_hardwareHardwareDeviceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/certified_hardware_hardware_device_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -8523,8 +8523,8 @@
           "description": "Minimum configuration for certified_hardwareHardwareType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for certified_hardwareHardwareType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for certified_hardwareHardwareType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/certified_hardware_hardware_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -8550,7 +8550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196243+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8574,7 +8574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196288+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8645,7 +8645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.196339+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493854+00:00"
               },
               "deterministic": true
             },
@@ -8658,7 +8658,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768497+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758765+00:00"
           },
           "provider": {
             "type": "string",
@@ -8676,7 +8676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196385+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8688,7 +8688,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768527+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758780+00:00"
           }
         },
         "x-f5xc-description-short": "Describes the image to be used for this certified hardware.",
@@ -8750,7 +8750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:43.196442+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8813,7 +8813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:43.196511+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8825,7 +8825,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768609+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758815+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8891,7 +8891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.196564+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493951+00:00"
               },
               "deterministic": true
             },
@@ -8904,7 +8904,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768681+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758852+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8933,7 +8933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.196619+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493969+00:00"
               },
               "deterministic": true
             },
@@ -8946,7 +8946,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768710+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758867+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8985,7 +8985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196688+00:00"
+                "validatedAt": "2026-05-09T01:33:07.493995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8998,7 +8998,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768767+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758898+00:00"
           },
           "uid": {
             "type": "string",
@@ -9016,7 +9016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196721+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9030,7 +9030,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768798+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758914+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of certified_hardware is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9094,7 +9094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.196759+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494028+00:00"
               },
               "deterministic": true
             },
@@ -9107,7 +9107,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768831+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758931+00:00"
           },
           "offer": {
             "type": "string",
@@ -9122,7 +9122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196802+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9145,7 +9145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196850+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9168,7 +9168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196885+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9192,7 +9192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.196930+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9204,7 +9204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768890+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.758963+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9242,8 +9242,8 @@
           "description": "Minimum configuration for certified_hardwareMemPageSize",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for certified_hardwareMemPageSize\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for certified_hardwareMemPageSize\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/certified_hardware_mem_page_sizes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -9386,7 +9386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197040+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9399,7 +9399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.768985+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759013+00:00"
           },
           "name": {
             "type": "string",
@@ -9432,7 +9432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.197077+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494180+00:00"
               },
               "deterministic": true
             },
@@ -9445,7 +9445,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769015+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759029+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9476,7 +9476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.197113+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494197+00:00"
               },
               "deterministic": true
             },
@@ -9489,7 +9489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769044+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759045+00:00"
           },
           "tenant": {
             "type": "string",
@@ -9508,7 +9508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197156+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9522,7 +9522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769073+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759061+00:00"
           },
           "uid": {
             "type": "string",
@@ -9541,7 +9541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197190+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9556,7 +9556,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769103+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759076+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -9594,7 +9594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197237+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9617,7 +9617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197279+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9629,7 +9629,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769146+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759099+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -9675,7 +9675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:11:43.197322+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494298+00:00"
               },
               "deterministic": true
             },
@@ -9701,7 +9701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197375+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9728,7 +9728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197418+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9740,7 +9740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769196+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759127+00:00"
           },
           "service_name": {
             "type": "string",
@@ -9757,7 +9757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197467+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9790,7 +9790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197516+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9802,7 +9802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769235+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759150+00:00"
           },
           "type": {
             "type": "string",
@@ -9827,7 +9827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197560+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9881,8 +9881,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9915,7 +9915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197627+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9977,7 +9977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.197667+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494444+00:00"
               },
               "deterministic": true
             },
@@ -9990,7 +9990,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769308+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759194+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -10109,7 +10109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.197794+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494500+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10125,7 +10125,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769373+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759228+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -10197,7 +10197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.197844+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494523+00:00"
               },
               "deterministic": true
             },
@@ -10210,7 +10210,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769424+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759255+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10241,7 +10241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.197879+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494539+00:00"
               },
               "deterministic": true
             },
@@ -10254,7 +10254,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769453+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759272+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -10299,7 +10299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197935+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10327,7 +10327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.197986+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10355,7 +10355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198036+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10384,7 +10384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198085+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10411,7 +10411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198118+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10425,7 +10425,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769533+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759314+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -10441,7 +10441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198162+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10504,8 +10504,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10550,7 +10550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198223+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10562,7 +10562,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769615+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759347+00:00"
           },
           "status": {
             "type": "string",
@@ -10580,7 +10580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198266+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10592,7 +10592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769645+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759363+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -10634,7 +10634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198323+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10661,7 +10661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198373+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10688,7 +10688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198421+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10716,7 +10716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198474+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10781,7 +10781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198552+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10830,7 +10830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198630+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10843,7 +10843,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769773+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759432+00:00"
           },
           "uid": {
             "type": "string",
@@ -10862,7 +10862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198666+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10876,7 +10876,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769804+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759447+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -10926,7 +10926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198706+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10938,7 +10938,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769835+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759464+00:00"
           },
           "name": {
             "type": "string",
@@ -10971,7 +10971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.198742+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494897+00:00"
               },
               "deterministic": true
             },
@@ -10984,7 +10984,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769863+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759480+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11015,7 +11015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:43.198778+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494913+00:00"
               },
               "deterministic": true
             },
@@ -11028,7 +11028,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769892+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759495+00:00"
           },
           "uid": {
             "type": "string",
@@ -11045,7 +11045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198810+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11059,7 +11059,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.769921+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.759511+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -11242,7 +11242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.198985+00:00"
+                "validatedAt": "2026-05-09T01:33:07.494999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11268,7 +11268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.199037+00:00"
+                "validatedAt": "2026-05-09T01:33:07.495021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11294,7 +11294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.199091+00:00"
+                "validatedAt": "2026-05-09T01:33:07.495043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11320,7 +11320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.199135+00:00"
+                "validatedAt": "2026-05-09T01:33:07.495062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11346,7 +11346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.199182+00:00"
+                "validatedAt": "2026-05-09T01:33:07.495082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11371,7 +11371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:43.199228+00:00"
+                "validatedAt": "2026-05-09T01:33:07.495101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11444,7 +11444,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.249532+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11478,7 +11478,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.249623+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11523,7 +11523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.249692+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11548,7 +11548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.249747+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11573,7 +11573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.249800+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11598,7 +11598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.249855+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11663,7 +11663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.249936+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11688,7 +11688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.249991+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11711,7 +11711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250037+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11737,7 +11737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250086+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11762,7 +11762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250132+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11785,7 +11785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250184+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11842,7 +11842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250245+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11867,7 +11867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250298+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11895,7 +11895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250356+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11933,7 +11933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250415+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11979,7 +11979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250476+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12002,7 +12002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250539+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12027,7 +12027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250615+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12050,7 +12050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250669+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12074,7 +12074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250727+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12129,7 +12129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250785+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12156,7 +12156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250841+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12182,7 +12182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.250895+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12220,7 +12220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.250937+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766838+00:00"
               },
               "deterministic": true
             },
@@ -12233,7 +12233,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.653060+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177058+00:00"
           },
           "tags": {
             "type": "object",
@@ -12312,7 +12312,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.251011+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12376,7 +12376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.251081+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12431,7 +12431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.251187+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12479,7 +12479,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.251251+00:00"
+                "validatedAt": "2026-05-09T01:33:24.766990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12523,7 +12523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.251305+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12549,7 +12549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.251360+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12574,7 +12574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:12:22.251412+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12598,7 +12598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.251465+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12666,7 +12666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.251543+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12730,7 +12730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.251637+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12754,7 +12754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.251702+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12779,7 +12779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.251767+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12886,7 +12886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.251857+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12970,7 +12970,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.251965+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13055,7 +13055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252040+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13078,7 +13078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252098+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13102,7 +13102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252154+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13125,7 +13125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252213+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13151,7 +13151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252269+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13174,7 +13174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252324+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13197,7 +13197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252379+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13220,7 +13220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252436+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13244,7 +13244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252493+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13307,7 +13307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252569+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13331,7 +13331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.252635+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13428,7 +13428,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.252754+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13476,7 +13476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.252821+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13541,7 +13541,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.252886+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13600,7 +13600,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.252948+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13680,7 +13680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.253050+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13716,7 +13716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.253122+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13801,7 +13801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.253193+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13844,7 +13844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.253249+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13867,7 +13867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.253303+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13891,7 +13891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.253351+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13941,7 +13941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:12:22.253398+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767929+00:00"
               },
               "deterministic": true
             },
@@ -14053,8 +14053,8 @@
           "description": "Minimum configuration for cloud_connectCloudConnectProviderType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectCloudConnectProviderType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectCloudConnectProviderType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connect_cloud_connect_provider_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -14077,8 +14077,8 @@
           "description": "Minimum configuration for cloud_connectCloudConnectState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectCloudConnectState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectCloudConnectState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connect_cloud_connect_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -14132,8 +14132,8 @@
           "description": "Minimum configuration for cloud_connectCloudConnectVPCStateType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectCloudConnectVPCStateType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectCloudConnectVPCStateType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connect_cloud_connect_v_p_c_state_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -14224,8 +14224,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connects\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -14354,7 +14354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.253547+00:00"
+                "validatedAt": "2026-05-09T01:33:24.767991+00:00"
               },
               "deterministic": true
             },
@@ -14367,7 +14367,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.653945+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177507+00:00"
           }
         },
         "x-f5xc-description-short": "Customer Edge uniquely identifies customer edge i.e. Site.",
@@ -14461,7 +14461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.253610+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768012+00:00"
               },
               "deterministic": true
             },
@@ -14474,7 +14474,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654011+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177540+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14504,7 +14504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.253647+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768028+00:00"
               },
               "deterministic": true
             },
@@ -14517,7 +14517,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654041+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177556+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14564,7 +14564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.253705+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14654,7 +14654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.253779+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14677,7 +14677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.253821+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14702,7 +14702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.253868+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14835,7 +14835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.253959+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14902,7 +14902,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654271+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177675+00:00"
           }
         },
         "x-f5xc-description-short": "Field Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -14940,8 +14940,8 @@
           "description": "Minimum configuration for cloud_connectFieldSelector",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectFieldSelector\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectFieldSelector\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connect_field_selectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -14976,7 +14976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.254030+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15012,7 +15012,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.254089+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15073,7 +15073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.254134+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768255+00:00"
               },
               "deterministic": true
             },
@@ -15086,7 +15086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654335+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177707+00:00"
           },
           "start_time": {
             "type": "string",
@@ -15111,7 +15111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.254186+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15144,7 +15144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.254227+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15219,7 +15219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.254283+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15329,7 +15329,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654475+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177780+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -15383,7 +15383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.254415+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15395,7 +15395,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654535+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177811+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the cloud connect are tagged with labels listed in the enum Label.",
@@ -15444,7 +15444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.254464+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15480,7 +15480,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.254524+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15515,7 +15515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.254600+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15548,7 +15548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.254654+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15621,7 +15621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.254714+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15689,7 +15689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:12:22.254769+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15752,7 +15752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:12:22.254834+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15764,7 +15764,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654679+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177878+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15830,7 +15830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.254885+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768576+00:00"
               },
               "deterministic": true
             },
@@ -15843,7 +15843,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654748+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177915+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15872,7 +15872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.254920+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768593+00:00"
               },
               "deterministic": true
             },
@@ -15885,7 +15885,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654778+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177931+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -15924,7 +15924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.254985+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15937,7 +15937,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654836+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177961+00:00"
           },
           "uid": {
             "type": "string",
@@ -15954,7 +15954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255018+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15968,7 +15968,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.654867+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.177977+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_connect is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -16027,7 +16027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255068+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16063,7 +16063,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.255128+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16113,7 +16113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.255198+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16146,7 +16146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255250+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16179,7 +16179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255290+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16267,7 +16267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255360+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16360,7 +16360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255439+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16388,7 +16388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255487+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16411,7 +16411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255537+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16464,7 +16464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255605+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16502,8 +16502,8 @@
           "description": "Minimum configuration for cloud_connectReApplyVPCAttachmentResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectReApplyVPCAttachmentResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectReApplyVPCAttachmentResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connect_re_apply_v_p_c_attachment_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -16575,8 +16575,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connect_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -16588,8 +16588,8 @@
           "description": "Minimum configuration for cloud_connectReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connect_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -16655,8 +16655,8 @@
           "description": "Minimum configuration for cloud_connectStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connect_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -16742,7 +16742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255736+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16765,7 +16765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255788+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16788,7 +16788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255844+00:00"
+                "validatedAt": "2026-05-09T01:33:24.768980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16812,7 +16812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255900+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16836,7 +16836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255944+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16848,7 +16848,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.655241+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178175+00:00"
           },
           "subnet_id": {
             "type": "string",
@@ -16863,7 +16863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.255991+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16962,7 +16962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.256060+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16998,7 +16998,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.256119+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17025,7 +17025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.256163+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17064,7 +17064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:12:22.256212+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17097,7 +17097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.256262+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17170,7 +17170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.256317+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17213,8 +17213,8 @@
           "description": "Minimum configuration for cloud_connectTrafficType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_connectTrafficType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_connectTrafficType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_connect_traffic_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -17257,7 +17257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.256360+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769210+00:00"
               },
               "deterministic": true
             },
@@ -17270,7 +17270,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.655390+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178251+00:00"
           },
           "site": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -17300,8 +17300,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -17367,7 +17367,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.257132+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17421,7 +17421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.257203+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17461,8 +17461,8 @@
           "description": "Minimum configuration for schemaMetricLabelOp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaMetricLabelOp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaMetricLabelOp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_metric_label_ops\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "label"
@@ -17507,7 +17507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.257270+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17519,7 +17519,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.655899+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178506+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -17597,7 +17597,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.257374+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769655+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17613,7 +17613,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.655944+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178529+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17683,7 +17683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.257428+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769678+00:00"
               },
               "deterministic": true
             },
@@ -17696,7 +17696,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.655996+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178556+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17727,7 +17727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.257465+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769694+00:00"
               },
               "deterministic": true
             },
@@ -17740,7 +17740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.656026+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178571+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -17822,7 +17822,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.257767+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769826+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17838,7 +17838,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.656196+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178658+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17908,7 +17908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.257816+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769847+00:00"
               },
               "deterministic": true
             },
@@ -17921,7 +17921,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.656252+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178684+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17952,7 +17952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.257851+00:00"
+                "validatedAt": "2026-05-09T01:33:24.769864+00:00"
               },
               "deterministic": true
             },
@@ -17965,7 +17965,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.656282+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178699+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -18003,8 +18003,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18036,7 +18036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:12:22.258744+00:00"
+                "validatedAt": "2026-05-09T01:33:24.770244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18048,7 +18048,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.656667+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178892+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -18066,7 +18066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.258795+00:00"
+                "validatedAt": "2026-05-09T01:33:24.770266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18094,7 +18094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:22.258841+00:00"
+                "validatedAt": "2026-05-09T01:33:24.770286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18106,7 +18106,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.656716+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.178917+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -18167,8 +18167,8 @@
           "description": "Minimum configuration for schemaUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18261,8 +18261,8 @@
           "description": "Minimum configuration for schemacloud_connectLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemacloud_connectLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemacloud_connectLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemacloud_connect_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -18346,7 +18346,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.259102+00:00"
+                "validatedAt": "2026-05-09T01:33:24.770404+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18362,7 +18362,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.656963+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.179056+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18399,7 +18399,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.259169+00:00"
+                "validatedAt": "2026-05-09T01:33:24.770436+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18415,7 +18415,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.656993+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.179071+00:00"
           },
           "tenant": {
             "type": "string",
@@ -18444,7 +18444,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:22.259243+00:00"
+                "validatedAt": "2026-05-09T01:33:24.770470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18458,7 +18458,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.657022+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.179087+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -18560,7 +18560,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.839183+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18638,7 +18638,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.839407+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18682,7 +18682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.839511+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18771,7 +18771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.839619+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18837,7 +18837,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.839713+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18873,7 +18873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.839793+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18913,7 +18913,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.839877+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18950,7 +18950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.839950+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19013,7 +19013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.840026+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19053,7 +19053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.840111+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19090,7 +19090,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.840185+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19138,8 +19138,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_credentialsCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_credentialsCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_credentialses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -19262,7 +19262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.840270+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810880+00:00"
               },
               "deterministic": true
             },
@@ -19275,7 +19275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774259+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.236632+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19305,7 +19305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.840308+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810898+00:00"
               },
               "deterministic": true
             },
@@ -19318,7 +19318,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774292+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.236649+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19444,7 +19444,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774404+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.236708+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19552,7 +19552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:12:26.840473+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19615,7 +19615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:12:26.840539+00:00"
+                "validatedAt": "2026-05-09T01:33:26.810995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19627,7 +19627,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774529+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.236780+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -19693,7 +19693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.840622+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811018+00:00"
               },
               "deterministic": true
             },
@@ -19706,7 +19706,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774613+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.236817+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19735,7 +19735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.840663+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811035+00:00"
               },
               "deterministic": true
             },
@@ -19748,7 +19748,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774643+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.236833+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -19787,7 +19787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:26.840732+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19800,7 +19800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774701+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.236863+00:00"
           },
           "uid": {
             "type": "string",
@@ -19818,7 +19818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:26.840765+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19832,7 +19832,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774732+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.236879+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_credentials is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19882,8 +19882,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_credentialsReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_credentialsReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_credentials_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -19895,8 +19895,8 @@
           "description": "Minimum configuration for cloud_credentialsReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_credentialsReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_credentialsReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_credentials_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -20023,7 +20023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:26.840976+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20061,7 +20061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.841051+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20073,7 +20073,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774922+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.236982+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -20092,7 +20092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:26.841104+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20143,7 +20143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:26.841149+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20155,7 +20155,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.774965+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.237004+00:00"
           },
           "url": {
             "type": "string",
@@ -20193,7 +20193,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.841227+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811286+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -20246,7 +20246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:26.842032+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20259,7 +20259,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.775436+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.237259+00:00"
           },
           "name": {
             "type": "string",
@@ -20292,7 +20292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.842069+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811651+00:00"
               },
               "deterministic": true
             },
@@ -20305,7 +20305,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.775465+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.237275+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20336,7 +20336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:26.842105+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811667+00:00"
               },
               "deterministic": true
             },
@@ -20349,7 +20349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.775494+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.237296+00:00"
           },
           "tenant": {
             "type": "string",
@@ -20368,7 +20368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:26.842147+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20382,7 +20382,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.775523+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.237313+00:00"
           },
           "uid": {
             "type": "string",
@@ -20401,7 +20401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:26.842180+00:00"
+                "validatedAt": "2026-05-09T01:33:26.811699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20416,7 +20416,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.775554+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.237329+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -20452,8 +20452,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20508,8 +20508,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_elastic_ipCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_elastic_ipCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_elastic_ips\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -20574,7 +20574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:12:31.324730+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20610,7 +20610,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:31.324808+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20685,7 +20685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:31.324861+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791579+00:00"
               },
               "deterministic": true
             },
@@ -20698,7 +20698,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855442+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.275937+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20728,7 +20728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:31.324900+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791597+00:00"
               },
               "deterministic": true
             },
@@ -20741,7 +20741,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855475+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.275953+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20781,7 +20781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:31.324937+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20804,7 +20804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:31.324995+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20827,7 +20827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:31.325042+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20839,7 +20839,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855530+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.275981+00:00"
           },
           "public_ip_address": {
             "type": "string",
@@ -20854,7 +20854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:31.325095+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20931,7 +20931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:31.325155+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791707+00:00"
               },
               "deterministic": true
             },
@@ -20944,7 +20944,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855595+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.276008+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20997,7 +20997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:31.325193+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791725+00:00"
               },
               "deterministic": true
             },
@@ -21010,7 +21010,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855629+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.276025+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21035,8 +21035,8 @@
           "description": "Minimum configuration for cloud_elastic_ipForceDeleteCloudElasticIPResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_elastic_ipForceDeleteCloudElasticIPResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_elastic_ipForceDeleteCloudElasticIPResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_elastic_ip_forces\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -21127,7 +21127,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855730+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.276078+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -21185,7 +21185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:12:31.325328+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21221,7 +21221,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:31.325393+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21288,7 +21288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:12:31.325447+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21351,7 +21351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:12:31.325515+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21363,7 +21363,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855827+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.276128+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21429,7 +21429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:31.325567+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791887+00:00"
               },
               "deterministic": true
             },
@@ -21442,7 +21442,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855897+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.276170+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21471,7 +21471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:31.325620+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791904+00:00"
               },
               "deterministic": true
             },
@@ -21484,7 +21484,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855926+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.276186+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21523,7 +21523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:31.325688+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21536,7 +21536,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.855983+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.276217+00:00"
           },
           "uid": {
             "type": "string",
@@ -21554,7 +21554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:31.325723+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21568,7 +21568,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.856013+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.276233+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_elastic_ip is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21618,8 +21618,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_elastic_ipReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_elastic_ipReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_elastic_ip_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -21631,8 +21631,8 @@
           "description": "Minimum configuration for cloud_elastic_ipReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_elastic_ipReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_elastic_ipReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_elastic_ip_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -21669,7 +21669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:12:31.325780+00:00"
+                "validatedAt": "2026-05-09T01:33:28.791972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21705,7 +21705,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:31.325840+00:00"
+                "validatedAt": "2026-05-09T01:33:28.792001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21859,7 +21859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.064332+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21882,7 +21882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.064385+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21922,7 +21922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.064459+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21946,7 +21946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.064514+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21970,7 +21970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.064557+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21982,7 +21982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.924019+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.307738+00:00"
           },
           "tags": {
             "type": "object",
@@ -22010,7 +22010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.064638+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22063,7 +22063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.064998+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22087,7 +22087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:12:36.065041+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22126,7 +22126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.065087+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22149,7 +22149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.065137+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22172,7 +22172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.065182+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22195,7 +22195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.065224+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22218,7 +22218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:36.065273+00:00"
+                "validatedAt": "2026-05-09T01:33:30.899424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22393,7 +22393,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.009222+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.350065+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22488,7 +22488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:12:38.300264+00:00"
+                "validatedAt": "2026-05-09T01:33:31.913579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22551,7 +22551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:12:38.300345+00:00"
+                "validatedAt": "2026-05-09T01:33:31.913615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22563,7 +22563,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.009325+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.350117+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22629,7 +22629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:38.300401+00:00"
+                "validatedAt": "2026-05-09T01:33:31.913640+00:00"
               },
               "deterministic": true
             },
@@ -22642,7 +22642,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.009396+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.350159+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22671,7 +22671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:38.300439+00:00"
+                "validatedAt": "2026-05-09T01:33:31.913659+00:00"
               },
               "deterministic": true
             },
@@ -22684,7 +22684,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.009426+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.350175+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -22723,7 +22723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:38.300510+00:00"
+                "validatedAt": "2026-05-09T01:33:31.913687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22736,7 +22736,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.009484+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.350206+00:00"
           },
           "uid": {
             "type": "string",
@@ -22753,7 +22753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:38.300546+00:00"
+                "validatedAt": "2026-05-09T01:33:31.913703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22767,7 +22767,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.009515+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.350222+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_region is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22817,8 +22817,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_regionReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_regionReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_region_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -22830,8 +22830,8 @@
           "description": "Minimum configuration for cloud_regionReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_regionReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_regionReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_region_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -22960,7 +22960,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.246752+00:00"
+                "validatedAt": "2026-05-09T01:33:34.111808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23052,7 +23052,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.246906+00:00"
+                "validatedAt": "2026-05-09T01:33:34.111876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23094,7 +23094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.246964+00:00"
+                "validatedAt": "2026-05-09T01:33:34.111900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23159,7 +23159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.247061+00:00"
+                "validatedAt": "2026-05-09T01:33:34.111944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23271,7 +23271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247161+00:00"
+                "validatedAt": "2026-05-09T01:33:34.111985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23296,7 +23296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247214+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23387,8 +23387,8 @@
           "description": "Minimum configuration for cloud_linkAzureStatusType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_linkAzureStatusType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_linkAzureStatusType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_link_azure_status_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -23420,7 +23420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247300+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23457,7 +23457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247360+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23487,7 +23487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247415+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23516,7 +23516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247465+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23540,7 +23540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247521+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23564,7 +23564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247572+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23614,8 +23614,8 @@
           "description": "Minimum configuration for cloud_linkCloudLinkDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_linkCloudLinkDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_linkCloudLinkDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_link_cloud_link_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -23641,8 +23641,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_linkCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_linkCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_links\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -23725,7 +23725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.247658+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112201+00:00"
               },
               "deterministic": true
             },
@@ -23738,7 +23738,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.124473+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.399504+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23768,7 +23768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.247698+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112219+00:00"
               },
               "deterministic": true
             },
@@ -23781,7 +23781,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.124506+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.399520+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23819,7 +23819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247745+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23842,7 +23842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247791+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23866,7 +23866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247842+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23891,7 +23891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247894+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23921,7 +23921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.247949+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23954,7 +23954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248011+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23991,7 +23991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248060+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24003,7 +24003,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.124636+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.399578+00:00"
           },
           "owner_account": {
             "type": "string",
@@ -24019,7 +24019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248111+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24044,7 +24044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248160+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24069,7 +24069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248209+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24093,7 +24093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248251+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24190,7 +24190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248323+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24214,7 +24214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248367+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24237,7 +24237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248424+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24262,7 +24262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248483+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24292,7 +24292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248545+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24316,7 +24316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248610+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24340,7 +24340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248664+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24410,7 +24410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.248732+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24470,7 +24470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.248829+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24508,7 +24508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.248910+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24545,7 +24545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.248955+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24616,7 +24616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249022+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24640,7 +24640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249074+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24664,7 +24664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249120+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24704,7 +24704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249186+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24728,7 +24728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249238+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24773,7 +24773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249307+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24797,7 +24797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249350+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24821,7 +24821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249399+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24895,7 +24895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.249457+00:00"
+                "validatedAt": "2026-05-09T01:33:34.112982+00:00"
               },
               "deterministic": true
             },
@@ -24908,7 +24908,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.124996+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.399767+00:00"
           },
           "operational_status": {
             "type": "string",
@@ -24924,7 +24924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249510+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24965,7 +24965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249572+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24990,7 +24990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249636+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25014,7 +25014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249679+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25038,7 +25038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249726+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25071,7 +25071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249767+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25118,7 +25118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249832+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25187,7 +25187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249882+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25226,7 +25226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.249920+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113183+00:00"
               },
               "deterministic": true
             },
@@ -25239,7 +25239,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.125134+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.399841+00:00"
           },
           "portal_url": {
             "type": "string",
@@ -25256,7 +25256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.249967+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25437,7 +25437,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.125282+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.399927+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -25499,7 +25499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250140+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25538,7 +25538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250197+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25605,7 +25605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:12:43.250250+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25668,7 +25668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:12:43.250316+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25680,7 +25680,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.125380+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.399977+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -25746,7 +25746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.250368+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113374+00:00"
               },
               "deterministic": true
             },
@@ -25759,7 +25759,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.125449+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.400014+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25788,7 +25788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.250407+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113390+00:00"
               },
               "deterministic": true
             },
@@ -25801,7 +25801,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.125478+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.400029+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -25840,7 +25840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250471+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25853,7 +25853,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.125535+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.400066+00:00"
           },
           "uid": {
             "type": "string",
@@ -25870,7 +25870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250504+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25884,7 +25884,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.125566+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.400083+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_link is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -25949,7 +25949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.250540+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113450+00:00"
               },
               "deterministic": true
             },
@@ -25962,7 +25962,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.125611+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.400099+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25987,8 +25987,8 @@
           "description": "Minimum configuration for cloud_linkReapplyConfigResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_linkReapplyConfigResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_linkReapplyConfigResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_link_reapply_config_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -26014,8 +26014,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_linkReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_linkReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_link_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -26027,8 +26027,8 @@
           "description": "Minimum configuration for cloud_linkReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_linkReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_linkReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_link_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -26131,7 +26131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250664+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26155,7 +26155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250717+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26181,7 +26181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250765+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26205,7 +26205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250824+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26229,7 +26229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250867+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26283,7 +26283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.250946+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26313,7 +26313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251008+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26336,7 +26336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251064+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26361,7 +26361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251123+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26399,7 +26399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251171+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26411,7 +26411,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.125840+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.400235+00:00"
           },
           "mtu": {
             "type": "integer",
@@ -26441,7 +26441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251231+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26466,7 +26466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251273+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26505,7 +26505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251331+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26530,7 +26530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251389+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26559,7 +26559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251446+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26588,7 +26588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:43.251503+00:00"
+                "validatedAt": "2026-05-09T01:33:34.113857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26665,8 +26665,8 @@
           "description": "Minimum configuration for cloud_linkVirtualInterfaceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_linkVirtualInterfaceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_linkVirtualInterfaceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_link_virtual_interface_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cloud_infrastructure"
@@ -26690,8 +26690,8 @@
           "description": "Minimum configuration for schemaCloudLinkState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaCloudLinkState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaCloudLinkState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_cloud_link_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -26728,7 +26728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.252572+00:00"
+                "validatedAt": "2026-05-09T01:33:34.114329+00:00"
               },
               "deterministic": true
             },
@@ -26741,7 +26741,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.126439+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.400545+00:00"
           },
           "name": {
             "type": "string",
@@ -26785,7 +26785,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.252652+00:00"
+                "validatedAt": "2026-05-09T01:33:34.114361+00:00"
               },
               "deterministic": true
             },
@@ -26797,7 +26797,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.126467+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.400560+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -26897,7 +26897,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.254236+00:00"
+                "validatedAt": "2026-05-09T01:33:34.115067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27003,7 +27003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:12:43.254567+00:00"
+                "validatedAt": "2026-05-09T01:33:34.115244+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/container_services.json
+++ b/docs/specifications/api/container_services.json
@@ -3804,8 +3804,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3834,7 +3834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.816379+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3847,7 +3847,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443288+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934524+00:00"
           },
           "name": {
             "type": "string",
@@ -3880,7 +3880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.816475+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544413+00:00"
               },
               "deterministic": true
             },
@@ -3893,7 +3893,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443321+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934542+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3924,7 +3924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.816544+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544432+00:00"
               },
               "deterministic": true
             },
@@ -3937,7 +3937,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443352+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934558+00:00"
           },
           "tenant": {
             "type": "string",
@@ -3956,7 +3956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.816646+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3970,7 +3970,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443382+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934574+00:00"
           },
           "uid": {
             "type": "string",
@@ -3989,7 +3989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.816723+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4004,7 +4004,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443413+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934590+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -4042,7 +4042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.816805+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4065,7 +4065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.816852+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4077,7 +4077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443458+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934614+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4123,7 +4123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:28:15.816900+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544528+00:00"
               },
               "deterministic": true
             },
@@ -4149,7 +4149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.816955+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4176,7 +4176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.817000+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4188,7 +4188,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443511+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934641+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4205,7 +4205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.817051+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4238,7 +4238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.817107+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4250,7 +4250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443551+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934662+00:00"
           },
           "type": {
             "type": "string",
@@ -4275,7 +4275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.817150+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4329,8 +4329,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -4363,7 +4363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.817202+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4425,7 +4425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817243+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544676+00:00"
               },
               "deterministic": true
             },
@@ -4438,7 +4438,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443641+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934701+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -4536,7 +4536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.817332+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4548,7 +4548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443715+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934739+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -4626,7 +4626,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817443+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544763+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4642,7 +4642,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443761+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934763+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4712,7 +4712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817496+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544787+00:00"
               },
               "deterministic": true
             },
@@ -4725,7 +4725,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443812+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934790+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4756,7 +4756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817533+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544804+00:00"
               },
               "deterministic": true
             },
@@ -4769,7 +4769,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443841+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934806+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -4851,7 +4851,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817657+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544850+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4867,7 +4867,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443885+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934829+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4939,7 +4939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817713+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544872+00:00"
               },
               "deterministic": true
             },
@@ -4952,7 +4952,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443936+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934856+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4983,7 +4983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817750+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544890+00:00"
               },
               "deterministic": true
             },
@@ -4996,7 +4996,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.443965+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934872+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5078,7 +5078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817848+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544935+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5094,7 +5094,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444008+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934895+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5164,7 +5164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817897+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544957+00:00"
               },
               "deterministic": true
             },
@@ -5177,7 +5177,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444059+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934922+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5208,7 +5208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.817932+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544973+00:00"
               },
               "deterministic": true
             },
@@ -5221,7 +5221,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444088+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934938+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -5266,7 +5266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.817990+00:00"
+                "validatedAt": "2026-05-09T01:40:31.544997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5294,7 +5294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818042+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5322,7 +5322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818090+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5351,7 +5351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818141+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5378,7 +5378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818174+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5392,7 +5392,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444170+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.934981+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -5408,7 +5408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818217+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5471,8 +5471,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -5517,7 +5517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818277+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5529,7 +5529,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444232+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935015+00:00"
           },
           "status": {
             "type": "string",
@@ -5547,7 +5547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818320+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5559,7 +5559,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444261+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935031+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -5601,7 +5601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818376+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5628,7 +5628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818428+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5655,7 +5655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818476+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5683,7 +5683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818530+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5748,7 +5748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818627+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5797,7 +5797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818692+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5810,7 +5810,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444393+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935100+00:00"
           },
           "uid": {
             "type": "string",
@@ -5829,7 +5829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818725+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5843,7 +5843,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444423+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935116+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -5888,8 +5888,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -5921,7 +5921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:28:15.818787+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5933,7 +5933,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444456+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935133+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -5951,7 +5951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818840+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5979,7 +5979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818885+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5991,7 +5991,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444505+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935164+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -6052,8 +6052,8 @@
           "description": "Minimum configuration for schemaUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6080,7 +6080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.818925+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6092,7 +6092,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444537+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935181+00:00"
           },
           "name": {
             "type": "string",
@@ -6125,7 +6125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.818962+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545411+00:00"
               },
               "deterministic": true
             },
@@ -6138,7 +6138,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444566+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935198+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6169,7 +6169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.818998+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545428+00:00"
               },
               "deterministic": true
             },
@@ -6182,7 +6182,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444608+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935213+00:00"
           },
           "uid": {
             "type": "string",
@@ -6199,7 +6199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.819031+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6213,7 +6213,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444640+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935229+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -6282,7 +6282,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.819106+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545478+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -6298,7 +6298,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444672+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935246+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6335,7 +6335,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.819173+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545511+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -6351,7 +6351,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444701+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935262+00:00"
           },
           "tenant": {
             "type": "string",
@@ -6380,7 +6380,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.819244+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6394,7 +6394,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444730+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935278+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -6434,8 +6434,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_k8sCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_k8sCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_k8ses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -6509,7 +6509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.819338+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6586,7 +6586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.819380+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545607+00:00"
               },
               "deterministic": true
             },
@@ -6599,7 +6599,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444864+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935348+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6629,7 +6629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.819416+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545624+00:00"
               },
               "deterministic": true
             },
@@ -6642,7 +6642,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444893+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935364+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6745,7 +6745,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.444990+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935416+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -6812,7 +6812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.819576+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6881,7 +6881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:28:15.819648+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6944,7 +6944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:28:15.819714+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6956,7 +6956,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.445105+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935476+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7022,7 +7022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.819764+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545768+00:00"
               },
               "deterministic": true
             },
@@ -7035,7 +7035,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.445174+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935516+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7064,7 +7064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.819801+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545784+00:00"
               },
               "deterministic": true
             },
@@ -7077,7 +7077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.445203+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935532+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7116,7 +7116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.819866+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7129,7 +7129,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.445260+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935570+00:00"
           },
           "uid": {
             "type": "string",
@@ -7146,7 +7146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.819899+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7160,7 +7160,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.445290+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935588+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_k8s is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -7250,8 +7250,8 @@
           "description": "Minimum configuration for virtual_k8sPVCMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_k8sPVCMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_k8sPVCMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_k8s_p_v_c_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -7272,8 +7272,8 @@
           "description": "Minimum configuration for virtual_k8sPVCMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_k8sPVCMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_k8sPVCMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_k8s_p_v_c_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -7301,7 +7301,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.445355+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935628+00:00"
           },
           "value": {
             "type": "array",
@@ -7320,7 +7320,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.445387+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935647+00:00"
           }
         },
         "x-f5xc-description-short": "PVC Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -7368,7 +7368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.819989+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7413,7 +7413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.820057+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7440,7 +7440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.820100+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7493,7 +7493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.820152+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545939+00:00"
               },
               "deterministic": true
             },
@@ -7506,7 +7506,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.445457+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.935685+00:00"
           },
           "range": {
             "type": "string",
@@ -7531,7 +7531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.820196+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7564,7 +7564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.820250+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7597,7 +7597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.820291+00:00"
+                "validatedAt": "2026-05-09T01:40:31.545998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7674,7 +7674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:15.820347+00:00"
+                "validatedAt": "2026-05-09T01:40:31.546024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7719,8 +7719,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_k8sReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_k8sReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_k8s_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -7732,8 +7732,8 @@
           "description": "Minimum configuration for virtual_k8sReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_k8sReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_k8sReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_k8s_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -7779,7 +7779,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:15.820427+00:00"
+                "validatedAt": "2026-05-09T01:40:31.546063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7913,7 +7913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.000730+00:00"
+                "validatedAt": "2026-05-09T01:40:49.417847+00:00"
               },
               "deterministic": true
             },
@@ -7959,7 +7959,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.000893+00:00"
+                "validatedAt": "2026-05-09T01:40:49.417906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8037,7 +8037,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.000996+00:00"
+                "validatedAt": "2026-05-09T01:40:49.417952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8139,7 +8139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001105+00:00"
+                "validatedAt": "2026-05-09T01:40:49.417998+00:00"
               },
               "deterministic": true
             },
@@ -8185,7 +8185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001193+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8221,7 +8221,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001276+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8322,7 +8322,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001375+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8426,7 +8426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001476+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418180+00:00"
               },
               "deterministic": true
             },
@@ -8472,7 +8472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001561+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8508,7 +8508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001661+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8619,7 +8619,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001765+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418304+00:00"
               },
               "deterministic": true
             },
@@ -8696,7 +8696,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001855+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418346+00:00"
               },
               "deterministic": true
             },
@@ -8778,7 +8778,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.001957+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8853,7 +8853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.002042+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8924,7 +8924,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.002125+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418473+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8940,7 +8940,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.271351+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.319300+00:00"
           },
           "presence": {
             "type": "boolean",
@@ -8985,7 +8985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.002217+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418520+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -9057,7 +9057,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.002499+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418647+00:00"
               },
               "deterministic": true
             },
@@ -9097,7 +9097,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.002572+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9138,7 +9138,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.002685+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418724+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -9211,7 +9211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.002735+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418744+00:00"
               },
               "deterministic": true
             },
@@ -9255,7 +9255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.002822+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9322,7 +9322,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.003008+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9396,7 +9396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.003083+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9431,7 +9431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.003164+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9470,7 +9470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.003246+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9506,7 +9506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.003299+00:00"
+                "validatedAt": "2026-05-09T01:40:49.418995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9544,7 +9544,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.003389+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9629,7 +9629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.003471+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9667,7 +9667,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.003545+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9679,7 +9679,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.271800+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.319524+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -9698,7 +9698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.003610+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9749,7 +9749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.003657+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9761,7 +9761,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.271842+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.319547+00:00"
           },
           "url": {
             "type": "string",
@@ -9799,7 +9799,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.003739+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419189+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -9846,8 +9846,8 @@
           "description": "Minimum configuration for schemaHashAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_hash_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9893,7 +9893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.004151+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9980,8 +9980,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10008,7 +10008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.004268+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10020,7 +10020,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.272124+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.319695+00:00"
           },
           "name": {
             "type": "string",
@@ -10051,7 +10051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.004306+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419431+00:00"
               },
               "deterministic": true
             },
@@ -10064,7 +10064,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.272153+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.319710+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10093,7 +10093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.004343+00:00"
+                "validatedAt": "2026-05-09T01:40:49.419448+00:00"
               },
               "deterministic": true
             },
@@ -10106,7 +10106,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.272182+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.319726+00:00"
           }
         },
         "x-f5xc-description-short": "KubeRefType represents a reference to a Kubernetes (K8s) object.",
@@ -10139,8 +10139,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10248,7 +10248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.005901+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10280,7 +10280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:28:57.005969+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10292,7 +10292,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.273045+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.320178+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -10341,8 +10341,8 @@
           "description": "Minimum configuration for schemaTlsProtocol",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tls_protocols\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10368,8 +10368,8 @@
           "description": "Minimum configuration for schemaXfccElement",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_xfcc_elements\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10417,7 +10417,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.006357+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10511,7 +10511,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.006654+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10581,7 +10581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.006726+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10682,7 +10682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.006841+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10743,8 +10743,8 @@
           "description": "Minimum configuration for viewsSiteNetwork",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_networks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10819,7 +10819,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.006924+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11053,8 +11053,8 @@
           "description": "Minimum configuration for viewsworkloadProtocolType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsworkloadProtocolType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsworkloadProtocolType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/viewsworkload_protocol_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -11125,7 +11125,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007079+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11190,7 +11190,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007145+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11230,7 +11230,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007223+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11269,7 +11269,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007289+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11375,7 +11375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007368+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11411,7 +11411,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007424+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11498,7 +11498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007489+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11671,7 +11671,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007613+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420872+00:00"
               },
               "deterministic": true
             },
@@ -11820,7 +11820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007735+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11871,7 +11871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007809+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420958+00:00"
               },
               "deterministic": true
             },
@@ -11884,7 +11884,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.274221+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.320814+00:00"
           },
           "volume_name": {
             "type": "string",
@@ -11911,7 +11911,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007887+00:00"
+                "validatedAt": "2026-05-09T01:40:49.420995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11999,7 +11999,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.007961+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12041,8 +12041,8 @@
           "description": "Minimum configuration for workloadContainerFlavorType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workloadContainerFlavorType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workloadContainerFlavorType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_container_flavor_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -12081,7 +12081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008018+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12117,7 +12117,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008075+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12194,7 +12194,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008165+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421128+00:00"
               },
               "deterministic": true
             },
@@ -12207,7 +12207,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.274374+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.320897+00:00"
           },
           "readiness_check": {
             "$ref": "#/components/schemas/workloadHealthCheckType"
@@ -12256,8 +12256,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workloadCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workloadCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workloads\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -12340,7 +12340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008235+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421172+00:00"
               },
               "deterministic": true
             },
@@ -12353,7 +12353,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.274477+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.320952+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12383,7 +12383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008275+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421192+00:00"
               },
               "deterministic": true
             },
@@ -12396,7 +12396,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.274506+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.320970+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12454,7 +12454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008338+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12519,7 +12519,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008402+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12629,7 +12629,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008487+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12694,7 +12694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008551+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12809,7 +12809,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008661+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421374+00:00"
               },
               "deterministic": true
             },
@@ -12822,7 +12822,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.274682+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321064+00:00"
           },
           "value": {
             "type": "string",
@@ -12846,7 +12846,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008731+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12858,7 +12858,7 @@
             "x-original-maxLength": 256,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.274712+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321080+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12923,7 +12923,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008806+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421443+00:00"
               },
               "deterministic": true
             },
@@ -12936,7 +12936,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.274763+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321108+00:00"
           }
         },
         "x-f5xc-description-short": "Ephemeral storage volume configuration for the workload.",
@@ -13000,7 +13000,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.008867+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13111,7 +13111,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.274873+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321174+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -13199,7 +13199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.009045+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13238,7 +13238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.009133+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421591+00:00"
               },
               "deterministic": true
             },
@@ -13325,7 +13325,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.009216+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421630+00:00"
               },
               "deterministic": true
             },
@@ -13459,7 +13459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:28:57.009327+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421676+00:00"
               },
               "deterministic": true
             },
@@ -13503,7 +13503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:28:57.009373+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421697+00:00"
               },
               "deterministic": true
             },
@@ -13603,7 +13603,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.009505+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421763+00:00"
               },
               "deterministic": true
             },
@@ -13648,8 +13648,8 @@
           "description": "Minimum configuration for workloadImagePullPolicyType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workloadImagePullPolicyType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workloadImagePullPolicyType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_image_pull_policy_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -13705,7 +13705,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.009579+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421797+00:00"
               },
               "deterministic": true
             },
@@ -13718,7 +13718,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.275126+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321310+00:00"
           },
           "public": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -13781,7 +13781,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.009665+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13817,7 +13817,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.009732+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13850,7 +13850,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.009794+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13921,7 +13921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:28:57.009851+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13983,7 +13983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:28:57.009924+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13995,7 +13995,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.275260+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321381+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14061,7 +14061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.009979+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421973+00:00"
               },
               "deterministic": true
             },
@@ -14074,7 +14074,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.275330+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321418+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14103,7 +14103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010017+00:00"
+                "validatedAt": "2026-05-09T01:40:49.421990+00:00"
               },
               "deterministic": true
             },
@@ -14116,7 +14116,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.275359+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321433+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -14155,7 +14155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.010084+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14168,7 +14168,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.275416+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321464+00:00"
           },
           "uid": {
             "type": "string",
@@ -14185,7 +14185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.010119+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14199,7 +14199,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.275447+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321480+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of workload is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -14267,7 +14267,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010212+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14329,7 +14329,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010270+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14370,8 +14370,8 @@
           "description": "Minimum configuration for workloadPersistentStorageAccessModeType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workloadPersistentStorageAccessModeType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workloadPersistentStorageAccessModeType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_persistent_storage_access_mode_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -14410,7 +14410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010354+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14543,7 +14543,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010459+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422198+00:00"
               },
               "deterministic": true
             },
@@ -14556,7 +14556,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.275595+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321553+00:00"
           },
           "persistent_volume": {
             "$ref": "#/components/schemas/workloadPersistentStorageVolumeType"
@@ -14618,7 +14618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010505+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422219+00:00"
               },
               "deterministic": true
             },
@@ -14631,7 +14631,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.275636+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:15.321575+00:00",
             "x-f5xc-conflicts-with": [
               "num"
             ]
@@ -14714,7 +14714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010563+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422248+00:00"
               },
               "deterministic": true
             },
@@ -14821,7 +14821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010655+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422281+00:00"
               },
               "deterministic": true
             },
@@ -14834,7 +14834,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.275728+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321623+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14871,8 +14871,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workloadReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workloadReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -14884,8 +14884,8 @@
           "description": "Minimum configuration for workloadReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workloadReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workloadReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -15053,7 +15053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010795+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15093,7 +15093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010875+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15133,7 +15133,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.010943+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15169,7 +15169,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.011009+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15322,7 +15322,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.011140+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422507+00:00"
               },
               "deterministic": true
             },
@@ -15335,7 +15335,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.276035+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321787+00:00"
           },
           "persistent_volume": {
             "$ref": "#/components/schemas/workloadPersistentStorageVolumeType"
@@ -15420,7 +15420,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.011224+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422546+00:00"
               },
               "deterministic": true
             },
@@ -15524,8 +15524,8 @@
           "description": "Minimum configuration for workloadUsageLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workloadUsageLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workloadUsageLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_usage_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -15560,7 +15560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.011302+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15605,7 +15605,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.011371+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15632,7 +15632,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.011423+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15701,7 +15701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.011486+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422661+00:00"
               },
               "deterministic": true
             },
@@ -15714,7 +15714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.276190+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321869+00:00"
           },
           "range": {
             "type": "string",
@@ -15739,7 +15739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.011538+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15772,7 +15772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.011610+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15805,7 +15805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.011658+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15884,7 +15884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:57.011722+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15927,8 +15927,8 @@
           "description": "Minimum configuration for workloadUsageType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workloadUsageType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workloadUsageType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_usage_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -15956,7 +15956,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.276275+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321914+00:00"
           },
           "value": {
             "type": "array",
@@ -15975,7 +15975,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.276308+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.321931+00:00"
           }
         },
         "x-f5xc-description-short": "Usage Type Data contains key/value pair that uniquely identifies a workload in the response and the corresponding metric data.",
@@ -16010,8 +16010,8 @@
           "description": "Minimum configuration for workloadVolumeMountModeType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workloadVolumeMountModeType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workloadVolumeMountModeType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_volume_mount_mode_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -16056,7 +16056,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.011858+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16090,7 +16090,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:57.011939+00:00"
+                "validatedAt": "2026-05-09T01:40:49.422849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16140,7 +16140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.841130+00:00"
+                "validatedAt": "2026-05-09T01:40:52.393328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16153,7 +16153,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.430935+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394380+00:00"
           },
           "name": {
             "type": "string",
@@ -16186,7 +16186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:03.841168+00:00"
+                "validatedAt": "2026-05-09T01:40:52.393346+00:00"
               },
               "deterministic": true
             },
@@ -16199,7 +16199,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.430965+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394396+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16230,7 +16230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:03.841205+00:00"
+                "validatedAt": "2026-05-09T01:40:52.393363+00:00"
               },
               "deterministic": true
             },
@@ -16243,7 +16243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.430994+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394411+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16262,7 +16262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.841247+00:00"
+                "validatedAt": "2026-05-09T01:40:52.393381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16276,7 +16276,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.431023+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394427+00:00"
           },
           "uid": {
             "type": "string",
@@ -16295,7 +16295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.841282+00:00"
+                "validatedAt": "2026-05-09T01:40:52.393396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16310,7 +16310,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.431055+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394443+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -16352,8 +16352,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workload_flavorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workload_flavorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_flavors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -16416,7 +16416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.842489+00:00"
+                "validatedAt": "2026-05-09T01:40:52.393908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16449,7 +16449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.842537+00:00"
+                "validatedAt": "2026-05-09T01:40:52.393929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16547,7 +16547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:03.842614+00:00"
+                "validatedAt": "2026-05-09T01:40:52.393957+00:00"
               },
               "deterministic": true
             },
@@ -16560,7 +16560,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.431786+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394825+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16590,7 +16590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:03.842651+00:00"
+                "validatedAt": "2026-05-09T01:40:52.393974+00:00"
               },
               "deterministic": true
             },
@@ -16603,7 +16603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.431815+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394840+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16706,7 +16706,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.431913+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394892+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16762,7 +16762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.842795+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16795,7 +16795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.842843+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16885,7 +16885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:29:03.842918+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16948,7 +16948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:29:03.842983+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16960,7 +16960,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.432020+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394948+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17026,7 +17026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:03.843032+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394133+00:00"
               },
               "deterministic": true
             },
@@ -17039,7 +17039,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.432089+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.394985+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17068,7 +17068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:03.843069+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394149+00:00"
               },
               "deterministic": true
             },
@@ -17081,7 +17081,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.432119+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.395000+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -17120,7 +17120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.843137+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17133,7 +17133,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.432176+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.395031+00:00"
           },
           "uid": {
             "type": "string",
@@ -17150,7 +17150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.843171+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17164,7 +17164,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.432207+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.395047+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of workload_flavor is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -17214,8 +17214,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workload_flavorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workload_flavorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_flavor_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -17227,8 +17227,8 @@
           "description": "Minimum configuration for workload_flavorReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for workload_flavorReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for workload_flavorReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/workload_flavor_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"
@@ -17263,7 +17263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.843237+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17296,7 +17296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:03.843285+00:00"
+                "validatedAt": "2026-05-09T01:40:52.394246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17420,8 +17420,8 @@
           "description": "Minimum configuration for viewsworkloadUsageType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsworkloadUsageType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsworkloadUsageType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/viewsworkload_usage_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "container_services"

--- a/docs/specifications/api/data_and_privacy_security.json
+++ b/docs/specifications/api/data_and_privacy_security.json
@@ -3141,8 +3141,8 @@
           "description": "Minimum configuration for data_typeCompliance",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for data_typeCompliance\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for data_typeCompliance\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/data_type_compliances\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "data_and_privacy_security"
@@ -3168,8 +3168,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for data_typeCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for data_typeCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/data_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "data_and_privacy_security"
@@ -3240,7 +3240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284025+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3313,7 +3313,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284129+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345633+00:00"
               },
               "deterministic": true
             },
@@ -3391,7 +3391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284180+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345655+00:00"
               },
               "deterministic": true
             },
@@ -3404,7 +3404,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.762374+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.616671+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3434,7 +3434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284220+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345673+00:00"
               },
               "deterministic": true
             },
@@ -3447,7 +3447,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.762407+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.616687+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -3535,7 +3535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284299+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3644,7 +3644,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.762552+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.616762+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -3708,7 +3708,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284459+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3781,7 +3781,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284544+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345814+00:00"
               },
               "deterministic": true
             },
@@ -3883,7 +3883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:42.284625+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3945,7 +3945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:42.284698+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3957,7 +3957,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.762721+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.616839+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -4023,7 +4023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284755+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345895+00:00"
               },
               "deterministic": true
             },
@@ -4036,7 +4036,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.762791+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.616876+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4065,7 +4065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284792+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345912+00:00"
               },
               "deterministic": true
             },
@@ -4078,7 +4078,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.762821+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.616892+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -4117,7 +4117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.284861+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4130,7 +4130,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.762879+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.616922+00:00"
           },
           "uid": {
             "type": "string",
@@ -4147,7 +4147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.284895+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4161,7 +4161,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.762910+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.616938+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of data_type is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -4236,8 +4236,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for data_typeReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for data_typeReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/data_type_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "data_and_privacy_security"
@@ -4249,8 +4249,8 @@
           "description": "Minimum configuration for data_typeReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for data_typeReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for data_typeReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/data_type_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "data_and_privacy_security"
@@ -4293,7 +4293,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.284977+00:00"
+                "validatedAt": "2026-05-09T01:34:53.345991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4366,7 +4366,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.285061+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346030+00:00"
               },
               "deterministic": true
             },
@@ -4433,7 +4433,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.285151+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4473,7 +4473,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.285238+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4567,8 +4567,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -4590,7 +4590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.285326+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4613,7 +4613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.285370+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4625,7 +4625,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763103+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617039+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4671,7 +4671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:42.285414+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346195+00:00"
               },
               "deterministic": true
             },
@@ -4697,7 +4697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.285468+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4724,7 +4724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.285513+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4736,7 +4736,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763155+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617066+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4753,7 +4753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.285564+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4786,7 +4786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.285626+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4798,7 +4798,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763195+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617087+00:00"
           },
           "type": {
             "type": "string",
@@ -4823,7 +4823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.285669+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4877,8 +4877,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -4911,7 +4911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.285723+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4973,7 +4973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.285761+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346337+00:00"
               },
               "deterministic": true
             },
@@ -4986,7 +4986,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763268+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617127+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -5104,7 +5104,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.285881+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346392+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5120,7 +5120,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763334+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617166+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5190,7 +5190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.285931+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346413+00:00"
               },
               "deterministic": true
             },
@@ -5203,7 +5203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763384+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617193+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5234,7 +5234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.285966+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346429+00:00"
               },
               "deterministic": true
             },
@@ -5247,7 +5247,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763414+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617208+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -5329,7 +5329,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.286064+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346474+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5345,7 +5345,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763458+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617232+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5417,7 +5417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.286113+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346495+00:00"
               },
               "deterministic": true
             },
@@ -5430,7 +5430,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763508+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617259+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5461,7 +5461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.286148+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346511+00:00"
               },
               "deterministic": true
             },
@@ -5474,7 +5474,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763537+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617275+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5519,7 +5519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286191+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5532,7 +5532,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763568+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617292+00:00"
           },
           "name": {
             "type": "string",
@@ -5565,7 +5565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.286226+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346545+00:00"
               },
               "deterministic": true
             },
@@ -5578,7 +5578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763610+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617310+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5609,7 +5609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.286262+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346562+00:00"
               },
               "deterministic": true
             },
@@ -5622,7 +5622,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763640+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617326+00:00"
           },
           "tenant": {
             "type": "string",
@@ -5641,7 +5641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286304+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5655,7 +5655,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763669+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617342+00:00"
           },
           "uid": {
             "type": "string",
@@ -5674,7 +5674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286337+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5689,7 +5689,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763699+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617358+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -5771,7 +5771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.286435+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346640+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5787,7 +5787,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763743+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617381+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5857,7 +5857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.286483+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346661+00:00"
               },
               "deterministic": true
             },
@@ -5870,7 +5870,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763793+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617409+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5901,7 +5901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.286518+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346677+00:00"
               },
               "deterministic": true
             },
@@ -5914,7 +5914,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763822+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617424+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -5959,7 +5959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286575+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5987,7 +5987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286641+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6015,7 +6015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286690+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6044,7 +6044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286741+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6071,7 +6071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286775+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6085,7 +6085,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763902+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617467+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -6101,7 +6101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286818+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6164,8 +6164,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6210,7 +6210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286880+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6222,7 +6222,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763965+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617499+00:00"
           },
           "status": {
             "type": "string",
@@ -6240,7 +6240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286923+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6252,7 +6252,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.763993+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617515+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -6294,7 +6294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.286979+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6321,7 +6321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.287030+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6348,7 +6348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.287077+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6376,7 +6376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.287130+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6441,7 +6441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.287211+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6490,7 +6490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.287274+00:00"
+                "validatedAt": "2026-05-09T01:34:53.346992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6503,7 +6503,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.764122+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617584+00:00"
           },
           "uid": {
             "type": "string",
@@ -6522,7 +6522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.287306+00:00"
+                "validatedAt": "2026-05-09T01:34:53.347006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6536,7 +6536,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.764152+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617600+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -6586,7 +6586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.287345+00:00"
+                "validatedAt": "2026-05-09T01:34:53.347024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6598,7 +6598,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.764183+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617617+00:00"
           },
           "name": {
             "type": "string",
@@ -6631,7 +6631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.287381+00:00"
+                "validatedAt": "2026-05-09T01:34:53.347040+00:00"
               },
               "deterministic": true
             },
@@ -6644,7 +6644,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.764212+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617633+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6675,7 +6675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:42.287416+00:00"
+                "validatedAt": "2026-05-09T01:34:53.347056+00:00"
               },
               "deterministic": true
             },
@@ -6688,7 +6688,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.764241+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617648+00:00"
           },
           "uid": {
             "type": "string",
@@ -6705,7 +6705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:42.287449+00:00"
+                "validatedAt": "2026-05-09T01:34:53.347070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6719,7 +6719,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.764271+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.617664+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -6818,7 +6818,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.768532+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.549817+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -6873,7 +6873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:25.065300+00:00"
+                "validatedAt": "2026-05-09T01:35:39.052456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6977,7 +6977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:25.065456+00:00"
+                "validatedAt": "2026-05-09T01:35:39.052496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6990,7 +6990,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.768644+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.549862+00:00"
           },
           "name": {
             "type": "string",
@@ -7023,7 +7023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:25.065505+00:00"
+                "validatedAt": "2026-05-09T01:35:39.052519+00:00"
               },
               "deterministic": true
             },
@@ -7036,7 +7036,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.768676+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.549878+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7067,7 +7067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:25.065545+00:00"
+                "validatedAt": "2026-05-09T01:35:39.052538+00:00"
               },
               "deterministic": true
             },
@@ -7080,7 +7080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.768706+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.549894+00:00"
           },
           "tenant": {
             "type": "string",
@@ -7099,7 +7099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:25.065611+00:00"
+                "validatedAt": "2026-05-09T01:35:39.052557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7113,7 +7113,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.768736+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.549909+00:00"
           },
           "uid": {
             "type": "string",
@@ -7132,7 +7132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:25.065650+00:00"
+                "validatedAt": "2026-05-09T01:35:39.052573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7147,7 +7147,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.768767+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.549926+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -7196,7 +7196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:37.446754+00:00"
+                "validatedAt": "2026-05-09T01:36:38.176991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7234,7 +7234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:37.446807+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177020+00:00"
               },
               "deterministic": true
             },
@@ -7271,7 +7271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:37.446849+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7422,7 +7422,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.289970+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.738351+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -7580,7 +7580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:19:37.447041+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7643,7 +7643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:37.447112+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7655,7 +7655,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.290101+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.738419+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7721,7 +7721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:37.447165+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177192+00:00"
               },
               "deterministic": true
             },
@@ -7734,7 +7734,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.290173+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.738456+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7763,7 +7763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:37.447202+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177209+00:00"
               },
               "deterministic": true
             },
@@ -7776,7 +7776,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.290202+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.738472+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7815,7 +7815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:37.447268+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7828,7 +7828,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.290261+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.738503+00:00"
           },
           "uid": {
             "type": "string",
@@ -7845,7 +7845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:37.447301+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7859,7 +7859,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.290292+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.738519+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of lma_region is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -7970,7 +7970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:37.447483+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8008,7 +8008,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:37.447563+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8020,7 +8020,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.290409+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.738581+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -8039,7 +8039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:37.447630+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8090,7 +8090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:37.447678+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8102,7 +8102,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.290451+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.738603+00:00"
           },
           "url": {
             "type": "string",
@@ -8140,7 +8140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:37.447758+00:00"
+                "validatedAt": "2026-05-09T01:36:38.177462+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8184,8 +8184,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -8246,7 +8246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:05.171991+00:00"
+                "validatedAt": "2026-05-09T01:36:50.794821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8278,7 +8278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:05.172038+00:00"
+                "validatedAt": "2026-05-09T01:36:50.794844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8344,7 +8344,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338320+00:00"
+                "validatedAt": "2026-05-09T01:38:38.568856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8377,7 +8377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338379+00:00"
+                "validatedAt": "2026-05-09T01:38:38.568884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8418,7 +8418,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338445+00:00"
+                "validatedAt": "2026-05-09T01:38:38.568916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8481,7 +8481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338511+00:00"
+                "validatedAt": "2026-05-09T01:38:38.568947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8514,7 +8514,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338569+00:00"
+                "validatedAt": "2026-05-09T01:38:38.568975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8555,7 +8555,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338649+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8618,7 +8618,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338715+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8651,7 +8651,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338772+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8692,7 +8692,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338838+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8825,7 +8825,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.338957+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569163+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8841,7 +8841,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603371+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.198754+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8878,7 +8878,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.339027+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569196+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8894,7 +8894,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603401+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.198770+00:00"
           },
           "tenant": {
             "type": "string",
@@ -8923,7 +8923,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.339100+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8937,7 +8937,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603430+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.198785+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -9084,7 +9084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.339169+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569259+00:00"
               },
               "deterministic": true
             },
@@ -9097,7 +9097,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603535+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.198841+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9127,7 +9127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.339207+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569276+00:00"
               },
               "deterministic": true
             },
@@ -9140,7 +9140,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603565+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.198856+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9243,7 +9243,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603676+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.198908+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9311,7 +9311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:24:04.339349+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9374,7 +9374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:24:04.339415+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9386,7 +9386,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603751+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.198947+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9452,7 +9452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.339467+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569385+00:00"
               },
               "deterministic": true
             },
@@ -9465,7 +9465,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603820+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.198984+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9494,7 +9494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:04.339504+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569402+00:00"
               },
               "deterministic": true
             },
@@ -9507,7 +9507,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603848+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.199000+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9546,7 +9546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:04.339570+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9559,7 +9559,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603906+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.199030+00:00"
           },
           "uid": {
             "type": "string",
@@ -9577,7 +9577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:04.339618+00:00"
+                "validatedAt": "2026-05-09T01:38:38.569443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9591,7 +9591,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.603936+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.199046+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of sensitive_data_policy is returned in 'List'.",
@@ -9654,8 +9654,8 @@
           "description": "Minimum configuration for sensitive_data_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for sensitive_data_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for sensitive_data_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/sensitive_data_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "data_and_privacy_security"

--- a/docs/specifications/api/data_intelligence.json
+++ b/docs/specifications/api/data_intelligence.json
@@ -3585,8 +3585,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3615,7 +3615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.334426+00:00"
+                "validatedAt": "2026-05-09T01:34:46.258867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3628,7 +3628,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.429175+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.462769+00:00"
           },
           "name": {
             "type": "string",
@@ -3661,7 +3661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.334493+00:00"
+                "validatedAt": "2026-05-09T01:34:46.258901+00:00"
               },
               "deterministic": true
             },
@@ -3674,7 +3674,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.429208+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.462787+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3705,7 +3705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.334534+00:00"
+                "validatedAt": "2026-05-09T01:34:46.258920+00:00"
               },
               "deterministic": true
             },
@@ -3718,7 +3718,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.429238+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.462803+00:00"
           },
           "tenant": {
             "type": "string",
@@ -3737,7 +3737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.334580+00:00"
+                "validatedAt": "2026-05-09T01:34:46.258938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3751,7 +3751,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.429268+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.462819+00:00"
           },
           "uid": {
             "type": "string",
@@ -3770,7 +3770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.334635+00:00"
+                "validatedAt": "2026-05-09T01:34:46.258954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3785,7 +3785,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.429299+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.462835+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -3823,7 +3823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.334687+00:00"
+                "validatedAt": "2026-05-09T01:34:46.258977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3846,7 +3846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.334731+00:00"
+                "validatedAt": "2026-05-09T01:34:46.258996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3858,7 +3858,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.429344+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.462858+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -3948,7 +3948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.334863+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4074,7 +4074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.334979+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4155,8 +4155,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for receiverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for receiverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/receivers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -4227,7 +4227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.335101+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4305,7 +4305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:15:26.335171+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259203+00:00"
               },
               "deterministic": true
             },
@@ -4344,7 +4344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.335217+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4429,7 +4429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.335273+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259244+00:00"
               },
               "deterministic": true
             },
@@ -4442,7 +4442,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.429724+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463049+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4472,7 +4472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.335309+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259261+00:00"
               },
               "deterministic": true
             },
@@ -4485,7 +4485,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.429754+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463064+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4544,7 +4544,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.335408+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4663,7 +4663,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.429893+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463137+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -4727,7 +4727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.335606+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4761,7 +4761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.335662+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4788,7 +4788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.335719+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4821,7 +4821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.335774+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4855,7 +4855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.335828+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4948,7 +4948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.335920+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5013,7 +5013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.336005+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5080,7 +5080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:26.336061+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5142,7 +5142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:26.336129+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5154,7 +5154,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430174+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463290+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -5220,7 +5220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.336182+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259640+00:00"
               },
               "deterministic": true
             },
@@ -5233,7 +5233,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430243+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463327+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5262,7 +5262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.336221+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259661+00:00"
               },
               "deterministic": true
             },
@@ -5275,7 +5275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430272+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463343+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -5314,7 +5314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.336286+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5327,7 +5327,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430329+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463374+00:00"
           },
           "uid": {
             "type": "string",
@@ -5344,7 +5344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.336318+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5358,7 +5358,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430359+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463389+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -5408,8 +5408,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for receiverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for receiverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/receiver_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -5421,8 +5421,8 @@
           "description": "Minimum configuration for receiverReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for receiverReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for receiverReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/receiver_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -5465,7 +5465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.336417+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5541,7 +5541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.336486+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5586,7 +5586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.336600+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5656,7 +5656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:15:26.336658+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259870+00:00"
               },
               "deterministic": true
             },
@@ -5791,7 +5791,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.336802+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259937+00:00"
               },
               "deterministic": true
             },
@@ -5880,7 +5880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.336915+00:00"
+                "validatedAt": "2026-05-09T01:34:46.259986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5939,7 +5939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.336970+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5977,7 +5977,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.337044+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5989,7 +5989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430737+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463584+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -6008,7 +6008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.337094+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6059,7 +6059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.337139+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6071,7 +6071,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430779+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463606+00:00"
           },
           "url": {
             "type": "string",
@@ -6109,7 +6109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.337210+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260123+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -6166,7 +6166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:26.337249+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260141+00:00"
               },
               "deterministic": true
             },
@@ -6192,7 +6192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.337301+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6219,7 +6219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.337346+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6231,7 +6231,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430840+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463638+00:00"
           },
           "service_name": {
             "type": "string",
@@ -6248,7 +6248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.337395+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6281,7 +6281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.337440+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6293,7 +6293,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430879+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463659+00:00"
           },
           "type": {
             "type": "string",
@@ -6318,7 +6318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.337482+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6372,8 +6372,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6406,7 +6406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.337534+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6468,7 +6468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.337571+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260298+00:00"
               },
               "deterministic": true
             },
@@ -6481,7 +6481,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.430952+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463697+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -6599,7 +6599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.337705+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260353+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6615,7 +6615,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431017+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463731+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6685,7 +6685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.337755+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260380+00:00"
               },
               "deterministic": true
             },
@@ -6698,7 +6698,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431067+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463758+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6729,7 +6729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.337790+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260396+00:00"
               },
               "deterministic": true
             },
@@ -6742,7 +6742,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431097+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463773+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -6824,7 +6824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.337888+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260442+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6840,7 +6840,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431140+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463796+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6912,7 +6912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.337935+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260463+00:00"
               },
               "deterministic": true
             },
@@ -6925,7 +6925,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431190+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463823+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6956,7 +6956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.337969+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260480+00:00"
               },
               "deterministic": true
             },
@@ -6969,7 +6969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431219+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463838+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -7051,7 +7051,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.338068+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260525+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7067,7 +7067,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431263+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463861+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7137,7 +7137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.338116+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260546+00:00"
               },
               "deterministic": true
             },
@@ -7150,7 +7150,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431316+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463887+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7181,7 +7181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.338151+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260562+00:00"
               },
               "deterministic": true
             },
@@ -7194,7 +7194,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431346+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463903+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -7230,8 +7230,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7289,7 +7289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338214+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7317,7 +7317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338265+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7345,7 +7345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338312+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7374,7 +7374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338361+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7401,7 +7401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338393+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7415,7 +7415,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431449+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463957+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -7431,7 +7431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338436+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7494,8 +7494,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7540,7 +7540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338495+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7552,7 +7552,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431511+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.463989+00:00"
           },
           "status": {
             "type": "string",
@@ -7570,7 +7570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338537+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7582,7 +7582,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431540+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464005+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7624,7 +7624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338606+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7651,7 +7651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338658+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7678,7 +7678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338705+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7706,7 +7706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338757+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7771,7 +7771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338836+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7820,7 +7820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338900+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7833,7 +7833,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431682+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464073+00:00"
           },
           "uid": {
             "type": "string",
@@ -7852,7 +7852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338932+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7866,7 +7866,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431713+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464089+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -7916,7 +7916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.338972+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7928,7 +7928,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431744+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464106+00:00"
           },
           "name": {
             "type": "string",
@@ -7961,7 +7961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.339007+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260925+00:00"
               },
               "deterministic": true
             },
@@ -7974,7 +7974,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431773+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464121+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8005,7 +8005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.339043+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260942+00:00"
               },
               "deterministic": true
             },
@@ -8018,7 +8018,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431802+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464137+00:00"
           },
           "uid": {
             "type": "string",
@@ -8035,7 +8035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:26.339074+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8049,7 +8049,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431832+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464157+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -8118,7 +8118,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.339147+00:00"
+                "validatedAt": "2026-05-09T01:34:46.260990+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8134,7 +8134,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431863+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464175+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8171,7 +8171,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.339212+00:00"
+                "validatedAt": "2026-05-09T01:34:46.261022+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8187,7 +8187,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431892+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464190+00:00"
           },
           "tenant": {
             "type": "string",
@@ -8216,7 +8216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:26.339285+00:00"
+                "validatedAt": "2026-05-09T01:34:46.261056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8230,7 +8230,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.431921+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.464206+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -8278,7 +8278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:31.188580+00:00"
+                "validatedAt": "2026-05-09T01:34:48.414870+00:00"
               },
               "deterministic": true
             },
@@ -8304,7 +8304,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.576424+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529387+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8344,7 +8344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:31.188753+00:00"
+                "validatedAt": "2026-05-09T01:34:48.414912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8356,7 +8356,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.576462+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529406+00:00"
           },
           "id": {
             "type": "string",
@@ -8375,7 +8375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.188817+00:00"
+                "validatedAt": "2026-05-09T01:34:48.414927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8414,7 +8414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:31.188882+00:00"
+                "validatedAt": "2026-05-09T01:34:48.414947+00:00"
               },
               "deterministic": true
             },
@@ -8427,7 +8427,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.576504+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529427+00:00"
           },
           "status": {
             "type": "string",
@@ -8445,7 +8445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.188927+00:00"
+                "validatedAt": "2026-05-09T01:34:48.414965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8457,7 +8457,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.576534+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529443+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8497,7 +8497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.188978+00:00"
+                "validatedAt": "2026-05-09T01:34:48.414987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8550,7 +8550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189056+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8562,7 +8562,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.576612+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529475+00:00"
           }
         },
         "x-f5xc-description-short": "Message object representing events reason.",
@@ -8603,7 +8603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189108+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8630,7 +8630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:31.189167+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8642,7 +8642,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.576656+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529497+00:00"
           },
           "feature_name": {
             "type": "string",
@@ -8658,7 +8658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189222+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8696,7 +8696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189268+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8761,7 +8761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189322+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8784,7 +8784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189367+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8905,7 +8905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189457+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9067,7 +9067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189611+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9105,7 +9105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:31.189653+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415281+00:00"
               },
               "deterministic": true
             },
@@ -9118,7 +9118,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.576849+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529595+00:00"
           },
           "platform": {
             "type": "string",
@@ -9136,7 +9136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189701+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9161,7 +9161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.189749+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9193,7 +9193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:31.189802+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415346+00:00"
               },
               "deterministic": true
             },
@@ -9324,7 +9324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:31.189878+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415416+00:00"
               },
               "deterministic": true
             },
@@ -9337,7 +9337,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.576952+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529648+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9549,7 +9549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.190094+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9594,7 +9594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:31.190135+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415554+00:00"
               },
               "deterministic": true
             },
@@ -9607,7 +9607,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.577093+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529722+00:00"
           }
         },
         "x-f5xc-description-short": "Request to test receiver & destination sink.",
@@ -9647,7 +9647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.190180+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9693,8 +9693,8 @@
           "description": "Minimum configuration for data_deliveryTestReceiverStatusType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for data_deliveryTestReceiverStatusType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for data_deliveryTestReceiverStatusType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/data_delivery_test_receiver_status_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -9729,7 +9729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.190220+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9767,7 +9767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:31.190257+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415624+00:00"
               },
               "deterministic": true
             },
@@ -9780,7 +9780,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.577158+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529755+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/shapedata_deliveryStatusType"
@@ -9824,7 +9824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.190294+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9850,7 +9850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.190344+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9876,7 +9876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.190387+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9888,7 +9888,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.577219+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529787+00:00"
           }
         },
         "x-f5xc-description-short": "Payload about status of receiver status result.",
@@ -9936,7 +9936,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:31.190472+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9970,7 +9970,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:31.190555+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10008,7 +10008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:31.190607+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415808+00:00"
               },
               "deterministic": true
             },
@@ -10021,7 +10021,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.577270+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529814+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -10067,7 +10067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:31.190652+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10116,7 +10116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:31.190712+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10128,7 +10128,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.577330+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529842+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -10146,7 +10146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.190763+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10175,7 +10175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.190806+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10187,7 +10187,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.577378+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529867+00:00"
           },
           "value": {
             "type": "string",
@@ -10203,7 +10203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:31.190847+00:00"
+                "validatedAt": "2026-05-09T01:34:48.415935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10215,7 +10215,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.577409+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.529911+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -10245,8 +10245,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10267,8 +10267,8 @@
           "description": "Minimum configuration for shapedata_deliveryStatusType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for shapedata_deliveryStatusType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for shapedata_deliveryStatusType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/shapedata_delivery_status_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "cdn"
@@ -10284,8 +10284,8 @@
           "description": "Minimum configuration for subscriptionSubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionSubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionSubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_subscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -10301,8 +10301,8 @@
           "description": "Minimum configuration for subscriptionSubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_subscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -10318,8 +10318,8 @@
           "description": "Minimum configuration for subscriptionUnsubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_unsubscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -10335,8 +10335,8 @@
           "description": "Minimum configuration for subscriptionUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"

--- a/docs/specifications/api/ddos.json
+++ b/docs/specifications/api/ddos.json
@@ -15792,7 +15792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.318406+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15869,7 +15869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.318490+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15895,7 +15895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.318537+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15934,7 +15934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.318599+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904592+00:00"
               },
               "deterministic": true
             },
@@ -15947,7 +15947,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.870740+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.076983+00:00"
           }
         },
         "x-f5xc-description-short": "Request to add an alert to event (link them together).",
@@ -15975,8 +15975,8 @@
           "description": "Minimum configuration for infraprotectAddAlertToEventResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotectAddAlertToEventResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotectAddAlertToEventResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_add_alert_to_event_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -16022,7 +16022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:23.318686+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16034,7 +16034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.870787+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077007+00:00"
           },
           "event_id": {
             "type": "string",
@@ -16052,7 +16052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.318735+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16091,7 +16091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.318773+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904671+00:00"
               },
               "deterministic": true
             },
@@ -16104,7 +16104,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.870828+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077028+00:00"
           },
           "time": {
             "type": "string",
@@ -16127,7 +16127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:18:23.318821+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904693+00:00"
               },
               "deterministic": true
             },
@@ -16153,7 +16153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.318862+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16165,7 +16165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.870868+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077049+00:00"
           }
         },
         "x-f5xc-description-short": "Request to add a single event detail to an event.",
@@ -16231,7 +16231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.318917+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16260,7 +16260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.318962+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16284,7 +16284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319006+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16313,7 +16313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319051+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16358,7 +16358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319097+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16384,7 +16384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319131+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16407,7 +16407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319178+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16439,7 +16439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319230+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16464,7 +16464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319269+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16521,7 +16521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319311+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16574,7 +16574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.319353+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904937+00:00"
               },
               "deterministic": true
             },
@@ -16587,7 +16587,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871047+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077166+00:00"
           },
           "number": {
             "type": "integer",
@@ -16621,7 +16621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319413+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16646,7 +16646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319456+00:00"
+                "validatedAt": "2026-05-09T01:36:04.904982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16701,7 +16701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:18:23.319499+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905003+00:00"
               },
               "deterministic": true
             },
@@ -16743,7 +16743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319551+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16770,7 +16770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319613+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16815,8 +16815,8 @@
           "description": "Minimum configuration for infraprotectAlertSourceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotectAlertSourceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotectAlertSourceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_alert_source_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -16843,7 +16843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319669+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16874,7 +16874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319716+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16900,7 +16900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319760+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16926,7 +16926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319809+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16965,7 +16965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.319847+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905151+00:00"
               },
               "deterministic": true
             },
@@ -16978,7 +16978,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871201+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077249+00:00"
           },
           "size_bytes": {
             "type": "string",
@@ -16997,7 +16997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319893+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17024,7 +17024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.319941+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17075,8 +17075,8 @@
           "description": "Minimum configuration for infraprotectAttachmentType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotectAttachmentType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotectAttachmentType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_attachment_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -17127,7 +17127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.320022+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17192,7 +17192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.320072+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905264+00:00"
               },
               "deterministic": true
             },
@@ -17205,7 +17205,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871306+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077304+00:00"
           },
           "time": {
             "type": "string",
@@ -17232,7 +17232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:18:23.320125+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905289+00:00"
               },
               "deterministic": true
             },
@@ -17284,7 +17284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:23.320166+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17329,8 +17329,8 @@
           "description": "Minimum configuration for infraprotectBgpPeerSessionState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotectBgpPeerSessionState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotectBgpPeerSessionState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_bgp_peer_session_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -17369,8 +17369,8 @@
           "description": "Minimum configuration for infraprotectDeleteEventDetailResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotectDeleteEventDetailResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotectDeleteEventDetailResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotects\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -17421,7 +17421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.320247+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905352+00:00"
               },
               "deterministic": true
             },
@@ -17434,7 +17434,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871377+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077341+00:00"
           },
           "zone1": {
             "$ref": "#/components/schemas/schemaEmpty"
@@ -17500,7 +17500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:23.320334+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17512,7 +17512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871439+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077373+00:00"
           },
           "event_detail_id": {
             "type": "string",
@@ -17529,7 +17529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.320387+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17556,7 +17556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.320433+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17595,7 +17595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.320470+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905448+00:00"
               },
               "deterministic": true
             },
@@ -17608,7 +17608,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871490+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077400+00:00"
           },
           "time": {
             "type": "string",
@@ -17631,7 +17631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:18:23.320519+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905479+00:00"
               },
               "deterministic": true
             },
@@ -17657,7 +17657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.320559+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17669,7 +17669,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871529+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077421+00:00"
           }
         },
         "x-f5xc-description-short": "Request to update a single event detail.",
@@ -17740,7 +17740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:23.320676+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17752,7 +17752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871574+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077444+00:00"
           },
           "end_time": {
             "type": "string",
@@ -17772,7 +17772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.320724+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17813,7 +17813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.320788+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17853,7 +17853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.320825+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905590+00:00"
               },
               "deterministic": true
             },
@@ -17866,7 +17866,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871649+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077475+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17896,7 +17896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.320861+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905607+00:00"
               },
               "deterministic": true
             },
@@ -17909,7 +17909,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871680+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077491+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17990,7 +17990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.320927+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18021,7 +18021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:23.320985+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18033,7 +18033,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871744+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077525+00:00"
           },
           "end_time": {
             "type": "string",
@@ -18052,7 +18052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321029+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18108,7 +18108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321068+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18133,7 +18133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321101+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18158,7 +18158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321152+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18198,7 +18198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.321188+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905757+00:00"
               },
               "deterministic": true
             },
@@ -18211,7 +18211,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871832+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077573+00:00"
           },
           "network_id": {
             "type": "string",
@@ -18228,7 +18228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321234+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18256,7 +18256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321280+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18328,7 +18328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321340+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18359,7 +18359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:23.321397+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18371,7 +18371,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871904+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077611+00:00"
           },
           "id": {
             "type": "string",
@@ -18391,7 +18391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321429+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18423,7 +18423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:18:23.321477+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905901+00:00"
               },
               "deterministic": true
             },
@@ -18449,7 +18449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321519+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18461,7 +18461,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871954+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077637+00:00"
           }
         },
         "x-f5xc-description-short": "Event detail represents a single occurrence of event detail, that tracks customer, SOC notes on a given event.",
@@ -18507,7 +18507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321552+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18547,7 +18547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.321602+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905959+00:00"
               },
               "deterministic": true
             },
@@ -18560,7 +18560,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.871996+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077659+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18675,7 +18675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321683+00:00"
+                "validatedAt": "2026-05-09T01:36:04.905995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18765,7 +18765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321750+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18792,7 +18792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321796+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18831,7 +18831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.321831+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906065+00:00"
               },
               "deterministic": true
             },
@@ -18844,7 +18844,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.872114+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077721+00:00"
           },
           "network_id": {
             "type": "string",
@@ -18863,7 +18863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321878+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18893,7 +18893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.321924+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19129,7 +19129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322051+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19156,7 +19156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322102+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19195,7 +19195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.322138+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906212+00:00"
               },
               "deterministic": true
             },
@@ -19208,7 +19208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.872245+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077797+00:00"
           },
           "network_id": {
             "type": "string",
@@ -19226,7 +19226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322184+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19256,7 +19256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322230+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19420,7 +19420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322320+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19469,7 +19469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322365+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19496,7 +19496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322414+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19535,7 +19535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.322450+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906357+00:00"
               },
               "deterministic": true
             },
@@ -19548,7 +19548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.872364+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077862+00:00"
           },
           "network_id": {
             "type": "string",
@@ -19567,7 +19567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322496+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19597,7 +19597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322542+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19684,7 +19684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:23.322620+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19734,7 +19734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322668+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19772,7 +19772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.322706+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906472+00:00"
               },
               "deterministic": true
             },
@@ -19785,7 +19785,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.872449+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077906+00:00"
           },
           "start_time": {
             "type": "string",
@@ -19806,7 +19806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322753+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19890,7 +19890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322816+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19915,7 +19915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322859+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19944,7 +19944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322902+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19971,7 +19971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.322933+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20024,7 +20024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.322973+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906593+00:00"
               },
               "deterministic": true
             },
@@ -20037,7 +20037,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.872551+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.077959+00:00"
           },
           "network_id": {
             "type": "string",
@@ -20053,7 +20053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323019+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20080,7 +20080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323068+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20105,7 +20105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323109+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20133,7 +20133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323158+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20187,7 +20187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323207+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20212,7 +20212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323249+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20240,7 +20240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323280+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20271,7 +20271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:18:23.323327+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906754+00:00"
               },
               "deterministic": true
             },
@@ -20320,7 +20320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323359+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20348,7 +20348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323404+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20397,7 +20397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323436+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20436,7 +20436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.323472+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906830+00:00"
               },
               "deterministic": true
             },
@@ -20449,7 +20449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.872706+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078033+00:00"
           },
           "prefixes": {
             "$ref": "#/components/schemas/schemaPrefixListType"
@@ -20515,7 +20515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:18:23.323533+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906858+00:00"
               },
               "deterministic": true
             },
@@ -20542,7 +20542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323576+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20569,7 +20569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323620+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20608,7 +20608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.323656+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906908+00:00"
               },
               "deterministic": true
             },
@@ -20621,7 +20621,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.872789+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078076+00:00"
           },
           "scheduled": {
             "type": "boolean",
@@ -20652,7 +20652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323709+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20677,7 +20677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323747+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20703,7 +20703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.323789+00:00"
+                "validatedAt": "2026-05-09T01:36:04.906967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20715,7 +20715,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.872847+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078107+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20767,7 +20767,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.323878+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20801,7 +20801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.323960+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20839,7 +20839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.323999+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907065+00:00"
               },
               "deterministic": true
             },
@@ -20852,7 +20852,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.872900+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078134+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -20935,8 +20935,8 @@
           "description": "Minimum configuration for infraprotectTransitUsageLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotectTransitUsageLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotectTransitUsageLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_transit_usage_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -20971,7 +20971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324072+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21016,7 +21016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.324141+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21043,7 +21043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324183+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21096,7 +21096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.324236+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907181+00:00"
               },
               "deterministic": true
             },
@@ -21109,7 +21109,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873015+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078206+00:00"
           },
           "range": {
             "type": "string",
@@ -21134,7 +21134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324280+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21167,7 +21167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324330+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21200,7 +21200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324371+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21277,7 +21277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324427+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21319,8 +21319,8 @@
           "description": "Minimum configuration for infraprotectTransitUsageType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotectTransitUsageType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotectTransitUsageType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_transit_usage_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -21348,7 +21348,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873101+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078251+00:00"
           },
           "value": {
             "type": "array",
@@ -21367,7 +21367,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873133+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078269+00:00"
           }
         },
         "x-f5xc-description-short": "Transit Usage Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -21402,7 +21402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324494+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21425,7 +21425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324536+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21437,7 +21437,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873178+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078292+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -21465,8 +21465,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21532,7 +21532,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.324631+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21586,7 +21586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.324701+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21650,7 +21650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324766+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21662,7 +21662,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873277+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078343+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -21715,7 +21715,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.324825+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21757,8 +21757,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21790,7 +21790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:23.324887+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21802,7 +21802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873323+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078366+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -21820,7 +21820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324937+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21848,7 +21848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.324980+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21860,7 +21860,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873372+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078392+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -21921,8 +21921,8 @@
           "description": "Minimum configuration for schemaUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21952,7 +21952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:23.325021+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22001,7 +22001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:23.325080+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22013,7 +22013,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873420+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078416+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -22031,7 +22031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.325129+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22058,7 +22058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:23.325169+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22070,7 +22070,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873470+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078445+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -22139,7 +22139,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.325248+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907670+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22155,7 +22155,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873502+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078465+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22192,7 +22192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.325317+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907703+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22208,7 +22208,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873532+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078480+00:00"
           },
           "tenant": {
             "type": "string",
@@ -22237,7 +22237,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:23.325390+00:00"
+                "validatedAt": "2026-05-09T01:36:04.907740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22251,7 +22251,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.873562+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.078498+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -22291,8 +22291,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asnCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asnCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asns\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -22430,7 +22430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.699236+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957461+00:00"
               },
               "deterministic": true
             },
@@ -22443,7 +22443,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.958809+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120166+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22473,7 +22473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.699284+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957483+00:00"
               },
               "deterministic": true
             },
@@ -22486,7 +22486,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.958841+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120182+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22589,7 +22589,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.958942+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120235+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22725,7 +22725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:25.699468+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22788,7 +22788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:25.699541+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22800,7 +22800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959077+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120305+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22866,7 +22866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.699632+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957609+00:00"
               },
               "deterministic": true
             },
@@ -22879,7 +22879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959147+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120342+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22908,7 +22908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.699679+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957627+00:00"
               },
               "deterministic": true
             },
@@ -22921,7 +22921,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959176+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120358+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -22960,7 +22960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.699750+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22973,7 +22973,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959234+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120388+00:00"
           },
           "uid": {
             "type": "string",
@@ -22991,7 +22991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.699785+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23005,7 +23005,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959265+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120404+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_asn is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23055,8 +23055,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asnReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asnReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asn_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -23068,8 +23068,8 @@
           "description": "Minimum configuration for infraprotect_asnReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asnReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asnReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asn_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -23084,8 +23084,8 @@
           "description": "Minimum configuration for infraprotect_asnReplaceSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asnReplaceSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asnReplaceSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asn_replace_spec_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -23183,7 +23183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.699872+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957707+00:00"
               },
               "deterministic": true
             },
@@ -23196,7 +23196,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959354+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120455+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23233,7 +23233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.699920+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957728+00:00"
               },
               "deterministic": true
             },
@@ -23246,7 +23246,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959384+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120470+00:00"
           },
           "review_type_approved": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -23286,8 +23286,8 @@
           "description": "Minimum configuration for infraprotect_asnUpdateASNReviewStatusResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asnUpdateASNReviewStatusResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asnUpdateASNReviewStatusResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asns\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -23302,8 +23302,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -23336,7 +23336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:18:25.700066+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957791+00:00"
               },
               "deterministic": true
             },
@@ -23362,7 +23362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.700119+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23389,7 +23389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.700162+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23401,7 +23401,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959509+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120539+00:00"
           },
           "service_name": {
             "type": "string",
@@ -23418,7 +23418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.700213+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23451,7 +23451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.700260+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23463,7 +23463,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959548+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120559+00:00"
           },
           "type": {
             "type": "string",
@@ -23488,7 +23488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.700304+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23542,8 +23542,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -23576,7 +23576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.700358+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23638,7 +23638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.700395+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957931+00:00"
               },
               "deterministic": true
             },
@@ -23651,7 +23651,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959639+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120598+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -23769,7 +23769,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.700523+00:00"
+                "validatedAt": "2026-05-09T01:36:05.957988+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -23785,7 +23785,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959706+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120631+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -23855,7 +23855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.700574+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958009+00:00"
               },
               "deterministic": true
             },
@@ -23868,7 +23868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959758+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120664+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23899,7 +23899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.700652+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958025+00:00"
               },
               "deterministic": true
             },
@@ -23912,7 +23912,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959787+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120680+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -23994,7 +23994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.700758+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958079+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24010,7 +24010,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959831+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120702+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24082,7 +24082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.700807+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958100+00:00"
               },
               "deterministic": true
             },
@@ -24095,7 +24095,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959883+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120729+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24126,7 +24126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.700843+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958117+00:00"
               },
               "deterministic": true
             },
@@ -24139,7 +24139,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959912+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120744+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -24184,7 +24184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.700883+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24197,7 +24197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959944+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120761+00:00"
           },
           "name": {
             "type": "string",
@@ -24230,7 +24230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.700919+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958164+00:00"
               },
               "deterministic": true
             },
@@ -24243,7 +24243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.959974+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120776+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24274,7 +24274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.700955+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958182+00:00"
               },
               "deterministic": true
             },
@@ -24287,7 +24287,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960003+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120791+00:00"
           },
           "tenant": {
             "type": "string",
@@ -24306,7 +24306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.700998+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24320,7 +24320,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960032+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120807+00:00"
           },
           "uid": {
             "type": "string",
@@ -24339,7 +24339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701030+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24354,7 +24354,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960063+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120823+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -24436,7 +24436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.701131+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958266+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24452,7 +24452,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960107+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120845+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24522,7 +24522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.701180+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958288+00:00"
               },
               "deterministic": true
             },
@@ -24535,7 +24535,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960157+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120871+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24566,7 +24566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.701218+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958306+00:00"
               },
               "deterministic": true
             },
@@ -24579,7 +24579,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960187+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120887+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -24624,7 +24624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701275+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24652,7 +24652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701326+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24680,7 +24680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701374+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24709,7 +24709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701424+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24736,7 +24736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701457+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24750,7 +24750,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960268+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120928+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -24766,7 +24766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701501+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24829,8 +24829,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -24875,7 +24875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701564+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24887,7 +24887,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960331+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120961+00:00"
           },
           "status": {
             "type": "string",
@@ -24905,7 +24905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701642+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24917,7 +24917,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960360+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.120976+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -24959,7 +24959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701703+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24986,7 +24986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701755+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25013,7 +25013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701803+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25041,7 +25041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701856+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25106,7 +25106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.701936+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25155,7 +25155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.702000+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25168,7 +25168,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960489+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.121044+00:00"
           },
           "uid": {
             "type": "string",
@@ -25187,7 +25187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.702033+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25201,7 +25201,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960519+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.121060+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -25251,7 +25251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.702072+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25263,7 +25263,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960550+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.121076+00:00"
           },
           "name": {
             "type": "string",
@@ -25296,7 +25296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.702109+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958682+00:00"
               },
               "deterministic": true
             },
@@ -25309,7 +25309,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960579+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.121092+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25340,7 +25340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:25.702146+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958699+00:00"
               },
               "deterministic": true
             },
@@ -25353,7 +25353,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960621+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.121107+00:00"
           },
           "uid": {
             "type": "string",
@@ -25370,7 +25370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:25.702179+00:00"
+                "validatedAt": "2026-05-09T01:36:05.958713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25384,7 +25384,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.960652+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.121123+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -25424,8 +25424,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asn_prefixCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asn_prefixCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asn_prefixs\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -25491,7 +25491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:32.658737+00:00"
+                "validatedAt": "2026-05-09T01:36:09.050730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25565,7 +25565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.658816+00:00"
+                "validatedAt": "2026-05-09T01:36:09.050764+00:00"
               },
               "deterministic": true
             },
@@ -25578,7 +25578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.119981+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.190847+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25608,7 +25608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.658858+00:00"
+                "validatedAt": "2026-05-09T01:36:09.050782+00:00"
               },
               "deterministic": true
             },
@@ -25621,7 +25621,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120014+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.190864+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25724,7 +25724,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120115+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.190916+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -25808,7 +25808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:32.659037+00:00"
+                "validatedAt": "2026-05-09T01:36:09.050858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25856,7 +25856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:32.659122+00:00"
+                "validatedAt": "2026-05-09T01:36:09.050900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25935,7 +25935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:32.659187+00:00"
+                "validatedAt": "2026-05-09T01:36:09.050927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25998,7 +25998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:32.659258+00:00"
+                "validatedAt": "2026-05-09T01:36:09.050960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26010,7 +26010,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120336+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191033+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26077,7 +26077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.659311+00:00"
+                "validatedAt": "2026-05-09T01:36:09.050984+00:00"
               },
               "deterministic": true
             },
@@ -26090,7 +26090,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120407+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191070+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26119,7 +26119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.659347+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051004+00:00"
               },
               "deterministic": true
             },
@@ -26132,7 +26132,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120436+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191085+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26171,7 +26171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:32.659416+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26184,7 +26184,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120495+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191116+00:00"
           },
           "uid": {
             "type": "string",
@@ -26202,7 +26202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:32.659450+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26216,7 +26216,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120526+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191132+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_asn_prefix is returned in 'List'.",
@@ -26266,8 +26266,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asn_prefixReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asn_prefixReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asn_prefix_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -26279,8 +26279,8 @@
           "description": "Minimum configuration for infraprotect_asn_prefixReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asn_prefixReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asn_prefixReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asn_prefix_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -26295,8 +26295,8 @@
           "description": "Minimum configuration for infraprotect_asn_prefixReplaceSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asn_prefixReplaceSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asn_prefixReplaceSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asn_prefix_replace_spec_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -26394,7 +26394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.659537+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051092+00:00"
               },
               "deterministic": true
             },
@@ -26407,7 +26407,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120629+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191183+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26444,7 +26444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.659577+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051111+00:00"
               },
               "deterministic": true
             },
@@ -26457,7 +26457,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120659+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191199+00:00"
           }
         },
         "x-f5xc-description-short": "Request to update infraprotect ASN irr override status.",
@@ -26485,8 +26485,8 @@
           "description": "Minimum configuration for infraprotect_asn_prefixUpdateASNPrefixIRROverrideResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asn_prefixUpdateASNPrefixIRROverrideResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asn_prefixUpdateASNPrefixIRROverrideResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asn_prefixs\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -26529,7 +26529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.659632+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051128+00:00"
               },
               "deterministic": true
             },
@@ -26542,7 +26542,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120692+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191216+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26579,7 +26579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.659671+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051145+00:00"
               },
               "deterministic": true
             },
@@ -26592,7 +26592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120722+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191231+00:00"
           },
           "review_type_approved": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -26632,8 +26632,8 @@
           "description": "Minimum configuration for infraprotect_asn_prefixUpdateASNPrefixReviewStatusResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_asn_prefixUpdateASNPrefixReviewStatusResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_asn_prefixUpdateASNPrefixReviewStatusResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_asn_prefixs\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -26662,7 +26662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:32.659723+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26675,7 +26675,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120786+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191264+00:00"
           },
           "name": {
             "type": "string",
@@ -26708,7 +26708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.659759+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051195+00:00"
               },
               "deterministic": true
             },
@@ -26721,7 +26721,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120815+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191280+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26752,7 +26752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:32.659796+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051214+00:00"
               },
               "deterministic": true
             },
@@ -26765,7 +26765,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120844+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191296+00:00"
           },
           "tenant": {
             "type": "string",
@@ -26784,7 +26784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:32.659840+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26798,7 +26798,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120874+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191311+00:00"
           },
           "uid": {
             "type": "string",
@@ -26817,7 +26817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:32.659873+00:00"
+                "validatedAt": "2026-05-09T01:36:09.051248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26832,7 +26832,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.120904+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.191328+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -26874,8 +26874,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_deny_list_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_deny_list_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_deny_list_rules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -26935,7 +26935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:34.930854+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26987,7 +26987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:34.930944+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27066,7 +27066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:34.930998+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064074+00:00"
               },
               "deterministic": true
             },
@@ -27079,7 +27079,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.165845+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.213241+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27109,7 +27109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:34.931040+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064093+00:00"
               },
               "deterministic": true
             },
@@ -27122,7 +27122,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.165878+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.213258+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27225,7 +27225,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.165979+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.213310+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -27278,7 +27278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:34.931193+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27314,7 +27314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:34.931246+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27381,7 +27381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:34.931304+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27444,7 +27444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:34.931374+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27456,7 +27456,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.166087+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.213367+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27523,7 +27523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:34.931428+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064288+00:00"
               },
               "deterministic": true
             },
@@ -27536,7 +27536,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.166157+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.213405+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27565,7 +27565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:34.931466+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064307+00:00"
               },
               "deterministic": true
             },
@@ -27578,7 +27578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.166186+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.213420+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27617,7 +27617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:34.931534+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27630,7 +27630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.166244+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.213451+00:00"
           },
           "uid": {
             "type": "string",
@@ -27648,7 +27648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:34.931568+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27662,7 +27662,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.166275+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.213467+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_deny_list_rule is returned in 'List'.",
@@ -27712,8 +27712,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_deny_list_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_deny_list_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_deny_list_rule_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -27725,8 +27725,8 @@
           "description": "Minimum configuration for infraprotect_deny_list_ruleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_deny_list_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_deny_list_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_deny_list_rule_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -27758,7 +27758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:34.931654+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27810,7 +27810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:34.931717+00:00"
+                "validatedAt": "2026-05-09T01:36:10.064407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27915,8 +27915,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_firewall_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_firewall_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_firewall_rules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -27991,7 +27991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.591346+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28059,7 +28059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.591547+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28167,7 +28167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:39.591673+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133262+00:00"
               },
               "deterministic": true
             },
@@ -28180,7 +28180,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.251871+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253083+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28210,7 +28210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:39.591719+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133281+00:00"
               },
               "deterministic": true
             },
@@ -28223,7 +28223,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.251905+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253100+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28326,7 +28326,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.252004+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253157+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -28394,7 +28394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.591891+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28462,7 +28462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.591996+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28854,7 +28854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:39.592147+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28917,7 +28917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:39.592218+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28929,7 +28929,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.252457+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253397+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -28996,7 +28996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:39.592272+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133498+00:00"
               },
               "deterministic": true
             },
@@ -29009,7 +29009,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.252527+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253434+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29038,7 +29038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:39.592313+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133516+00:00"
               },
               "deterministic": true
             },
@@ -29051,7 +29051,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.252556+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253450+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -29090,7 +29090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.592382+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29103,7 +29103,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.252627+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253480+00:00"
           },
           "uid": {
             "type": "string",
@@ -29121,7 +29121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.592416+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29135,7 +29135,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.252660+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253497+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_firewall_rule is returned in 'List'.",
@@ -29185,8 +29185,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_firewall_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_firewall_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_firewall_rule_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -29198,8 +29198,8 @@
           "description": "Minimum configuration for infraprotect_firewall_ruleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_firewall_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_firewall_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_firewall_rule_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -29246,7 +29246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.592501+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29314,7 +29314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.592637+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29453,7 +29453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:39.592787+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29465,7 +29465,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.252941+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253684+00:00"
           },
           "destination_port_all": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -29491,7 +29491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.592857+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29528,7 +29528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.592919+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29585,7 +29585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:39.592983+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29597,7 +29597,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.253012+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.253724+00:00"
           },
           "destination_port_all": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -29623,7 +29623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.593049+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29660,7 +29660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:39.593110+00:00"
+                "validatedAt": "2026-05-09T01:36:12.133813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29712,8 +29712,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_firewall_rule_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_firewall_rule_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_firewall_rule_groups\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -29774,7 +29774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:45.980472+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29848,7 +29848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:45.980551+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964444+00:00"
               },
               "deterministic": true
             },
@@ -29861,7 +29861,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.346624+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.297846+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29891,7 +29891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:45.980627+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964463+00:00"
               },
               "deterministic": true
             },
@@ -29904,7 +29904,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.346658+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.297863+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -30007,7 +30007,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.346758+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.297924+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -30061,7 +30061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:45.980794+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30096,7 +30096,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:45.980865+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30162,7 +30162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:45.980932+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30225,7 +30225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:45.981003+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964614+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30237,7 +30237,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.346857+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.297977+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -30304,7 +30304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:45.981058+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964637+00:00"
               },
               "deterministic": true
             },
@@ -30317,7 +30317,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.346927+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.298014+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30346,7 +30346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:45.981095+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964654+00:00"
               },
               "deterministic": true
             },
@@ -30359,7 +30359,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.346957+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.298030+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -30398,7 +30398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:45.981165+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30411,7 +30411,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.347014+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.298060+00:00"
           },
           "uid": {
             "type": "string",
@@ -30429,7 +30429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:45.981199+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30443,7 +30443,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.347045+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.298076+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_firewall_rule_group is returned in 'List'.",
@@ -30493,8 +30493,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_firewall_rule_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_firewall_rule_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_firewall_rule_group_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -30506,8 +30506,8 @@
           "description": "Minimum configuration for infraprotect_firewall_rule_groupReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_firewall_rule_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_firewall_rule_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_firewall_rule_group_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -30540,7 +30540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:45.981272+00:00"
+                "validatedAt": "2026-05-09T01:36:14.964727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30643,7 +30643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.011051+00:00"
+                "validatedAt": "2026-05-09T01:36:16.303918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30671,7 +30671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.011094+00:00"
+                "validatedAt": "2026-05-09T01:36:16.303938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30696,7 +30696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.011133+00:00"
+                "validatedAt": "2026-05-09T01:36:16.303955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30747,7 +30747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.011515+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30791,7 +30791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.011573+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30840,8 +30840,8 @@
           "description": "Minimum configuration for infraprotectAlertTcpFlagType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotectAlertTcpFlagType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotectAlertTcpFlagType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_alert_tcp_flag_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -30868,7 +30868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012185+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30915,7 +30915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012230+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30962,7 +30962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012277+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31009,7 +31009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012322+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31056,7 +31056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012368+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31103,7 +31103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012413+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31150,7 +31150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012458+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31197,7 +31197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012503+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31243,7 +31243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012548+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31290,7 +31290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012606+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31337,7 +31337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012654+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31383,7 +31383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012700+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31430,7 +31430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012747+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31477,7 +31477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012791+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31524,7 +31524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012836+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31571,7 +31571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012881+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31618,7 +31618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012927+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31665,7 +31665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.012972+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31712,7 +31712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013017+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31759,7 +31759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013062+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31806,7 +31806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013106+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31853,7 +31853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013151+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31900,7 +31900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013195+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31946,7 +31946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013239+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31993,7 +31993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013285+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32040,7 +32040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013329+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32087,7 +32087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013375+00:00"
+                "validatedAt": "2026-05-09T01:36:16.304985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32134,7 +32134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013420+00:00"
+                "validatedAt": "2026-05-09T01:36:16.305005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32181,7 +32181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013465+00:00"
+                "validatedAt": "2026-05-09T01:36:16.305025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32228,7 +32228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:49.013510+00:00"
+                "validatedAt": "2026-05-09T01:36:16.305048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32475,7 +32475,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.502386+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.372556+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -32533,7 +32533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:51.304075+00:00"
+                "validatedAt": "2026-05-09T01:36:17.318623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32606,7 +32606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:51.304207+00:00"
+                "validatedAt": "2026-05-09T01:36:17.318656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32669,7 +32669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:51.304309+00:00"
+                "validatedAt": "2026-05-09T01:36:17.318689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32681,7 +32681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.502500+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.372613+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -32748,7 +32748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:51.304366+00:00"
+                "validatedAt": "2026-05-09T01:36:17.318713+00:00"
               },
               "deterministic": true
             },
@@ -32761,7 +32761,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.502572+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.372651+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32790,7 +32790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:51.304405+00:00"
+                "validatedAt": "2026-05-09T01:36:17.318730+00:00"
               },
               "deterministic": true
             },
@@ -32803,7 +32803,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.502628+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.372666+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -32842,7 +32842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:51.304478+00:00"
+                "validatedAt": "2026-05-09T01:36:17.318762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32855,7 +32855,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.502689+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.372697+00:00"
           },
           "uid": {
             "type": "string",
@@ -32873,7 +32873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:51.304513+00:00"
+                "validatedAt": "2026-05-09T01:36:17.318776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32887,7 +32887,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.502720+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.372713+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_firewall_ruleset is returned in 'List'.",
@@ -32937,8 +32937,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_firewall_rulesetReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_firewall_rulesetReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_firewall_ruleset_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -32950,8 +32950,8 @@
           "description": "Minimum configuration for infraprotect_firewall_rulesetReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_firewall_rulesetReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_firewall_rulesetReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_firewall_ruleset_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -32988,7 +32988,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:51.304606+00:00"
+                "validatedAt": "2026-05-09T01:36:17.318811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33146,7 +33146,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.577187+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.407623+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -33195,7 +33195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:55.700802+00:00"
+                "validatedAt": "2026-05-09T01:36:19.257467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33268,7 +33268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:55.701010+00:00"
+                "validatedAt": "2026-05-09T01:36:19.257520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33315,7 +33315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:55.701086+00:00"
+                "validatedAt": "2026-05-09T01:36:19.257551+00:00"
               },
               "deterministic": true
             },
@@ -33475,7 +33475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:55.701214+00:00"
+                "validatedAt": "2026-05-09T01:36:19.257603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33513,7 +33513,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:55.701298+00:00"
+                "validatedAt": "2026-05-09T01:36:19.257642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33525,7 +33525,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.577449+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.407755+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -33544,7 +33544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:55.701355+00:00"
+                "validatedAt": "2026-05-09T01:36:19.257666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33595,7 +33595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:55.701402+00:00"
+                "validatedAt": "2026-05-09T01:36:19.257686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33607,7 +33607,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.577492+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.407778+00:00"
           },
           "url": {
             "type": "string",
@@ -33645,7 +33645,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:55.701487+00:00"
+                "validatedAt": "2026-05-09T01:36:19.257726+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -33689,8 +33689,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -33745,8 +33745,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_internet_prefix_advertisementCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_internet_prefix_advertisementCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_internet_prefix_advertisements\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -33813,7 +33813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:00.366323+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33850,7 +33850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:00.366396+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33927,7 +33927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:00.366454+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546492+00:00"
               },
               "deterministic": true
             },
@@ -33940,7 +33940,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.654564+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444130+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33970,7 +33970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:00.366494+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546510+00:00"
               },
               "deterministic": true
             },
@@ -33983,7 +33983,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.654614+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444147+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34086,7 +34086,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.654718+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444206+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -34146,7 +34146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:00.366674+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34183,7 +34183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:00.366728+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34252,7 +34252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:19:00.366787+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34315,7 +34315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:00.366858+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34327,7 +34327,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.654847+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444272+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34394,7 +34394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:00.366912+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546681+00:00"
               },
               "deterministic": true
             },
@@ -34407,7 +34407,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.654918+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444309+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34436,7 +34436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:00.366951+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546698+00:00"
               },
               "deterministic": true
             },
@@ -34449,7 +34449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.654948+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444325+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -34488,7 +34488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:00.367017+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34501,7 +34501,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.655007+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444356+00:00"
           },
           "uid": {
             "type": "string",
@@ -34519,7 +34519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:00.367052+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34533,7 +34533,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.655038+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444372+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_internet_prefix_advertisement is returned in 'List'.",
@@ -34583,8 +34583,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_internet_prefix_advertisementReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_internet_prefix_advertisementReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_internet_prefix_advertisement_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -34596,8 +34596,8 @@
           "description": "Minimum configuration for infraprotect_internet_prefix_advertisementReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_internet_prefix_advertisementReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_internet_prefix_advertisementReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_internet_prefix_advertisement_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -34636,7 +34636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:00.367127+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34771,7 +34771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:00.367214+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546816+00:00"
               },
               "deterministic": true
             },
@@ -34784,7 +34784,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.655186+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444447+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34821,7 +34821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:00.367254+00:00"
+                "validatedAt": "2026-05-09T01:36:21.546834+00:00"
               },
               "deterministic": true
             },
@@ -34834,7 +34834,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.655217+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.444463+00:00"
           }
         },
         "x-f5xc-description-short": "Request to toggle Internet prefix advertisement announcement/withdrawal.",
@@ -34860,8 +34860,8 @@
           "description": "Minimum configuration for infraprotect_internet_prefix_advertisementUpdateInternetPrefixAdvertisementResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_internet_prefix_advertisementUpdateInternetPrefixAdvertisementResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_internet_prefix_advertisementUpdateInternetPrefixAdvertisementResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_internet_prefix_advertisements\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -34991,8 +34991,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_tunnelCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_tunnelCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_tunnels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -35127,7 +35127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:04.747908+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557380+00:00"
               },
               "deterministic": true
             },
@@ -35140,7 +35140,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.061669+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.301857+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35170,7 +35170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:04.747994+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557402+00:00"
               },
               "deterministic": true
             },
@@ -35183,7 +35183,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.061705+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.301874+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35286,7 +35286,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.061805+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.301926+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -35356,7 +35356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748188+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35384,7 +35384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748252+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35408,7 +35408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748305+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35436,7 +35436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748367+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35464,7 +35464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748427+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35513,7 +35513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748488+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35615,7 +35615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748579+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35695,7 +35695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748683+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35758,7 +35758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748752+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35813,7 +35813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.748815+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35846,8 +35846,8 @@
           "description": "Minimum configuration for infraprotect_tunnelL2DirectConnectTunnel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_tunnelL2DirectConnectTunnel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_tunnelL2DirectConnectTunnel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_tunnel_l2_direct_connect_tunnels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -35862,8 +35862,8 @@
           "description": "Minimum configuration for infraprotect_tunnelL2EquinixTunnel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_tunnelL2EquinixTunnel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_tunnelL2EquinixTunnel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_tunnel_l2_equinix_tunnels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -35878,8 +35878,8 @@
           "description": "Minimum configuration for infraprotect_tunnelL2MegaportTunnel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_tunnelL2MegaportTunnel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_tunnelL2MegaportTunnel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_tunnel_l2_megaport_tunnels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -35894,8 +35894,8 @@
           "description": "Minimum configuration for infraprotect_tunnelL2PacketFabricTunnel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_tunnelL2PacketFabricTunnel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_tunnelL2PacketFabricTunnel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_tunnel_l2_packet_fabric_tunnels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -35942,7 +35942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:27:04.748877+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36005,7 +36005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:04.748951+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36017,7 +36017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.062216+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.302138+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -36083,7 +36083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:04.749006+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557811+00:00"
               },
               "deterministic": true
             },
@@ -36096,7 +36096,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.062288+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.302179+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36125,7 +36125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:04.749045+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557827+00:00"
               },
               "deterministic": true
             },
@@ -36138,7 +36138,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.062317+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.302195+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -36177,7 +36177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.749111+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36190,7 +36190,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.062375+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.302226+00:00"
           },
           "uid": {
             "type": "string",
@@ -36208,7 +36208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.749147+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36222,7 +36222,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.062406+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.302243+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_tunnel is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -36272,8 +36272,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_tunnelReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_tunnelReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_tunnel_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -36285,8 +36285,8 @@
           "description": "Minimum configuration for infraprotect_tunnelReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_tunnelReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_tunnelReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_tunnel_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -36437,7 +36437,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:04.749295+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557933+00:00"
               },
               "deterministic": true
             },
@@ -36450,7 +36450,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.062550+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.302318+00:00"
           },
           "zone1": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -36493,8 +36493,8 @@
           "description": "Minimum configuration for infraprotect_tunnelTunnelStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_tunnelTunnelStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_tunnelTunnelStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_tunnel_tunnel_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"
@@ -36541,7 +36541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:04.749345+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557955+00:00"
               },
               "deterministic": true
             },
@@ -36554,7 +36554,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.062638+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.302346+00:00"
           },
           "tunnel_id": {
             "type": "string",
@@ -36579,7 +36579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:04.749395+00:00"
+                "validatedAt": "2026-05-09T01:40:00.557976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36619,8 +36619,8 @@
           "description": "Minimum configuration for infraprotect_tunnelUpdateTunnelStatusResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for infraprotect_tunnelUpdateTunnelStatusResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for infraprotect_tunnelUpdateTunnelStatusResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/infraprotect_tunnels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "ddos"

--- a/docs/specifications/api/dns.json
+++ b/docs/specifications/api/dns.json
@@ -13172,8 +13172,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_compliance_checksCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_compliance_checksCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_compliance_checkses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -13238,7 +13238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.010710+00:00"
+                "validatedAt": "2026-05-09T01:33:49.565822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13273,7 +13273,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.010840+00:00"
+                "validatedAt": "2026-05-09T01:33:49.565859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13316,7 +13316,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.010958+00:00"
+                "validatedAt": "2026-05-09T01:33:49.565890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13362,8 +13362,8 @@
           "description": "Minimum configuration for dns_compliance_checksDNSComplianceChecksDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_compliance_checksDNSComplianceChecksDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_compliance_checksDNSComplianceChecksDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_compliance_checks_d_n_s_compliance_checks_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -13441,7 +13441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011028+00:00"
+                "validatedAt": "2026-05-09T01:33:49.565919+00:00"
               },
               "deterministic": true
             },
@@ -13454,7 +13454,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.996630+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821035+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13484,7 +13484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011071+00:00"
+                "validatedAt": "2026-05-09T01:33:49.565938+00:00"
               },
               "deterministic": true
             },
@@ -13497,7 +13497,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.996664+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821052+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13534,8 +13534,8 @@
           "description": "Minimum configuration for dns_compliance_checksDisallowedQueryType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_compliance_checksDisallowedQueryType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_compliance_checksDisallowedQueryType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_compliance_checks_disallowed_query_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -13638,8 +13638,8 @@
           "description": "Minimum configuration for dns_compliance_checksDisallowedResourceRecordType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_compliance_checksDisallowedResourceRecordType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_compliance_checksDisallowedResourceRecordType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_compliance_checks_disallowed_resource_record_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -13730,7 +13730,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.996769+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821114+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -13788,7 +13788,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011242+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13823,7 +13823,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011312+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13866,7 +13866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011375+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13949,7 +13949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:13:18.011454+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14012,7 +14012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:18.011536+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14024,7 +14024,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.996886+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821195+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14090,7 +14090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011612+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566164+00:00"
               },
               "deterministic": true
             },
@@ -14103,7 +14103,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.996956+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821233+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14132,7 +14132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011652+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566182+00:00"
               },
               "deterministic": true
             },
@@ -14145,7 +14145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.996986+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821249+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -14184,7 +14184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.011725+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14197,7 +14197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997043+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821282+00:00"
           },
           "uid": {
             "type": "string",
@@ -14215,7 +14215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.011760+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14229,7 +14229,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997074+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821298+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_compliance_checks is returned in 'List'.",
@@ -14279,8 +14279,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_compliance_checksReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_compliance_checksReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_compliance_checks_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -14292,8 +14292,8 @@
           "description": "Minimum configuration for dns_compliance_checksReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_compliance_checksReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_compliance_checksReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_compliance_checks_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -14330,7 +14330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011841+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14365,7 +14365,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011913+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14408,7 +14408,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.011977+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14519,7 +14519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012064+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14532,7 +14532,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997201+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821365+00:00"
           },
           "name": {
             "type": "string",
@@ -14565,7 +14565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.012105+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566372+00:00"
               },
               "deterministic": true
             },
@@ -14578,7 +14578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997230+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821381+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14609,7 +14609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.012144+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566390+00:00"
               },
               "deterministic": true
             },
@@ -14622,7 +14622,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997259+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821397+00:00"
           },
           "tenant": {
             "type": "string",
@@ -14641,7 +14641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012189+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14655,7 +14655,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997289+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821413+00:00"
           },
           "uid": {
             "type": "string",
@@ -14674,7 +14674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012223+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14689,7 +14689,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997319+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821429+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -14727,7 +14727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012272+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14750,7 +14750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012316+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14762,7 +14762,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997362+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821451+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -14808,7 +14808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:13:18.012362+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566482+00:00"
               },
               "deterministic": true
             },
@@ -14834,7 +14834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012420+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14861,7 +14861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012465+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14873,7 +14873,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997413+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821479+00:00"
           },
           "service_name": {
             "type": "string",
@@ -14890,7 +14890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012517+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14923,7 +14923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012571+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14935,7 +14935,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997452+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821500+00:00"
           },
           "type": {
             "type": "string",
@@ -14960,7 +14960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012634+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15014,8 +15014,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -15048,7 +15048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.012690+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15110,7 +15110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.012732+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566621+00:00"
               },
               "deterministic": true
             },
@@ -15123,7 +15123,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997526+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821538+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -15241,7 +15241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.012863+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566676+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15257,7 +15257,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997611+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821572+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15327,7 +15327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.012917+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566698+00:00"
               },
               "deterministic": true
             },
@@ -15340,7 +15340,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997663+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821599+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15371,7 +15371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.012954+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566714+00:00"
               },
               "deterministic": true
             },
@@ -15384,7 +15384,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997692+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821615+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -15466,7 +15466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.013056+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566760+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15482,7 +15482,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997736+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821638+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15554,7 +15554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.013106+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566781+00:00"
               },
               "deterministic": true
             },
@@ -15567,7 +15567,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997786+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821665+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15598,7 +15598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.013143+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566797+00:00"
               },
               "deterministic": true
             },
@@ -15611,7 +15611,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997815+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821680+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -15693,7 +15693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.013242+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566842+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15709,7 +15709,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997859+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821705+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15779,7 +15779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.013291+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566864+00:00"
               },
               "deterministic": true
             },
@@ -15792,7 +15792,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997908+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821733+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15823,7 +15823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.013327+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566880+00:00"
               },
               "deterministic": true
             },
@@ -15836,7 +15836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.997937+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821748+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -15881,7 +15881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013385+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15909,7 +15909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013438+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15937,7 +15937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013487+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15966,7 +15966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013539+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15993,7 +15993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013573+00:00"
+                "validatedAt": "2026-05-09T01:33:49.566981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16007,7 +16007,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998016+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821791+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -16023,7 +16023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013634+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16086,8 +16086,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -16132,7 +16132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013700+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16144,7 +16144,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998077+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821823+00:00"
           },
           "status": {
             "type": "string",
@@ -16162,7 +16162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013744+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16174,7 +16174,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998106+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821839+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -16216,7 +16216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013802+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16243,7 +16243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013854+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16270,7 +16270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013904+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16298,7 +16298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.013959+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16363,7 +16363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.014045+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16412,7 +16412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.014110+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16425,7 +16425,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998234+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821907+00:00"
           },
           "uid": {
             "type": "string",
@@ -16444,7 +16444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.014144+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16458,7 +16458,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998263+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821923+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -16508,7 +16508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.014186+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16520,7 +16520,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998295+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821940+00:00"
           },
           "name": {
             "type": "string",
@@ -16553,7 +16553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.014224+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567245+00:00"
               },
               "deterministic": true
             },
@@ -16566,7 +16566,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998323+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821955+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16597,7 +16597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.014263+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567261+00:00"
               },
               "deterministic": true
             },
@@ -16610,7 +16610,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998352+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821970+00:00"
           },
           "uid": {
             "type": "string",
@@ -16627,7 +16627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:18.014296+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16641,7 +16641,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998382+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.821986+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -16710,7 +16710,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.014373+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567309+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -16726,7 +16726,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998413+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.822003+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16763,7 +16763,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.014441+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567341+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -16779,7 +16779,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998443+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.822019+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16808,7 +16808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:18.014515+00:00"
+                "validatedAt": "2026-05-09T01:33:49.567375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16822,7 +16822,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:33.998471+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.822034+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -16862,8 +16862,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_proxyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_proxyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_proxies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -16915,8 +16915,8 @@
           "description": "Minimum configuration for dns_proxyDNSProxyDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_proxyDNSProxyDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_proxyDNSProxyDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_proxy_d_n_s_proxy_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -16994,7 +16994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.329933+00:00"
+                "validatedAt": "2026-05-09T01:34:07.336882+00:00"
               },
               "deterministic": true
             },
@@ -17007,7 +17007,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.214151+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.407288+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17037,7 +17037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.329997+00:00"
+                "validatedAt": "2026-05-09T01:34:07.336906+00:00"
               },
               "deterministic": true
             },
@@ -17050,7 +17050,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.214184+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.407304+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17153,7 +17153,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.214284+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.407357+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -17251,7 +17251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.330230+00:00"
+                "validatedAt": "2026-05-09T01:34:07.336986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17318,7 +17318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:13:58.330310+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337019+00:00"
               },
               "deterministic": true
             },
@@ -17359,7 +17359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:13:58.330352+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337039+00:00"
               },
               "deterministic": true
             },
@@ -17481,7 +17481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:13:58.330437+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17543,7 +17543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:58.330509+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17555,7 +17555,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.214455+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.407445+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17621,7 +17621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.330564+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337131+00:00"
               },
               "deterministic": true
             },
@@ -17634,7 +17634,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.214525+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.407482+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17663,7 +17663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.330619+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337148+00:00"
               },
               "deterministic": true
             },
@@ -17676,7 +17676,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.214554+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.407498+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -17715,7 +17715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:58.330688+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17728,7 +17728,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.214627+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.407528+00:00"
           },
           "uid": {
             "type": "string",
@@ -17745,7 +17745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:58.330722+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17759,7 +17759,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.214659+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.407544+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_proxy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -17832,7 +17832,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.330797+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17914,8 +17914,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_proxyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_proxyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_proxy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -17927,8 +17927,8 @@
           "description": "Minimum configuration for dns_proxyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_proxyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_proxyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_proxy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -18011,8 +18011,8 @@
           "description": "Minimum configuration for dns_proxyTransportType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_proxyTransportType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_proxyTransportType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_proxy_transport_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -18033,8 +18033,8 @@
           "description": "Minimum configuration for healthcheckDNSQueryType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for healthcheckDNSQueryType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for healthcheckDNSQueryType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/healthcheck_d_n_s_query_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -18056,8 +18056,8 @@
           "description": "Minimum configuration for healthcheckDNSResponseRcodeType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for healthcheckDNSResponseRcodeType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for healthcheckDNSResponseRcodeType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/healthcheck_d_n_s_response_rcode_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -18079,8 +18079,8 @@
           "description": "Minimum configuration for healthcheckDNSResponseRecordType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for healthcheckDNSResponseRecordType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for healthcheckDNSResponseRecordType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/healthcheck_d_n_s_response_record_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -18125,7 +18125,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.330961+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18165,7 +18165,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.331046+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18248,7 +18248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.331141+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18283,7 +18283,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.331220+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18319,8 +18319,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18367,7 +18367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:58.331486+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18438,7 +18438,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.331563+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18510,7 +18510,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.331658+00:00"
+                "validatedAt": "2026-05-09T01:34:07.337615+00:00"
               },
               "deterministic": true
             },
@@ -18575,8 +18575,8 @@
           "description": "Minimum configuration for origin_poolProtocolType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for origin_poolProtocolType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for origin_poolProtocolType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/origin_pool_protocol_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -18621,7 +18621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.333721+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18707,7 +18707,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.333805+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18833,7 +18833,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.333904+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18908,7 +18908,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.334194+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18973,7 +18973,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.334260+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19060,7 +19060,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.334325+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19136,8 +19136,8 @@
           "description": "Minimum configuration for viewsSiteNetwork",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_networks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19159,8 +19159,8 @@
           "description": "Minimum configuration for viewsSiteNetworkSpecifiedVIP",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_network_specified_v_i_ps\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19225,7 +19225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.334403+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19298,7 +19298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.334458+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338867+00:00"
               },
               "deterministic": true
             },
@@ -19345,7 +19345,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.334540+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19468,7 +19468,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.334670+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19503,7 +19503,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.334747+00:00"
+                "validatedAt": "2026-05-09T01:34:07.338994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19598,7 +19598,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:58.334819+00:00"
+                "validatedAt": "2026-05-09T01:34:07.339027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19733,8 +19733,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_domainCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_domainCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_domains\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -19859,8 +19859,8 @@
           "description": "Minimum configuration for dns_domainDNSDomainVerificationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_domainDNSDomainVerificationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_domainDNSDomainVerificationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_domain_d_n_s_domain_verification_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -19881,8 +19881,8 @@
           "description": "Minimum configuration for dns_domainDNSSECMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_domainDNSSECMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_domainDNSSECMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_domain_d_n_s_s_e_c_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -19907,7 +19907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:56.391262+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19930,7 +19930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:56.391365+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19953,7 +19953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:56.391461+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19976,7 +19976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:56.391507+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19999,7 +19999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:56.391553+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20035,7 +20035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:14:56.391646+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006844+00:00"
               },
               "deterministic": true
             },
@@ -20130,7 +20130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:56.391714+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006876+00:00"
               },
               "deterministic": true
             },
@@ -20143,7 +20143,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.759560+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144116+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20173,7 +20173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:56.391753+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006898+00:00"
               },
               "deterministic": true
             },
@@ -20186,7 +20186,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.759612+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144133+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20289,7 +20289,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.759716+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144191+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -20339,7 +20339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:56.391891+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20352,7 +20352,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.759771+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144219+00:00"
           },
           "txt_record": {
             "type": "string",
@@ -20367,7 +20367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:56.391943+00:00"
+                "validatedAt": "2026-05-09T01:34:33.006978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20439,7 +20439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:56.392005+00:00"
+                "validatedAt": "2026-05-09T01:34:33.007010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20502,7 +20502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:56.392076+00:00"
+                "validatedAt": "2026-05-09T01:34:33.007042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20514,7 +20514,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.759859+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144263+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20580,7 +20580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:56.392128+00:00"
+                "validatedAt": "2026-05-09T01:34:33.007066+00:00"
               },
               "deterministic": true
             },
@@ -20593,7 +20593,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.759970+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144301+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20622,7 +20622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:56.392165+00:00"
+                "validatedAt": "2026-05-09T01:34:33.007085+00:00"
               },
               "deterministic": true
             },
@@ -20635,7 +20635,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.760016+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144316+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -20674,7 +20674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:56.392230+00:00"
+                "validatedAt": "2026-05-09T01:34:33.007113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20687,7 +20687,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.760076+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144347+00:00"
           },
           "uid": {
             "type": "string",
@@ -20704,7 +20704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:56.392263+00:00"
+                "validatedAt": "2026-05-09T01:34:33.007130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20718,7 +20718,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.760107+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144363+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_domain is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -20768,8 +20768,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_domainReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_domainReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_domain_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -20781,8 +20781,8 @@
           "description": "Minimum configuration for dns_domainReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_domainReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_domainReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_domain_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -20914,7 +20914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:56.392359+00:00"
+                "validatedAt": "2026-05-09T01:34:33.007182+00:00"
               },
               "deterministic": true
             },
@@ -20927,7 +20927,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.760230+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144424+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20957,7 +20957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:56.392396+00:00"
+                "validatedAt": "2026-05-09T01:34:33.007201+00:00"
               },
               "deterministic": true
             },
@@ -20970,7 +20970,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.760259+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.144439+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20996,8 +20996,8 @@
           "description": "Minimum configuration for dns_domainVerifyDnsDomainResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_domainVerifyDnsDomainResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_domainVerifyDnsDomainResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_domain_verify_dns_domain_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -21023,8 +21023,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_load_balancerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_load_balancerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_load_balancers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -21115,7 +21115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:59.000559+00:00"
+                "validatedAt": "2026-05-09T01:34:34.161989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21193,7 +21193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.000672+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162021+00:00"
               },
               "deterministic": true
             },
@@ -21206,7 +21206,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.810835+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.167970+00:00"
           },
           "status": {
             "type": "array",
@@ -21226,7 +21226,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.810869+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.167987+00:00"
           }
         },
         "x-f5xc-description-short": "Individual item in a collection of DNS Load Balancer.",
@@ -21284,7 +21284,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.810912+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168009+00:00"
           }
         },
         "x-f5xc-description-short": "Response for DNS Load Balancer Health Status Request.",
@@ -21340,7 +21340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.000807+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21379,7 +21379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.000846+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162092+00:00"
               },
               "deterministic": true
             },
@@ -21392,7 +21392,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.810964+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168036+00:00"
           },
           "status": {
             "type": "array",
@@ -21413,7 +21413,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.810994+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168052+00:00"
           }
         },
         "x-f5xc-description-short": "Individual item in a collection of DNS Load Balancer Pool.",
@@ -21474,7 +21474,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811035+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168073+00:00"
           }
         },
         "x-f5xc-description-short": "Response for DNS Load Balancer Pool Health Status Request.",
@@ -21517,7 +21517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.000956+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21542,7 +21542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.001016+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21570,7 +21570,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811096+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168105+00:00"
           }
         },
         "x-f5xc-description-short": "Pool member health status change event data.",
@@ -21615,7 +21615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:59.001072+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21662,7 +21662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.001125+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21687,7 +21687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.001179+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21716,7 +21716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.001237+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21742,7 +21742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.001292+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21785,7 +21785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.001332+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162304+00:00"
               },
               "deterministic": true
             },
@@ -21798,7 +21798,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811196+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168164+00:00"
           },
           "ports": {
             "type": "array",
@@ -21827,7 +21827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.001398+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21856,7 +21856,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811235+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168185+00:00"
           },
           "unhealthy_ports": {
             "type": "array",
@@ -21884,7 +21884,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.001475+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22005,7 +22005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.001544+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162403+00:00"
               },
               "deterministic": true
             },
@@ -22018,7 +22018,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811298+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168218+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22048,7 +22048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.001582+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162420+00:00"
               },
               "deterministic": true
             },
@@ -22061,7 +22061,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811326+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168234+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22164,7 +22164,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811424+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168285+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22209,8 +22209,8 @@
           "description": "Minimum configuration for dns_load_balancerHealthStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_load_balancerHealthStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_load_balancerHealthStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_load_balancer_health_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -22297,7 +22297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:59.001756+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22360,7 +22360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:59.001828+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22372,7 +22372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811522+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168336+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22438,7 +22438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.001881+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162536+00:00"
               },
               "deterministic": true
             },
@@ -22451,7 +22451,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811606+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168373+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22480,7 +22480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.001919+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162553+00:00"
               },
               "deterministic": true
             },
@@ -22493,7 +22493,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811636+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168388+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -22532,7 +22532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.001986+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22545,7 +22545,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811693+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168419+00:00"
           },
           "uid": {
             "type": "string",
@@ -22563,7 +22563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.002020+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22577,7 +22577,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811724+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168435+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_load_balancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22720,7 +22720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.002150+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162651+00:00"
               },
               "deterministic": true
             },
@@ -22765,8 +22765,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_load_balancerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_load_balancerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_load_balancer_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -22778,8 +22778,8 @@
           "description": "Minimum configuration for dns_load_balancerReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_load_balancerReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_load_balancerReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_load_balancer_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -22803,8 +22803,8 @@
           "description": "Minimum configuration for dns_load_balancerResourceRecordType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_load_balancerResourceRecordType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_load_balancerResourceRecordType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_load_balancer_resource_record_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -22961,7 +22961,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.002322+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22995,7 +22995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.002405+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23033,7 +23033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.002446+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162783+00:00"
               },
               "deterministic": true
             },
@@ -23046,7 +23046,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.811951+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168554+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -23091,8 +23091,8 @@
           "description": "Minimum configuration for ioschemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -23142,7 +23142,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.002723+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23201,7 +23201,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.002785+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23272,7 +23272,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.002853+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23350,7 +23350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.002922+00:00"
+                "validatedAt": "2026-05-09T01:34:34.162995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23447,8 +23447,8 @@
           "description": "Minimum configuration for schemaHttpStatusCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpStatusCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpStatusCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_status_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -23497,7 +23497,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:59.003472+00:00"
+                "validatedAt": "2026-05-09T01:34:34.163237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23562,7 +23562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.003535+00:00"
+                "validatedAt": "2026-05-09T01:34:34.163262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23574,7 +23574,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.812471+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.168827+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -23609,8 +23609,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -23642,7 +23642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:59.004959+00:00"
+                "validatedAt": "2026-05-09T01:34:34.163921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23654,7 +23654,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.813224+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.169218+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -23672,7 +23672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.005011+00:00"
+                "validatedAt": "2026-05-09T01:34:34.163943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23700,7 +23700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.005057+00:00"
+                "validatedAt": "2026-05-09T01:34:34.163962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23712,7 +23712,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.813272+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.169243+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -23800,8 +23800,8 @@
           "description": "Minimum configuration for schemadns_load_balancerErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemadns_load_balancerErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemadns_load_balancerErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemadns_load_balancer_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -23974,7 +23974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:59.005345+00:00"
+                "validatedAt": "2026-05-09T01:34:34.164097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24023,7 +24023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:59.005406+00:00"
+                "validatedAt": "2026-05-09T01:34:34.164124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24035,7 +24035,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.813622+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.169412+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -24053,7 +24053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:59.005456+00:00"
+                "validatedAt": "2026-05-09T01:34:34.164146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24103,8 +24103,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_lb_health_checkCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_lb_health_checkCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_lb_health_checks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -24233,7 +24233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.865074+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209308+00:00"
               },
               "deterministic": true
             },
@@ -24246,7 +24246,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.948807+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.234203+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24276,7 +24276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.865133+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209333+00:00"
               },
               "deterministic": true
             },
@@ -24289,7 +24289,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.948840+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.234220+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24392,7 +24392,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.948941+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.234276+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -24564,7 +24564,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.865408+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24596,7 +24596,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.865479+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24664,7 +24664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:05.865537+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24727,7 +24727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:05.865627+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24739,7 +24739,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.949128+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.234374+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -24805,7 +24805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.865681+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209568+00:00"
               },
               "deterministic": true
             },
@@ -24818,7 +24818,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.949199+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.234411+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24847,7 +24847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.865718+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209588+00:00"
               },
               "deterministic": true
             },
@@ -24860,7 +24860,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.949229+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.234427+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -24899,7 +24899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:05.865784+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24912,7 +24912,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.949287+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.234458+00:00"
           },
           "uid": {
             "type": "string",
@@ -24930,7 +24930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:05.865819+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24944,7 +24944,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.949318+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.234474+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_lb_health_check is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -24994,8 +24994,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_lb_health_checkReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_lb_health_checkReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_lb_health_check_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -25007,8 +25007,8 @@
           "description": "Minimum configuration for dns_lb_health_checkReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_lb_health_checkReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_lb_health_checkReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_lb_health_check_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -25198,7 +25198,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.866012+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25231,7 +25231,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.866083+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25342,7 +25342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.866207+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25378,7 +25378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.866278+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25494,7 +25494,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.866404+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25532,7 +25532,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:05.866476+00:00"
+                "validatedAt": "2026-05-09T01:34:37.209943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25623,7 +25623,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.625194+00:00"
+                "validatedAt": "2026-05-09T01:34:39.318749+00:00"
               },
               "deterministic": true
             },
@@ -25720,7 +25720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.625316+00:00"
+                "validatedAt": "2026-05-09T01:34:39.318806+00:00"
               },
               "deterministic": true
             },
@@ -25797,7 +25797,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.625414+00:00"
+                "validatedAt": "2026-05-09T01:34:39.318850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25842,7 +25842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.625492+00:00"
+                "validatedAt": "2026-05-09T01:34:39.318888+00:00"
               },
               "deterministic": true
             },
@@ -25855,7 +25855,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.038931+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277509+00:00"
           },
           "priority": {
             "type": "integer",
@@ -25883,7 +25883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:10.625541+00:00"
+                "validatedAt": "2026-05-09T01:34:39.318910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25969,7 +25969,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.625656+00:00"
+                "validatedAt": "2026-05-09T01:34:39.318956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25982,7 +25982,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.038989+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277541+00:00"
           },
           "final_translation": {
             "type": "boolean",
@@ -26033,7 +26033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.625731+00:00"
+                "validatedAt": "2026-05-09T01:34:39.318992+00:00"
               },
               "deterministic": true
             },
@@ -26046,7 +26046,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039031+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277562+00:00"
           },
           "ratio": {
             "type": "integer",
@@ -26126,7 +26126,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.625829+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319036+00:00"
               },
               "deterministic": true
             },
@@ -26171,8 +26171,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_lb_poolCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_lb_poolCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_lb_pools\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -26332,7 +26332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.625934+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319079+00:00"
               },
               "deterministic": true
             },
@@ -26345,7 +26345,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039229+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277663+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26375,7 +26375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.625973+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319097+00:00"
               },
               "deterministic": true
             },
@@ -26388,7 +26388,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039259+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277679+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26491,7 +26491,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039358+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277732+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -26651,7 +26651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:10.626168+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26714,7 +26714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:10.626238+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26726,7 +26726,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039522+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277818+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26792,7 +26792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.626287+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319237+00:00"
               },
               "deterministic": true
             },
@@ -26805,7 +26805,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039608+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277855+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26834,7 +26834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.626322+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319254+00:00"
               },
               "deterministic": true
             },
@@ -26847,7 +26847,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039637+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277871+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26886,7 +26886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:10.626389+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26899,7 +26899,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039696+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277908+00:00"
           },
           "uid": {
             "type": "string",
@@ -26916,7 +26916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:10.626423+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26930,7 +26930,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039727+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277924+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_lb_pool is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -26978,8 +26978,8 @@
           "description": "Minimum configuration for dns_lb_poolLoadBalancingMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_lb_poolLoadBalancingMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_lb_poolLoadBalancingMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_lb_pool_load_balancing_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -27018,7 +27018,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.626498+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27031,7 +27031,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039762+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277942+00:00"
           },
           "name": {
             "type": "string",
@@ -27068,7 +27068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.626569+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319366+00:00"
               },
               "deterministic": true
             },
@@ -27081,7 +27081,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039791+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.277957+00:00"
           },
           "priority": {
             "type": "integer",
@@ -27108,7 +27108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:10.626629+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27223,7 +27223,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.626745+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319438+00:00"
               },
               "deterministic": true
             },
@@ -27269,8 +27269,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_lb_poolReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_lb_poolReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_lb_pool_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -27282,8 +27282,8 @@
           "description": "Minimum configuration for dns_lb_poolReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_lb_poolReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_lb_poolReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_lb_pool_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -27422,7 +27422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.626864+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319491+00:00"
               },
               "deterministic": true
             },
@@ -27435,7 +27435,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.039975+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.278059+00:00"
           },
           "port": {
             "type": "integer",
@@ -27468,7 +27468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.626901+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319509+00:00"
               },
               "deterministic": true
             },
@@ -27508,7 +27508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:10.626943+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27568,7 +27568,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.627053+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27607,7 +27607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:10.627098+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27702,7 +27702,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:10.627198+00:00"
+                "validatedAt": "2026-05-09T01:34:39.319646+00:00"
               },
               "deterministic": true
             },
@@ -27801,8 +27801,8 @@
           "description": "Minimum configuration for dns_zoneAFSDBRecordSubtype",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneAFSDBRecordSubtype\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneAFSDBRecordSubtype\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_a_f_s_d_b_record_subtypes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -27844,7 +27844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.489683+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097258+00:00"
               },
               "deterministic": true
             },
@@ -27896,8 +27896,8 @@
           "description": "Minimum configuration for dns_zoneCERTAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneCERTAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneCERTAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_c_e_r_t_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -27979,7 +27979,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.489839+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097333+00:00"
               },
               "deterministic": true
             },
@@ -28050,7 +28050,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.489930+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097378+00:00"
               },
               "deterministic": true
             },
@@ -28063,7 +28063,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.280900+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391000+00:00"
           },
           "values": {
             "type": "array",
@@ -28097,7 +28097,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.489995+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28147,8 +28147,8 @@
           "description": "Minimum configuration for dns_zoneCERTType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneCERTType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneCERTType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_c_e_r_t_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -28204,7 +28204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.490057+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28240,7 +28240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490138+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28251,7 +28251,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.280968+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391033+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28289,7 +28289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.490186+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28302,7 +28302,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281002+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391050+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28389,8 +28389,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zones\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -28496,7 +28496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490335+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097568+00:00"
               },
               "deterministic": true
             },
@@ -28509,7 +28509,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281130+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391115+00:00"
           },
           "values": {
             "type": "array",
@@ -28548,7 +28548,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490395+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28616,7 +28616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490478+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097639+00:00"
               },
               "deterministic": true
             },
@@ -28629,7 +28629,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281172+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391137+00:00"
           },
           "values": {
             "type": "array",
@@ -28663,7 +28663,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490536+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28730,7 +28730,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490633+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097709+00:00"
               },
               "deterministic": true
             },
@@ -28743,7 +28743,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281215+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391164+00:00"
           },
           "values": {
             "type": "array",
@@ -28782,7 +28782,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490696+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28837,7 +28837,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490771+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28849,7 +28849,7 @@
             "x-original-maxLength": 255,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281258+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391186+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28906,7 +28906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490852+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097816+00:00"
               },
               "deterministic": true
             },
@@ -28919,7 +28919,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281290+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391202+00:00"
           },
           "values": {
             "type": "array",
@@ -28944,7 +28944,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490909+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29011,7 +29011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.490988+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097889+00:00"
               },
               "deterministic": true
             },
@@ -29024,7 +29024,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281333+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391224+00:00"
           },
           "values": {
             "type": "array",
@@ -29056,7 +29056,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491049+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29126,7 +29126,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491131+00:00"
+                "validatedAt": "2026-05-09T01:34:44.097967+00:00"
               },
               "deterministic": true
             },
@@ -29139,7 +29139,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281375+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391246+00:00"
           },
           "value": {
             "type": "string",
@@ -29166,7 +29166,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491203+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29178,7 +29178,7 @@
             "x-original-maxLength": 255,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281404+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391261+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29237,7 +29237,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491281+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098044+00:00"
               },
               "deterministic": true
             },
@@ -29250,7 +29250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281437+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391278+00:00"
           },
           "values": {
             "type": "array",
@@ -29282,7 +29282,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491341+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29325,8 +29325,8 @@
           "description": "Minimum configuration for dns_zoneDNSDeploymentStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneDNSDeploymentStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneDNSDeploymentStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_d_n_s_deployment_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -29375,7 +29375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491422+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098116+00:00"
               },
               "deterministic": true
             },
@@ -29388,7 +29388,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281480+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391300+00:00"
           },
           "value": {
             "type": "string",
@@ -29422,7 +29422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491510+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29433,7 +29433,7 @@
             },
             "x-original-maxLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281509+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391315+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29493,7 +29493,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491606+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098206+00:00"
               },
               "deterministic": true
             },
@@ -29506,7 +29506,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281542+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391331+00:00"
           },
           "value": {
             "type": "string",
@@ -29540,7 +29540,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491699+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29551,7 +29551,7 @@
             },
             "x-original-maxLength": 23,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281571+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391347+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29611,7 +29611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491766+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098281+00:00"
               },
               "deterministic": true
             },
@@ -29624,7 +29624,7 @@
             "x-original-maxLength": 255,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281622+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391363+00:00"
           },
           "value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -29686,7 +29686,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491848+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098321+00:00"
               },
               "deterministic": true
             },
@@ -29699,7 +29699,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281665+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391384+00:00"
           },
           "values": {
             "type": "array",
@@ -29733,7 +29733,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491908+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29799,7 +29799,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.491986+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098391+00:00"
               },
               "deterministic": true
             },
@@ -29812,7 +29812,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281709+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391406+00:00"
           },
           "values": {
             "type": "array",
@@ -29840,7 +29840,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492043+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29908,7 +29908,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492120+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098459+00:00"
               },
               "deterministic": true
             },
@@ -29921,7 +29921,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281751+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391427+00:00"
           },
           "values": {
             "type": "array",
@@ -29955,7 +29955,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492178+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30021,7 +30021,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492258+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098527+00:00"
               },
               "deterministic": true
             },
@@ -30034,7 +30034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281794+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391450+00:00"
           },
           "values": {
             "type": "array",
@@ -30073,7 +30073,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492318+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30139,7 +30139,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492395+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098597+00:00"
               },
               "deterministic": true
             },
@@ -30152,7 +30152,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281836+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391473+00:00"
           },
           "values": {
             "type": "array",
@@ -30191,7 +30191,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492455+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30252,8 +30252,8 @@
           "description": "Minimum configuration for dns_zoneDNSSECModeEnable",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneDNSSECModeEnable\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneDNSSECModeEnable\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_d_n_s_s_e_c_mode_enables\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -30343,7 +30343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492564+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098679+00:00"
               },
               "deterministic": true
             },
@@ -30356,7 +30356,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281924+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391518+00:00"
           },
           "values": {
             "type": "array",
@@ -30390,7 +30390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492638+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30456,7 +30456,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492718+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098752+00:00"
               },
               "deterministic": true
             },
@@ -30469,7 +30469,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.281967+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391540+00:00"
           },
           "values": {
             "type": "array",
@@ -30509,7 +30509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.492789+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30602,8 +30602,8 @@
           "description": "Minimum configuration for dns_zoneDSKeyAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneDSKeyAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneDSKeyAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_d_s_key_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -30636,7 +30636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.492891+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30667,7 +30667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.492940+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30698,7 +30698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.492992+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30774,7 +30774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:15:21.493086+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098905+00:00"
               },
               "deterministic": true
             },
@@ -30941,7 +30941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.493178+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098945+00:00"
               },
               "deterministic": true
             },
@@ -30954,7 +30954,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.282175+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391645+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30984,7 +30984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.493214+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098963+00:00"
               },
               "deterministic": true
             },
@@ -30997,7 +30997,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.282204+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391660+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31043,7 +31043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493264+00:00"
+                "validatedAt": "2026-05-09T01:34:44.098984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31070,7 +31070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493308+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31122,7 +31122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:15:21.493371+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31160,7 +31160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.493409+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099054+00:00"
               },
               "deterministic": true
             },
@@ -31173,7 +31173,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.282276+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391696+00:00"
           },
           "sort": {
             "$ref": "#/components/schemas/schemaSortOrder"
@@ -31201,7 +31201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493464+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099078+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31234,7 +31234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493507+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31310,7 +31310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493565+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31338,7 +31338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493657+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31393,7 +31393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493715+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31420,7 +31420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493760+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31457,7 +31457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:15:21.493807+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31495,7 +31495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.493849+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099245+00:00"
               },
               "deterministic": true
             },
@@ -31508,7 +31508,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.282397+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391759+00:00"
           },
           "sort": {
             "$ref": "#/components/schemas/schemaSortOrder"
@@ -31536,7 +31536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493904+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31608,7 +31608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.493969+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31654,7 +31654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494024+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31679,7 +31679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494074+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31704,7 +31704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494126+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31729,7 +31729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494169+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31742,7 +31742,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.282501+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391812+00:00"
           },
           "query_type": {
             "type": "string",
@@ -31759,7 +31759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494219+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31784,7 +31784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494271+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31825,7 +31825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:21.494327+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099457+00:00"
               },
               "deterministic": true
             },
@@ -31876,7 +31876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494377+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31977,7 +31977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494450+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32000,7 +32000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494498+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32044,7 +32044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494548+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32153,7 +32153,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.282715+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391915+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -32200,7 +32200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.494700+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32213,7 +32213,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.282759+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391937+00:00"
           },
           "num_of_dns_records": {
             "type": "integer",
@@ -32299,7 +32299,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.494810+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099661+00:00"
               },
               "deterministic": true
             },
@@ -32336,7 +32336,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.494890+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32412,7 +32412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:21.494961+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32424,7 +32424,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.282865+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.391990+00:00"
           },
           "file": {
             "type": "string",
@@ -32451,7 +32451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.495003+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32568,7 +32568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:21.495124+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32580,7 +32580,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.282940+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392028+00:00"
           },
           "file": {
             "type": "string",
@@ -32607,7 +32607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.495166+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32706,7 +32706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.495239+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32730,7 +32730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.495287+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32838,7 +32838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.495396+00:00"
+                "validatedAt": "2026-05-09T01:34:44.099976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32877,7 +32877,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.495463+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32964,7 +32964,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.495569+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33003,7 +33003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.495650+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33100,8 +33100,8 @@
           "description": "Minimum configuration for dns_zoneLatitudeHemisphere",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneLatitudeHemisphere\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneLatitudeHemisphere\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_latitude_hemispheres\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -33148,7 +33148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:21.495749+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33210,7 +33210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:21.495815+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33222,7 +33222,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.283201+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392166+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -33288,7 +33288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.495866+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100219+00:00"
               },
               "deterministic": true
             },
@@ -33301,7 +33301,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.283271+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392202+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33330,7 +33330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.495902+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100237+00:00"
               },
               "deterministic": true
             },
@@ -33343,7 +33343,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.283300+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392217+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -33382,7 +33382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.495968+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33395,7 +33395,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.283358+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392247+00:00"
           },
           "uid": {
             "type": "string",
@@ -33412,7 +33412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.496000+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33426,7 +33426,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.283389+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392263+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_zone is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -33471,8 +33471,8 @@
           "description": "Minimum configuration for dns_zoneLongitudeHemisphere",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneLongitudeHemisphere\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneLongitudeHemisphere\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_longitude_hemispheres\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -33507,7 +33507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.496075+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33520,7 +33520,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.283424+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392283+00:00"
           },
           "priority": {
             "type": "integer",
@@ -33547,7 +33547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:21.496123+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33609,7 +33609,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.283479+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392311+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -33662,7 +33662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.496236+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33750,7 +33750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.496347+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33776,7 +33776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.496397+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33811,7 +33811,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.496485+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33881,7 +33881,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.496553+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33922,7 +33922,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.496634+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33972,7 +33972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.496681+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34017,7 +34017,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.496747+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34058,7 +34058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.496811+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34153,7 +34153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:21.496913+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34165,7 +34165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.283796+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392477+00:00"
           },
           "ds_record": {
             "$ref": "#/components/schemas/dns_zoneDNSDSRecord"
@@ -34296,7 +34296,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497028+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34341,8 +34341,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -34354,8 +34354,8 @@
           "description": "Minimum configuration for dns_zoneReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -34424,7 +34424,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497121+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34488,7 +34488,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497220+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100892+00:00"
               },
               "deterministic": true
             },
@@ -34548,7 +34548,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497300+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34612,7 +34612,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497394+00:00"
+                "validatedAt": "2026-05-09T01:34:44.100976+00:00"
               },
               "deterministic": true
             },
@@ -34672,7 +34672,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497471+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34873,7 +34873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497618+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101074+00:00"
               },
               "deterministic": true
             },
@@ -34910,7 +34910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:21.497663+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34944,7 +34944,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497754+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34980,7 +34980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:21.497799+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35027,8 +35027,8 @@
           "description": "Minimum configuration for dns_zoneSSHFPAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneSSHFPAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneSSHFPAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_s_s_h_f_p_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -35108,7 +35108,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497895+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101219+00:00"
               },
               "deterministic": true
             },
@@ -35121,7 +35121,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.284205+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392688+00:00"
           },
           "values": {
             "type": "array",
@@ -35155,7 +35155,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.497955+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35223,7 +35223,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.498022+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35260,7 +35260,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.498110+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35310,7 +35310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.498176+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35353,7 +35353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.498243+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35387,7 +35387,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.498330+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35494,8 +35494,8 @@
           "description": "Minimum configuration for dns_zoneTLSARecordCSelector",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneTLSARecordCSelector\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneTLSARecordCSelector\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_t_l_s_a_record_c_selectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -35519,8 +35519,8 @@
           "description": "Minimum configuration for dns_zoneTLSARecordCertificateUsage",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneTLSARecordCertificateUsage\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneTLSARecordCertificateUsage\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_t_l_s_a_record_certificate_usages\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -35542,8 +35542,8 @@
           "description": "Minimum configuration for dns_zoneTLSARecordMatchingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneTLSARecordMatchingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneTLSARecordMatchingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_t_l_s_a_record_matching_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -35587,7 +35587,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.498477+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35666,7 +35666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.498570+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101540+00:00"
               },
               "deterministic": true
             },
@@ -35679,7 +35679,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.284423+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392799+00:00"
           },
           "values": {
             "type": "array",
@@ -35713,7 +35713,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.498646+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35772,7 +35772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.498740+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35822,8 +35822,8 @@
           "description": "Minimum configuration for dns_zoneTSIGKeyAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dns_zoneTSIGKeyAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dns_zoneTSIGKeyAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dns_zone_t_s_i_g_key_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -35861,7 +35861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.498813+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35910,7 +35910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.499167+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35948,7 +35948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.499243+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35960,7 +35960,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.284737+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392953+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -35979,7 +35979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.499297+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36030,7 +36030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:21.499346+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36042,7 +36042,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.284779+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.392975+00:00"
           },
           "url": {
             "type": "string",
@@ -36080,7 +36080,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.499420+00:00"
+                "validatedAt": "2026-05-09T01:34:44.101929+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -36141,7 +36141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.499935+00:00"
+                "validatedAt": "2026-05-09T01:34:44.102174+00:00"
               },
               "deterministic": true
             },
@@ -36154,7 +36154,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.285010+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.393091+00:00"
           },
           "name": {
             "type": "string",
@@ -36198,7 +36198,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:21.500000+00:00"
+                "validatedAt": "2026-05-09T01:34:44.102206+00:00"
               },
               "deterministic": true
             },
@@ -36210,7 +36210,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.285038+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.393106+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -36243,8 +36243,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -36294,8 +36294,8 @@
           "description": "Minimum configuration for schemaSortOrder",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_sort_orders\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -36321,8 +36321,8 @@
           "description": "Minimum configuration for schemadns_zoneLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemadns_zoneLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemadns_zoneLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemadns_zone_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "dns"
@@ -36358,7 +36358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:23.245486+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36397,7 +36397,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:23.245594+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36456,7 +36456,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:23.245697+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36495,7 +36495,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:23.245790+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36526,7 +36526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:23.245846+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36561,7 +36561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:23.245890+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36608,7 +36608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:23.245943+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36632,7 +36632,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:23.245990+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36668,7 +36668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:23.246028+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538458+00:00"
               },
               "deterministic": true
             },
@@ -36681,7 +36681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.670532+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.044753+00:00"
           },
           "record_name": {
             "type": "string",
@@ -36697,7 +36697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:23.246079+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36723,7 +36723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:23.246120+00:00"
+                "validatedAt": "2026-05-09T01:35:11.538498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36761,8 +36761,8 @@
           "description": "Minimum configuration for subscriptionSubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionSubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionSubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_subscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -36778,8 +36778,8 @@
           "description": "Minimum configuration for subscriptionSubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_subscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -36795,8 +36795,8 @@
           "description": "Minimum configuration for subscriptionUnsubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_unsubscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -36812,8 +36812,8 @@
           "description": "Minimum configuration for subscriptionUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"

--- a/docs/specifications/api/index.json
+++ b/docs/specifications/api/index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.1.78",
-  "timestamp": "2026-05-08T20:30:18.267506+00:00",
+  "timestamp": "2026-05-09T01:41:27.382480+00:00",
   "specifications": [
     {
       "domain": "admin_console_and_ui",

--- a/docs/specifications/api/managed_kubernetes.json
+++ b/docs/specifications/api/managed_kubernetes.json
@@ -5873,8 +5873,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for container_registryCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for container_registryCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/container_registries\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -5943,7 +5943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380019+00:00"
+                "validatedAt": "2026-05-09T01:34:25.065692+00:00"
               },
               "deterministic": true
             },
@@ -5983,7 +5983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380124+00:00"
+                "validatedAt": "2026-05-09T01:34:25.065734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6018,7 +6018,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380214+00:00"
+                "validatedAt": "2026-05-09T01:34:25.065773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6094,7 +6094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380268+00:00"
+                "validatedAt": "2026-05-09T01:34:25.065796+00:00"
               },
               "deterministic": true
             },
@@ -6107,7 +6107,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.334796+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940524+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6137,7 +6137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380309+00:00"
+                "validatedAt": "2026-05-09T01:34:25.065814+00:00"
               },
               "deterministic": true
             },
@@ -6150,7 +6150,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.334829+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940540+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6253,7 +6253,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.334929+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940593+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -6315,7 +6315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380483+00:00"
+                "validatedAt": "2026-05-09T01:34:25.065887+00:00"
               },
               "deterministic": true
             },
@@ -6355,7 +6355,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380563+00:00"
+                "validatedAt": "2026-05-09T01:34:25.065924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6390,7 +6390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380664+00:00"
+                "validatedAt": "2026-05-09T01:34:25.065961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6458,7 +6458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:38.380731+00:00"
+                "validatedAt": "2026-05-09T01:34:25.065987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6521,7 +6521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:38.380804+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6533,7 +6533,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335047+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940655+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -6599,7 +6599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380857+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066040+00:00"
               },
               "deterministic": true
             },
@@ -6612,7 +6612,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335117+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940692+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6641,7 +6641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.380895+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066058+00:00"
               },
               "deterministic": true
             },
@@ -6654,7 +6654,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335146+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940708+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -6693,7 +6693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.380963+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6706,7 +6706,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335204+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940739+00:00"
           },
           "uid": {
             "type": "string",
@@ -6724,7 +6724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.380997+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6738,7 +6738,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335235+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940755+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of container_registry is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -6788,8 +6788,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for container_registryReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for container_registryReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/container_registry_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -6801,8 +6801,8 @@
           "description": "Minimum configuration for container_registryReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for container_registryReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for container_registryReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/container_registry_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -6843,7 +6843,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.381087+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066145+00:00"
               },
               "deterministic": true
             },
@@ -6883,7 +6883,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.381166+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6918,7 +6918,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.381248+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7017,7 +7017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.381337+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7040,7 +7040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.381381+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7052,7 +7052,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335372+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940827+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -7095,7 +7095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.381440+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7133,7 +7133,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.381516+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7145,7 +7145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335414+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940849+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -7164,7 +7164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.381569+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7215,7 +7215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.381632+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7227,7 +7227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335456+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940871+00:00"
           },
           "url": {
             "type": "string",
@@ -7265,7 +7265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.381714+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066416+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -7322,7 +7322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:14:38.381758+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066433+00:00"
               },
               "deterministic": true
             },
@@ -7348,7 +7348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.381813+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7375,7 +7375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.381858+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7387,7 +7387,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335516+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940902+00:00"
           },
           "service_name": {
             "type": "string",
@@ -7404,7 +7404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.381909+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7437,7 +7437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.381958+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7449,7 +7449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335554+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940923+00:00"
           },
           "type": {
             "type": "string",
@@ -7474,7 +7474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.382001+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7528,8 +7528,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7562,7 +7562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.382054+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7624,7 +7624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382093+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066574+00:00"
               },
               "deterministic": true
             },
@@ -7637,7 +7637,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335645+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940961+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -7755,7 +7755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382215+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066629+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7771,7 +7771,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335712+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.940995+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7841,7 +7841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382265+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066651+00:00"
               },
               "deterministic": true
             },
@@ -7854,7 +7854,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335763+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941022+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7885,7 +7885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382300+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066666+00:00"
               },
               "deterministic": true
             },
@@ -7898,7 +7898,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335792+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941037+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -7980,7 +7980,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382398+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066710+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7996,7 +7996,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335836+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941060+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8068,7 +8068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382447+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066731+00:00"
               },
               "deterministic": true
             },
@@ -8081,7 +8081,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335887+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941087+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8112,7 +8112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382484+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066747+00:00"
               },
               "deterministic": true
             },
@@ -8125,7 +8125,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335916+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941102+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -8170,7 +8170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.382524+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8183,7 +8183,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335947+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941119+00:00"
           },
           "name": {
             "type": "string",
@@ -8216,7 +8216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382562+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066779+00:00"
               },
               "deterministic": true
             },
@@ -8229,7 +8229,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.335976+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941135+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8260,7 +8260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382615+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066795+00:00"
               },
               "deterministic": true
             },
@@ -8273,7 +8273,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336005+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941150+00:00"
           },
           "tenant": {
             "type": "string",
@@ -8292,7 +8292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.382663+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8306,7 +8306,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336034+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941171+00:00"
           },
           "uid": {
             "type": "string",
@@ -8325,7 +8325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.382701+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8340,7 +8340,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336063+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941187+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -8422,7 +8422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382803+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066872+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8438,7 +8438,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336106+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941210+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8508,7 +8508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382851+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066893+00:00"
               },
               "deterministic": true
             },
@@ -8521,7 +8521,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336156+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941237+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8552,7 +8552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.382887+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066909+00:00"
               },
               "deterministic": true
             },
@@ -8565,7 +8565,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336185+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941253+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -8601,8 +8601,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -8660,7 +8660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.382952+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8688,7 +8688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383005+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8716,7 +8716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383054+00:00"
+                "validatedAt": "2026-05-09T01:34:25.066979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8745,7 +8745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383105+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8772,7 +8772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383138+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8786,7 +8786,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336287+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941307+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -8802,7 +8802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383184+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8865,8 +8865,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -8911,7 +8911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383251+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8923,7 +8923,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336348+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941342+00:00"
           },
           "status": {
             "type": "string",
@@ -8941,7 +8941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383297+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8953,7 +8953,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336377+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941358+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -8995,7 +8995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383356+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9022,7 +9022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383409+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9049,7 +9049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383459+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9077,7 +9077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383514+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9142,7 +9142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383651+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9191,7 +9191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383724+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9204,7 +9204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336505+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941427+00:00"
           },
           "uid": {
             "type": "string",
@@ -9223,7 +9223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383759+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9237,7 +9237,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336535+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941443+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -9287,7 +9287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383801+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9299,7 +9299,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336566+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941462+00:00"
           },
           "name": {
             "type": "string",
@@ -9332,7 +9332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.383840+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067281+00:00"
               },
               "deterministic": true
             },
@@ -9345,7 +9345,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336607+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941478+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9376,7 +9376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:38.383877+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067297+00:00"
               },
               "deterministic": true
             },
@@ -9389,7 +9389,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336637+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941494+00:00"
           },
           "uid": {
             "type": "string",
@@ -9406,7 +9406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:38.383910+00:00"
+                "validatedAt": "2026-05-09T01:34:25.067311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9420,7 +9420,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.336666+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.941510+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -9460,8 +9460,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_cluster_roleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_cluster_roleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_cluster_roles\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -9534,7 +9534,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.880003+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570579+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -9617,7 +9617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.880089+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570604+00:00"
               },
               "deterministic": true
             },
@@ -9630,7 +9630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.888724+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.554800+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9660,7 +9660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.880165+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570622+00:00"
               },
               "deterministic": true
             },
@@ -9673,7 +9673,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.888758+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.554817+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9776,7 +9776,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.888858+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.554869+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9842,7 +9842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.880396+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570712+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -9916,7 +9916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:19:13.880454+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9979,7 +9979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:13.880526+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9991,7 +9991,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.888966+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.554924+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10057,7 +10057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.880580+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570795+00:00"
               },
               "deterministic": true
             },
@@ -10070,7 +10070,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.889037+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.554961+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10099,7 +10099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.880668+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570815+00:00"
               },
               "deterministic": true
             },
@@ -10112,7 +10112,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.889066+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.554976+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10151,7 +10151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:13.880739+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10164,7 +10164,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.889123+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.555007+00:00"
           },
           "uid": {
             "type": "string",
@@ -10182,7 +10182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:13.880776+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10196,7 +10196,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.889155+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.555023+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_cluster_role is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -10271,7 +10271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.880847+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10320,7 +10320,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.880910+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10387,7 +10387,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.880976+00:00"
+                "validatedAt": "2026-05-09T01:36:27.570954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10459,8 +10459,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_cluster_roleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_cluster_roleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_cluster_role_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -10472,8 +10472,8 @@
           "description": "Minimum configuration for k8s_cluster_roleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_cluster_roleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_cluster_roleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_cluster_role_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -10518,7 +10518,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.881092+00:00"
+                "validatedAt": "2026-05-09T01:36:27.571005+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -10598,7 +10598,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.881157+00:00"
+                "validatedAt": "2026-05-09T01:36:27.571036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10640,7 +10640,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.881219+00:00"
+                "validatedAt": "2026-05-09T01:36:27.571068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10689,7 +10689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.881284+00:00"
+                "validatedAt": "2026-05-09T01:36:27.571099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10738,7 +10738,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.881344+00:00"
+                "validatedAt": "2026-05-09T01:36:27.571129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10865,7 +10865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:13.881957+00:00"
+                "validatedAt": "2026-05-09T01:36:27.571395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10914,7 +10914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:18.355825+00:00"
+                "validatedAt": "2026-05-09T01:36:29.558818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10927,7 +10927,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998245+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600685+00:00"
           },
           "name": {
             "type": "string",
@@ -10960,7 +10960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.355920+00:00"
+                "validatedAt": "2026-05-09T01:36:29.558855+00:00"
               },
               "deterministic": true
             },
@@ -10973,7 +10973,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998283+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600701+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11004,7 +11004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.355987+00:00"
+                "validatedAt": "2026-05-09T01:36:29.558873+00:00"
               },
               "deterministic": true
             },
@@ -11017,7 +11017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998313+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600717+00:00"
           },
           "tenant": {
             "type": "string",
@@ -11036,7 +11036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:18.356063+00:00"
+                "validatedAt": "2026-05-09T01:36:29.558893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11050,7 +11050,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998343+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600733+00:00"
           },
           "uid": {
             "type": "string",
@@ -11069,7 +11069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:18.356128+00:00"
+                "validatedAt": "2026-05-09T01:36:29.558908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11084,7 +11084,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998374+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600749+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11126,8 +11126,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_cluster_role_bindingCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_cluster_role_bindingCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_cluster_role_bindings\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -11203,7 +11203,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.356266+00:00"
+                "validatedAt": "2026-05-09T01:36:29.558959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11279,7 +11279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.356317+00:00"
+                "validatedAt": "2026-05-09T01:36:29.558981+00:00"
               },
               "deterministic": true
             },
@@ -11292,7 +11292,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998493+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600810+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11322,7 +11322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.356356+00:00"
+                "validatedAt": "2026-05-09T01:36:29.558999+00:00"
               },
               "deterministic": true
             },
@@ -11335,7 +11335,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998522+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600826+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -11438,7 +11438,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998636+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600879+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -11507,7 +11507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.356518+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11575,7 +11575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:19:18.356578+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11638,7 +11638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:18.356670+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11650,7 +11650,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998734+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600930+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -11717,7 +11717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.356723+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559149+00:00"
               },
               "deterministic": true
             },
@@ -11730,7 +11730,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998804+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600967+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11759,7 +11759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.356762+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559173+00:00"
               },
               "deterministic": true
             },
@@ -11772,7 +11772,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998834+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.600982+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -11811,7 +11811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:18.356830+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11824,7 +11824,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998890+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.601012+00:00"
           },
           "uid": {
             "type": "string",
@@ -11842,7 +11842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:18.356864+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11856,7 +11856,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998921+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.601028+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_cluster_role_binding is returned in 'List'.",
@@ -11906,8 +11906,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_cluster_role_bindingReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_cluster_role_bindingReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_cluster_role_binding_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -11919,8 +11919,8 @@
           "description": "Minimum configuration for k8s_cluster_role_bindingReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_cluster_role_bindingReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_cluster_role_bindingReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_cluster_role_binding_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -11968,7 +11968,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.356946+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12042,7 +12042,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.357028+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559297+00:00"
               },
               "deterministic": true
             },
@@ -12054,7 +12054,7 @@
             },
             "x-original-maxLength": 64,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.998998+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.601068+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12096,7 +12096,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.357099+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559335+00:00"
               },
               "deterministic": true
             },
@@ -12108,7 +12108,7 @@
             },
             "x-original-maxLength": 64,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:41.999027+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.601083+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12215,7 +12215,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.357213+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12263,7 +12263,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.357288+00:00"
+                "validatedAt": "2026-05-09T01:36:29.559426+00:00"
               },
               "deterministic": true
             },
@@ -12343,7 +12343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.359361+00:00"
+                "validatedAt": "2026-05-09T01:36:29.560388+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -12359,7 +12359,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.000191+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.601693+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12396,7 +12396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.359427+00:00"
+                "validatedAt": "2026-05-09T01:36:29.560424+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -12412,7 +12412,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.000221+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.601708+00:00"
           },
           "tenant": {
             "type": "string",
@@ -12441,7 +12441,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:18.359499+00:00"
+                "validatedAt": "2026-05-09T01:36:29.560458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12455,7 +12455,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.000250+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.601724+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -12484,8 +12484,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12511,8 +12511,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_pod_security_admissionCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_pod_security_admissionCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_pod_security_admissions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -12584,7 +12584,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:22.688883+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12658,7 +12658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:22.688932+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484259+00:00"
               },
               "deterministic": true
             },
@@ -12671,7 +12671,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.066836+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.632797+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12701,7 +12701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:22.688971+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484278+00:00"
               },
               "deterministic": true
             },
@@ -12714,7 +12714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.066867+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.632813+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12817,7 +12817,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.066967+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.632865+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -12882,7 +12882,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:22.689132+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12948,7 +12948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:19:22.689192+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13011,7 +13011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:22.689263+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13023,7 +13023,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.067058+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.632910+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -13090,7 +13090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:22.689317+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484460+00:00"
               },
               "deterministic": true
             },
@@ -13103,7 +13103,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.067128+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.632946+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13132,7 +13132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:22.689354+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484479+00:00"
               },
               "deterministic": true
             },
@@ -13145,7 +13145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.067158+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.632962+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -13184,7 +13184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:22.689420+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13197,7 +13197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.067216+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.632992+00:00"
           },
           "uid": {
             "type": "string",
@@ -13215,7 +13215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:22.689454+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13229,7 +13229,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.067247+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.633008+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_pod_security_admission is returned in 'List'.",
@@ -13325,8 +13325,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_pod_security_admissionReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_pod_security_admissionReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_pod_security_admission_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -13338,8 +13338,8 @@
           "description": "Minimum configuration for k8s_pod_security_admissionReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_pod_security_admissionReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_pod_security_admissionReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_pod_security_admission_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -13383,7 +13383,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:22.689556+00:00"
+                "validatedAt": "2026-05-09T01:36:31.484587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13507,7 +13507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.316225+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13552,8 +13552,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_pod_security_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_pod_security_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_pod_security_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -13623,7 +13623,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.316367+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548415+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -13704,7 +13704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.316413+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548437+00:00"
               },
               "deterministic": true
             },
@@ -13717,7 +13717,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.151791+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.673513+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13747,7 +13747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.316451+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548455+00:00"
               },
               "deterministic": true
             },
@@ -13760,7 +13760,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.151824+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.673529+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13863,7 +13863,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.151924+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.673580+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -13926,7 +13926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.316658+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548537+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -13995,7 +13995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.316749+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14140,7 +14140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.316859+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14181,7 +14181,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.316933+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14247,7 +14247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:19:27.316988+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14310,7 +14310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:27.317060+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14322,7 +14322,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.152087+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.673664+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14389,7 +14389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317112+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548744+00:00"
               },
               "deterministic": true
             },
@@ -14402,7 +14402,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.152156+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.673710+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14431,7 +14431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317148+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548761+00:00"
               },
               "deterministic": true
             },
@@ -14444,7 +14444,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.152185+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.673730+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -14483,7 +14483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:27.317215+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14496,7 +14496,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.152242+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.673763+00:00"
           },
           "uid": {
             "type": "string",
@@ -14514,7 +14514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:27.317249+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14528,7 +14528,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.152273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.673779+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_pod_security_policy is returned in 'List'.",
@@ -14625,7 +14625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317323+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14670,7 +14670,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317386+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14707,7 +14707,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317447+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14746,7 +14746,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317510+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14785,7 +14785,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317571+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14844,7 +14844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317658+00:00"
+                "validatedAt": "2026-05-09T01:36:33.548995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14921,7 +14921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:27.317731+00:00"
+                "validatedAt": "2026-05-09T01:36:33.549026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15030,7 +15030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317839+00:00"
+                "validatedAt": "2026-05-09T01:36:33.549075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15104,8 +15104,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_pod_security_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_pod_security_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_pod_security_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -15117,8 +15117,8 @@
           "description": "Minimum configuration for k8s_pod_security_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_pod_security_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_pod_security_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_pod_security_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "managed_kubernetes"
@@ -15160,7 +15160,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:27.317942+00:00"
+                "validatedAt": "2026-05-09T01:36:33.549123+00:00"
               },
               "deterministic": true,
               "format": "uri"

--- a/docs/specifications/api/marketplace.json
+++ b/docs/specifications/api/marketplace.json
@@ -8870,7 +8870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:05.016627+00:00"
+                "validatedAt": "2026-05-09T01:31:57.577810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8882,7 +8882,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359059+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.136692+00:00"
           },
           "subject": {
             "type": "string",
@@ -8897,7 +8897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.016685+00:00"
+                "validatedAt": "2026-05-09T01:31:57.577837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9030,7 +9030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.016782+00:00"
+                "validatedAt": "2026-05-09T01:31:57.577878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9055,7 +9055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.016840+00:00"
+                "validatedAt": "2026-05-09T01:31:57.577908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9084,7 +9084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:05.016883+00:00"
+                "validatedAt": "2026-05-09T01:31:57.577929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9240,7 +9240,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359301+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.136818+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9306,7 +9306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:05.017049+00:00"
+                "validatedAt": "2026-05-09T01:31:57.577995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9369,7 +9369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:05.017117+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9381,7 +9381,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359378+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.136858+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9447,7 +9447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.017172+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578048+00:00"
               },
               "deterministic": true
             },
@@ -9460,7 +9460,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359448+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.136895+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9489,7 +9489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.017210+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578066+00:00"
               },
               "deterministic": true
             },
@@ -9502,7 +9502,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359478+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.136912+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9541,7 +9541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.017278+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9554,7 +9554,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359536+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.136943+00:00"
           },
           "uid": {
             "type": "string",
@@ -9571,7 +9571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.017312+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9585,7 +9585,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359567+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.136959+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of addon_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9654,8 +9654,8 @@
           "description": "Minimum configuration for addon_servicePartiallyManagedActivationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for addon_servicePartiallyManagedActivationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for addon_servicePartiallyManagedActivationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/addon_service_partially_managed_activation_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "marketplace"
@@ -9693,7 +9693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.017419+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9849,8 +9849,8 @@
           "description": "Minimum configuration for customer_supportSupportService",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportService\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportService\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_services\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -9874,8 +9874,8 @@
           "description": "Minimum configuration for customer_supportSupportTicketPriority",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportTicketPriority\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportTicketPriority\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_ticket_priorities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -9890,8 +9890,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -9930,7 +9930,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.017530+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9988,7 +9988,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.017611+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10026,7 +10026,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.017677+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10063,7 +10063,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.017752+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578311+00:00"
               },
               "deterministic": true
             },
@@ -10100,7 +10100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.017813+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10137,7 +10137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:09:05.017862+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578360+00:00"
               },
               "deterministic": true
             },
@@ -10190,7 +10190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.017914+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10213,7 +10213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.017957+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10225,7 +10225,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359828+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137090+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -10262,8 +10262,8 @@
           "description": "Minimum configuration for schemaAddonServiceAccess",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceAccess\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceAccess\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_accesses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10287,8 +10287,8 @@
           "description": "Minimum configuration for schemaAddonServiceState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10313,8 +10313,8 @@
           "description": "Minimum configuration for schemaAddonServiceTierType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceTierType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceTierType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_tier_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10347,7 +10347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:09:05.018003+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578421+00:00"
               },
               "deterministic": true
             },
@@ -10373,7 +10373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018057+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10399,7 +10399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018100+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10411,7 +10411,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359885+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137119+00:00"
           },
           "service_name": {
             "type": "string",
@@ -10428,7 +10428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018150+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10461,7 +10461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018197+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10473,7 +10473,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359924+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137140+00:00"
           },
           "type": {
             "type": "string",
@@ -10498,7 +10498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018241+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10552,8 +10552,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10586,7 +10586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018294+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10631,8 +10631,8 @@
           "description": "Minimum configuration for schemaFeatureTag",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaFeatureTag\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaFeatureTag\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_feature_tags\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -10673,7 +10673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.018334+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578568+00:00"
               },
               "deterministic": true
             },
@@ -10686,7 +10686,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.359999+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137185+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -10805,7 +10805,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.018460+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578623+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10821,7 +10821,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360065+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137219+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -10893,7 +10893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.018512+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578643+00:00"
               },
               "deterministic": true
             },
@@ -10906,7 +10906,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360116+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137246+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10937,7 +10937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.018549+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578659+00:00"
               },
               "deterministic": true
             },
@@ -10950,7 +10950,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360146+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137262+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -10995,7 +10995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018605+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11008,7 +11008,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360178+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137278+00:00"
           },
           "name": {
             "type": "string",
@@ -11041,7 +11041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.018645+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578693+00:00"
               },
               "deterministic": true
             },
@@ -11054,7 +11054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360207+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137294+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11085,7 +11085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.018683+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578710+00:00"
               },
               "deterministic": true
             },
@@ -11098,7 +11098,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360235+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137312+00:00"
           },
           "tenant": {
             "type": "string",
@@ -11117,7 +11117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018726+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11131,7 +11131,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360265+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137328+00:00"
           },
           "uid": {
             "type": "string",
@@ -11150,7 +11150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018760+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11165,7 +11165,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360295+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137345+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11210,7 +11210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018816+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11238,7 +11238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018867+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11266,7 +11266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018915+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11295,7 +11295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018966+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11322,7 +11322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.018999+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11336,7 +11336,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360375+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137388+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -11352,7 +11352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019045+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11415,8 +11415,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11461,7 +11461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019109+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11473,7 +11473,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360437+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137420+00:00"
           },
           "status": {
             "type": "string",
@@ -11491,7 +11491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019152+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11503,7 +11503,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360465+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137436+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -11545,7 +11545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019207+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11572,7 +11572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019258+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11599,7 +11599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019307+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11627,7 +11627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019362+00:00"
+                "validatedAt": "2026-05-09T01:31:57.578994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11692,7 +11692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019444+00:00"
+                "validatedAt": "2026-05-09T01:31:57.579029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11741,7 +11741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019507+00:00"
+                "validatedAt": "2026-05-09T01:31:57.579056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11754,7 +11754,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360607+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137505+00:00"
           },
           "uid": {
             "type": "string",
@@ -11773,7 +11773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019540+00:00"
+                "validatedAt": "2026-05-09T01:31:57.579070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11787,7 +11787,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360638+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137520+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -11837,7 +11837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019579+00:00"
+                "validatedAt": "2026-05-09T01:31:57.579086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11849,7 +11849,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360669+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137537+00:00"
           },
           "name": {
             "type": "string",
@@ -11882,7 +11882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.019632+00:00"
+                "validatedAt": "2026-05-09T01:31:57.579103+00:00"
               },
               "deterministic": true
             },
@@ -11895,7 +11895,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360698+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137552+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11926,7 +11926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:05.019671+00:00"
+                "validatedAt": "2026-05-09T01:31:57.579120+00:00"
               },
               "deterministic": true
             },
@@ -11939,7 +11939,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360728+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137568+00:00"
           },
           "uid": {
             "type": "string",
@@ -11956,7 +11956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:05.019704+00:00"
+                "validatedAt": "2026-05-09T01:31:57.579134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11970,7 +11970,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.360757+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.137584+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -12008,8 +12008,8 @@
           "description": "Minimum configuration for addon_subscriptionAddonSubscriptionState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for addon_subscriptionAddonSubscriptionState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for addon_subscriptionAddonSubscriptionState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/addon_subscription_addon_subscription_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "marketplace"
@@ -12035,8 +12035,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for addon_subscriptionCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for addon_subscriptionCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/addon_subscriptions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "marketplace"
@@ -12152,7 +12152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.202376+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557572+00:00"
               },
               "deterministic": true
             },
@@ -12165,7 +12165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.398486+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155437+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12195,7 +12195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.202436+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557599+00:00"
               },
               "deterministic": true
             },
@@ -12208,7 +12208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.398520+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155453+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12390,7 +12390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:07.202613+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12453,7 +12453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:07.202689+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12465,7 +12465,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.398719+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155544+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -12531,7 +12531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.202747+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557712+00:00"
               },
               "deterministic": true
             },
@@ -12544,7 +12544,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.398791+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155580+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12573,7 +12573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.202788+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557730+00:00"
               },
               "deterministic": true
             },
@@ -12586,7 +12586,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.398821+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155596+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -12609,7 +12609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:07.202839+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12622,7 +12622,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.398870+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155621+00:00"
           },
           "uid": {
             "type": "string",
@@ -12640,7 +12640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:07.202873+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12654,7 +12654,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.398901+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155637+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of addon_subscription is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -12732,8 +12732,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for addon_subscriptionReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for addon_subscriptionReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/addon_subscription_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "marketplace"
@@ -12745,8 +12745,8 @@
           "description": "Minimum configuration for addon_subscriptionReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for addon_subscriptionReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for addon_subscriptionReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/addon_subscription_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "marketplace"
@@ -12806,7 +12806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:07.202962+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12831,7 +12831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:07.203021+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12881,7 +12881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:07.203062+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12894,7 +12894,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399034+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155703+00:00"
           },
           "name": {
             "type": "string",
@@ -12927,7 +12927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.203099+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557863+00:00"
               },
               "deterministic": true
             },
@@ -12940,7 +12940,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399063+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155718+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12971,7 +12971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.203137+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557879+00:00"
               },
               "deterministic": true
             },
@@ -12984,7 +12984,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399093+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155733+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13003,7 +13003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:07.203180+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13017,7 +13017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399122+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155749+00:00"
           },
           "uid": {
             "type": "string",
@@ -13036,7 +13036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:07.203213+00:00"
+                "validatedAt": "2026-05-09T01:31:58.557912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13051,7 +13051,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399153+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155765+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -13132,7 +13132,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.203612+00:00"
+                "validatedAt": "2026-05-09T01:31:58.558081+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -13148,7 +13148,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399411+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155860+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -13218,7 +13218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.203664+00:00"
+                "validatedAt": "2026-05-09T01:31:58.558104+00:00"
               },
               "deterministic": true
             },
@@ -13231,7 +13231,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399463+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155887+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13262,7 +13262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.203702+00:00"
+                "validatedAt": "2026-05-09T01:31:58.558121+00:00"
               },
               "deterministic": true
             },
@@ -13275,7 +13275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399493+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155902+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -13357,7 +13357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.203987+00:00"
+                "validatedAt": "2026-05-09T01:31:58.558257+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -13373,7 +13373,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399676+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.155989+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -13443,7 +13443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.204035+00:00"
+                "validatedAt": "2026-05-09T01:31:58.558279+00:00"
               },
               "deterministic": true
             },
@@ -13456,7 +13456,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399727+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.156015+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13487,7 +13487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.204071+00:00"
+                "validatedAt": "2026-05-09T01:31:58.558295+00:00"
               },
               "deterministic": true
             },
@@ -13500,7 +13500,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.399756+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.156031+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -13571,7 +13571,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.204796+00:00"
+                "validatedAt": "2026-05-09T01:31:58.558602+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13587,7 +13587,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.400137+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.156241+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13624,7 +13624,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.204862+00:00"
+                "validatedAt": "2026-05-09T01:31:58.558634+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13640,7 +13640,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.400166+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.156256+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13669,7 +13669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:07.204934+00:00"
+                "validatedAt": "2026-05-09T01:31:58.558669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13683,7 +13683,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.400195+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.156272+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -13723,8 +13723,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cminstanceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cminstanceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cminstances\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "marketplace"
@@ -13803,7 +13803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.409070+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851303+00:00"
               },
               "deterministic": true
             },
@@ -13847,7 +13847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.409213+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851353+00:00"
               },
               "deterministic": true
             },
@@ -13926,7 +13926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.409291+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851376+00:00"
               },
               "deterministic": true
             },
@@ -13939,7 +13939,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.575687+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.668752+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13969,7 +13969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.409337+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851394+00:00"
               },
               "deterministic": true
             },
@@ -13982,7 +13982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.575722+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.668769+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14085,7 +14085,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.575822+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.668822+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -14157,7 +14157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.409483+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851456+00:00"
               },
               "deterministic": true
             },
@@ -14201,7 +14201,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.409559+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851493+00:00"
               },
               "deterministic": true
             },
@@ -14272,7 +14272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:30.409633+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14335,7 +14335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:30.409704+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14347,7 +14347,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.575948+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.668889+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14413,7 +14413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.409756+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851572+00:00"
               },
               "deterministic": true
             },
@@ -14426,7 +14426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.576022+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.668927+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14455,7 +14455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.409793+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851590+00:00"
               },
               "deterministic": true
             },
@@ -14468,7 +14468,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.576051+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.668944+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -14507,7 +14507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:30.409860+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14520,7 +14520,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.576109+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.668982+00:00"
           },
           "uid": {
             "type": "string",
@@ -14537,7 +14537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:30.409895+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14551,7 +14551,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.576140+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.669002+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cminstance is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -14601,8 +14601,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cminstanceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cminstanceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cminstance_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "marketplace"
@@ -14614,8 +14614,8 @@
           "description": "Minimum configuration for cminstanceReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cminstanceReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cminstanceReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cminstance_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "marketplace"
@@ -14666,7 +14666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.409956+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851661+00:00"
               },
               "deterministic": true
             },
@@ -14710,7 +14710,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.410028+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851698+00:00"
               },
               "deterministic": true
             },
@@ -14821,7 +14821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:30.410247+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14859,7 +14859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.410325+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14871,7 +14871,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.576329+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.669107+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -14890,7 +14890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:30.410378+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14941,7 +14941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:30.410423+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14953,7 +14953,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.576370+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.669134+00:00"
           },
           "url": {
             "type": "string",
@@ -14991,7 +14991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.410498+00:00"
+                "validatedAt": "2026-05-09T01:33:01.851906+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -15051,7 +15051,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:30.410971+00:00"
+                "validatedAt": "2026-05-09T01:33:01.852115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15089,8 +15089,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -15172,8 +15172,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for external_connectorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for external_connectorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/external_connectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -15286,7 +15286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:20.848774+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469565+00:00"
               },
               "deterministic": true
             },
@@ -15299,7 +15299,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.622113+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.022172+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15329,7 +15329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:20.848844+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469587+00:00"
               },
               "deterministic": true
             },
@@ -15342,7 +15342,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.622146+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.022191+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -15389,7 +15389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:16:20.848930+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469612+00:00"
               },
               "deterministic": true
             },
@@ -15565,7 +15565,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.622319+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.022284+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -15665,7 +15665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:20.849193+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15753,7 +15753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:20.849263+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15816,7 +15816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:20.849336+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15828,7 +15828,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.622515+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.022384+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15894,7 +15894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:20.849390+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469788+00:00"
               },
               "deterministic": true
             },
@@ -15907,7 +15907,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.622604+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.022421+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15936,7 +15936,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:20.849427+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469805+00:00"
               },
               "deterministic": true
             },
@@ -15949,7 +15949,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.622635+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.022437+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -15988,7 +15988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:20.849496+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16001,7 +16001,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.622694+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.022468+00:00"
           },
           "uid": {
             "type": "string",
@@ -16019,7 +16019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:20.849531+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16033,7 +16033,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.622725+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.022484+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of external_connector is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -16083,8 +16083,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for external_connectorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for external_connectorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/external_connector_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -16096,8 +16096,8 @@
           "description": "Minimum configuration for external_connectorReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for external_connectorReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for external_connectorReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/external_connector_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -16218,7 +16218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:20.849663+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16254,7 +16254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:20.849721+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16286,7 +16286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:20.849763+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16322,7 +16322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:20.849821+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16382,7 +16382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:20.849862+00:00"
+                "validatedAt": "2026-05-09T01:35:10.469985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16432,7 +16432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:20.849945+00:00"
+                "validatedAt": "2026-05-09T01:35:10.470026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16550,7 +16550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:20.850814+00:00"
+                "validatedAt": "2026-05-09T01:35:10.470417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16608,7 +16608,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:20.851433+00:00"
+                "validatedAt": "2026-05-09T01:35:10.470712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16734,7 +16734,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.034382+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.549710+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16792,7 +16792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:09.043905+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16823,7 +16823,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:09.044009+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16860,7 +16860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:09.044086+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941197+00:00"
               },
               "deterministic": true
             },
@@ -16910,7 +16910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:09.044156+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16946,7 +16946,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:09.044213+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16974,7 +16974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:21:09.044256+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941282+00:00"
               },
               "deterministic": true
             },
@@ -17047,7 +17047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:21:09.044310+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17110,7 +17110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:09.044378+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17122,7 +17122,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.034537+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.549787+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17188,7 +17188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:09.044434+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941364+00:00"
               },
               "deterministic": true
             },
@@ -17201,7 +17201,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.034635+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.549824+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17230,7 +17230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:09.044474+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941383+00:00"
               },
               "deterministic": true
             },
@@ -17243,7 +17243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.034667+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.549839+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -17282,7 +17282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:09.044541+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17295,7 +17295,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.034727+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.549870+00:00"
           },
           "uid": {
             "type": "string",
@@ -17312,7 +17312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:09.044573+00:00"
+                "validatedAt": "2026-05-09T01:37:19.941427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17326,7 +17326,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.034758+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.549886+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of navigation_tile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -17433,7 +17433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.314703+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17479,8 +17479,8 @@
           "description": "Minimum configuration for aws_accountAWSAccountSignupResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for aws_accountAWSAccountSignupResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for aws_accountAWSAccountSignupResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/aws_account_a_w_s_account_signup_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -17507,7 +17507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.314854+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17554,7 +17554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.314955+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17588,8 +17588,8 @@
           "description": "Minimum configuration for schemaCRMInfo",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaCRMInfo\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaCRMInfo\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_c_r_m_infos\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -17626,7 +17626,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:43.315066+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17638,7 +17638,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.747926+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.870489+00:00"
           },
           "locale": {
             "type": "string",
@@ -17662,7 +17662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:43.315144+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17689,7 +17689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315199+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17721,7 +17721,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:43.315280+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17791,7 +17791,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:43.315361+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494502+00:00"
               },
               "deterministic": true
             },
@@ -17804,7 +17804,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.748003+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.870528+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17842,7 +17842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315409+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17867,7 +17867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315454+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17892,7 +17892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315493+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17917,7 +17917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315538+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17943,7 +17943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315599+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17968,7 +17968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315652+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17994,7 +17994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315695+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18020,7 +18020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315743+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18045,7 +18045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:43.315788+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18106,7 +18106,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:43.315876+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18146,7 +18146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:43.315955+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494851+00:00"
               },
               "deterministic": true
             },
@@ -18179,7 +18179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:43.316032+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18211,7 +18211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:43.316107+00:00"
+                "validatedAt": "2026-05-09T01:37:35.494949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18317,7 +18317,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.109302+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.039094+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -18375,7 +18375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:03.855129+00:00"
+                "validatedAt": "2026-05-09T01:37:44.664590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18412,7 +18412,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:03.855219+00:00"
+                "validatedAt": "2026-05-09T01:37:44.664635+00:00"
               },
               "deterministic": true
             },
@@ -18450,7 +18450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:03.855283+00:00"
+                "validatedAt": "2026-05-09T01:37:44.664665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18518,7 +18518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:22:03.855340+00:00"
+                "validatedAt": "2026-05-09T01:37:44.664689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18580,7 +18580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:22:03.855413+00:00"
+                "validatedAt": "2026-05-09T01:37:44.664720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18592,7 +18592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.109419+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.039158+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18657,7 +18657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:03.855473+00:00"
+                "validatedAt": "2026-05-09T01:37:44.664746+00:00"
               },
               "deterministic": true
             },
@@ -18670,7 +18670,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.109491+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.039195+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18699,7 +18699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:03.855511+00:00"
+                "validatedAt": "2026-05-09T01:37:44.664763+00:00"
               },
               "deterministic": true
             },
@@ -18712,7 +18712,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.109521+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.039211+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -18751,7 +18751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:03.855578+00:00"
+                "validatedAt": "2026-05-09T01:37:44.664791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18764,7 +18764,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.109581+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.039242+00:00"
           },
           "uid": {
             "type": "string",
@@ -18781,7 +18781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:03.855628+00:00"
+                "validatedAt": "2026-05-09T01:37:44.664806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18795,7 +18795,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.109630+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.039258+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of plan is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -18900,7 +18900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.440631+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18975,7 +18975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.440730+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406537+00:00"
               },
               "deterministic": true
             },
@@ -18988,7 +18988,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.574067+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.074935+00:00"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -19043,7 +19043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.440806+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19068,7 +19068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.440856+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19101,7 +19101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.440920+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19225,7 +19225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.441002+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19314,7 +19314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.441101+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19338,7 +19338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.441153+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19409,7 +19409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.441214+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19433,7 +19433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.441268+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19747,7 +19747,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.441510+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406857+00:00"
               },
               "deterministic": true
             },
@@ -19830,7 +19830,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.441608+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19942,7 +19942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.441705+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19980,7 +19980,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.441805+00:00"
+                "validatedAt": "2026-05-09T01:39:49.406973+00:00"
               },
               "deterministic": true
             },
@@ -20072,7 +20072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.441886+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20130,7 +20130,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.441967+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20143,7 +20143,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.574702+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.075264+00:00"
           },
           "simple_login": {
             "$ref": "#/components/schemas/common_wafSimpleLogin"
@@ -20206,7 +20206,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.442067+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20245,7 +20245,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.442149+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20474,7 +20474,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.442280+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20548,7 +20548,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.442356+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20611,7 +20611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.442444+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20650,7 +20650,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.442525+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20691,7 +20691,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.442648+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20762,7 +20762,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.442735+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407394+00:00"
               },
               "deterministic": true
             },
@@ -20827,7 +20827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.442804+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20934,8 +20934,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20959,8 +20959,8 @@
           "description": "Minimum configuration for schemaHttpSections",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpSections\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpSections\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_sectionses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20997,7 +20997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.443969+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407905+00:00"
               },
               "deterministic": true
             },
@@ -21010,7 +21010,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.575652+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.075763+00:00"
           },
           "name": {
             "type": "string",
@@ -21054,7 +21054,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.444036+00:00"
+                "validatedAt": "2026-05-09T01:39:49.407936+00:00"
               },
               "deterministic": true
             },
@@ -21066,7 +21066,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.575682+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.075778+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -21107,8 +21107,8 @@
           "description": "Minimum configuration for schemaOpenApiValidationProperties",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_open_api_validation_propertieses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21137,7 +21137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:26:39.445689+00:00"
+                "validatedAt": "2026-05-09T01:39:49.408652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21245,7 +21245,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.576618+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.076279+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -21316,7 +21316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.445822+00:00"
+                "validatedAt": "2026-05-09T01:39:49.408707+00:00"
               },
               "deterministic": true
             },
@@ -21329,7 +21329,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.576670+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.076306+00:00"
           },
           "third_party_applications_list": {
             "$ref": "#/components/schemas/third_party_applicationThirdPartyApplicationList"
@@ -21392,7 +21392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:39.445884+00:00"
+                "validatedAt": "2026-05-09T01:39:49.408734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21455,7 +21455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:39.445952+00:00"
+                "validatedAt": "2026-05-09T01:39:49.408763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21467,7 +21467,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.576747+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.076345+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21534,7 +21534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.446004+00:00"
+                "validatedAt": "2026-05-09T01:39:49.408784+00:00"
               },
               "deterministic": true
             },
@@ -21547,7 +21547,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.576816+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.076382+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21576,7 +21576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.446040+00:00"
+                "validatedAt": "2026-05-09T01:39:49.408800+00:00"
               },
               "deterministic": true
             },
@@ -21589,7 +21589,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.576846+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.076397+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21628,7 +21628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.446106+00:00"
+                "validatedAt": "2026-05-09T01:39:49.408829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21641,7 +21641,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.576904+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.076428+00:00"
           },
           "uid": {
             "type": "string",
@@ -21659,7 +21659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:39.446140+00:00"
+                "validatedAt": "2026-05-09T01:39:49.408846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21673,7 +21673,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.576935+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.076444+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of third_party_application is returned in 'List'.",
@@ -21723,8 +21723,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for third_party_applicationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for third_party_applicationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/third_party_application_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21736,8 +21736,8 @@
           "description": "Minimum configuration for third_party_applicationReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for third_party_applicationReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for third_party_applicationReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/third_party_application_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21844,7 +21844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:39.446259+00:00"
+                "validatedAt": "2026-05-09T01:39:49.408906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22065,8 +22065,8 @@
           "description": "Minimum configuration for terraform_parametersApplyStageState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersApplyStageState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersApplyStageState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_apply_stage_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22092,7 +22092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755312+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22120,7 +22120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755367+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22150,7 +22150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755427+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22176,7 +22176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755479+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22202,7 +22202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755527+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22225,7 +22225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755575+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22272,8 +22272,8 @@
           "description": "Minimum configuration for terraform_parametersDestroyStageState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersDestroyStageState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersDestroyStageState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_destroy_stage_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22313,7 +22313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:03.755637+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340511+00:00"
               },
               "deterministic": true
             },
@@ -22326,7 +22326,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.104205+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.773911+00:00"
           },
           "view_kind": {
             "type": "string",
@@ -22344,7 +22344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755687+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22370,7 +22370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755736+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22405,8 +22405,8 @@
           "description": "Minimum configuration for terraform_parametersForceDeleteResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersForceDeleteResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersForceDeleteResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_forces\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22473,8 +22473,8 @@
           "description": "Minimum configuration for terraform_parametersInfraState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersInfraState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersInfraState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_infra_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22499,8 +22499,8 @@
           "description": "Minimum configuration for terraform_parametersPlanStageState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersPlanStageState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersPlanStageState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_plan_stage_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22525,7 +22525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755801+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22555,7 +22555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755861+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22584,7 +22584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755917+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22610,7 +22610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.755969+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22656,8 +22656,8 @@
           "description": "Minimum configuration for terraform_parametersRunAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersRunAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersRunAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_run_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22700,7 +22700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:03.756012+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340678+00:00"
               },
               "deterministic": true
             },
@@ -22713,7 +22713,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.104355+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.773989+00:00"
           },
           "view_kind": {
             "type": "string",
@@ -22731,7 +22731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.756061+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22757,7 +22757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.756108+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22794,8 +22794,8 @@
           "description": "Minimum configuration for terraform_parametersRunResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersRunResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersRunResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_run_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22887,7 +22887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:03.756211+00:00"
+                "validatedAt": "2026-05-09T01:40:26.340768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22967,7 +22967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:05.758283+00:00"
+                "validatedAt": "2026-05-09T01:40:53.239559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22992,7 +22992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:05.758378+00:00"
+                "validatedAt": "2026-05-09T01:40:53.239594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23005,7 +23005,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.466292+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.411391+00:00"
           },
           "email": {
             "type": "string",
@@ -23031,7 +23031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:29:05.758468+00:00"
+                "validatedAt": "2026-05-09T01:40:53.239617+00:00"
               },
               "deterministic": true
             },
@@ -23058,7 +23058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:05.758527+00:00"
+                "validatedAt": "2026-05-09T01:40:53.239639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23106,7 +23106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:05.758575+00:00"
+                "validatedAt": "2026-05-09T01:40:53.239660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23169,7 +23169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:29:05.758680+00:00"
+                "validatedAt": "2026-05-09T01:40:53.239685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23229,7 +23229,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:05.758776+00:00"
+                "validatedAt": "2026-05-09T01:40:53.239729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23240,7 +23240,7 @@
             },
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.466380+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.411436+00:00"
           },
           "token": {
             "type": "string",
@@ -23258,7 +23258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:29:05.758831+00:00"
+                "validatedAt": "2026-05-09T01:40:53.239753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23291,8 +23291,8 @@
           "description": "Minimum configuration for xc_saasXCSaaSSignupResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for xc_saasXCSaaSSignupResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for xc_saasXCSaaSSignupResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/xc_saas_x_c_saa_s_signup_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"

--- a/docs/specifications/api/network.json
+++ b/docs/specifications/api/network.json
@@ -22761,8 +22761,8 @@
           "description": "Minimum configuration for address_allocatorAllocatorMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for address_allocatorAllocatorMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for address_allocatorAllocatorMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/address_allocator_allocator_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -22788,8 +22788,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for address_allocatorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for address_allocatorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/address_allocators\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -22867,7 +22867,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.387256+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538078+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22946,7 +22946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.387321+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538106+00:00"
               },
               "deterministic": true
             },
@@ -22959,7 +22959,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.436574+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173227+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22989,7 +22989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.387363+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538124+00:00"
               },
               "deterministic": true
             },
@@ -23002,7 +23002,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.436622+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173243+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23102,7 +23102,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.436715+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173291+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -23172,7 +23172,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.387523+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23243,7 +23243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:09.387604+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23306,7 +23306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:09.387685+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23318,7 +23318,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.436824+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173347+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23384,7 +23384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.387739+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538278+00:00"
               },
               "deterministic": true
             },
@@ -23397,7 +23397,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.436895+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173384+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23426,7 +23426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.387776+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538295+00:00"
               },
               "deterministic": true
             },
@@ -23439,7 +23439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.436926+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173400+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -23478,7 +23478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.387845+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23491,7 +23491,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.436984+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173431+00:00"
           },
           "uid": {
             "type": "string",
@@ -23509,7 +23509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.387881+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23523,7 +23523,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437015+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173447+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of address_allocator is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23570,8 +23570,8 @@
           "description": "Minimum configuration for address_allocatorLocalInterfaceAddressType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for address_allocatorLocalInterfaceAddressType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for address_allocatorLocalInterfaceAddressType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/address_allocator_local_interface_address_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -23650,7 +23650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.387966+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23673,7 +23673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388011+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23685,7 +23685,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437093+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173487+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -23731,7 +23731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:09:09.388056+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538421+00:00"
               },
               "deterministic": true
             },
@@ -23757,7 +23757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388109+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23783,7 +23783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388153+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23795,7 +23795,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437145+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173514+00:00"
           },
           "service_name": {
             "type": "string",
@@ -23812,7 +23812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388203+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23845,7 +23845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388252+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23857,7 +23857,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437184+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173535+00:00"
           },
           "type": {
             "type": "string",
@@ -23882,7 +23882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388296+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23936,8 +23936,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -23970,7 +23970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388348+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24032,7 +24032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.388386+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538563+00:00"
               },
               "deterministic": true
             },
@@ -24045,7 +24045,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437259+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173574+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -24163,7 +24163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.388509+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538618+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24179,7 +24179,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437323+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173607+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24249,7 +24249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.388558+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538639+00:00"
               },
               "deterministic": true
             },
@@ -24262,7 +24262,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437374+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173634+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24293,7 +24293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.388610+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538655+00:00"
               },
               "deterministic": true
             },
@@ -24306,7 +24306,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437404+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173650+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -24388,7 +24388,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.388713+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538700+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24404,7 +24404,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437447+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173672+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24476,7 +24476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.388761+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538721+00:00"
               },
               "deterministic": true
             },
@@ -24489,7 +24489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437498+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173699+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24520,7 +24520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.388798+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538738+00:00"
               },
               "deterministic": true
             },
@@ -24533,7 +24533,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437527+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173715+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -24578,7 +24578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388839+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24591,7 +24591,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437559+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173731+00:00"
           },
           "name": {
             "type": "string",
@@ -24624,7 +24624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.388875+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538772+00:00"
               },
               "deterministic": true
             },
@@ -24637,7 +24637,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437600+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173747+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24668,7 +24668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.388911+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538789+00:00"
               },
               "deterministic": true
             },
@@ -24681,7 +24681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437631+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173763+00:00"
           },
           "tenant": {
             "type": "string",
@@ -24700,7 +24700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388954+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24714,7 +24714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437660+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173779+00:00"
           },
           "uid": {
             "type": "string",
@@ -24733,7 +24733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.388987+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24748,7 +24748,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437691+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173795+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -24793,7 +24793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389043+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24821,7 +24821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389094+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24849,7 +24849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389143+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24878,7 +24878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389193+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24905,7 +24905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389226+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24919,7 +24919,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437771+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173839+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -24935,7 +24935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389270+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24998,8 +24998,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25044,7 +25044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389333+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25056,7 +25056,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437833+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173871+00:00"
           },
           "status": {
             "type": "string",
@@ -25074,7 +25074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389376+00:00"
+                "validatedAt": "2026-05-09T01:31:59.538987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25086,7 +25086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437863+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173887+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -25128,7 +25128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389432+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25155,7 +25155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389483+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25182,7 +25182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389533+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25210,7 +25210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389601+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25275,7 +25275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389683+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25324,7 +25324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389747+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25337,7 +25337,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.437991+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173956+00:00"
           },
           "uid": {
             "type": "string",
@@ -25356,7 +25356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389780+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25370,7 +25370,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.438021+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173972+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -25420,7 +25420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389820+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25432,7 +25432,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.438052+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.173989+00:00"
           },
           "name": {
             "type": "string",
@@ -25465,7 +25465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.389857+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539190+00:00"
               },
               "deterministic": true
             },
@@ -25478,7 +25478,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.438081+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.174004+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25509,7 +25509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:09.389897+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539206+00:00"
               },
               "deterministic": true
             },
@@ -25522,7 +25522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.438110+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.174020+00:00"
           },
           "uid": {
             "type": "string",
@@ -25539,7 +25539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:09.389929+00:00"
+                "validatedAt": "2026-05-09T01:31:59.539220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25553,7 +25553,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.438140+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.174036+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -25593,8 +25593,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for advertise_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for advertise_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/advertise_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -25658,7 +25658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.858999+00:00"
+                "validatedAt": "2026-05-09T01:32:00.619950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25693,7 +25693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.859082+00:00"
+                "validatedAt": "2026-05-09T01:32:00.619981+00:00"
               },
               "deterministic": true
             },
@@ -25738,7 +25738,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.859181+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25771,7 +25771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:11.859234+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25889,7 +25889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.859320+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620078+00:00"
               },
               "deterministic": true
             },
@@ -25902,7 +25902,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476190+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191705+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25932,7 +25932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.859366+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620097+00:00"
               },
               "deterministic": true
             },
@@ -25945,7 +25945,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476224+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191722+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26048,7 +26048,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476326+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191774+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -26105,7 +26105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.859535+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26140,7 +26140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.859600+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620195+00:00"
               },
               "deterministic": true
             },
@@ -26185,7 +26185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.859692+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26218,7 +26218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:11.859746+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26327,7 +26327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:11.859835+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26390,7 +26390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:11.859907+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26402,7 +26402,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476485+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191856+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26468,7 +26468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.859962+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620343+00:00"
               },
               "deterministic": true
             },
@@ -26481,7 +26481,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476555+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191894+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26510,7 +26510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.860001+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620360+00:00"
               },
               "deterministic": true
             },
@@ -26523,7 +26523,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476600+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191910+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26562,7 +26562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:11.860071+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26575,7 +26575,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476662+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191941+00:00"
           },
           "uid": {
             "type": "string",
@@ -26593,7 +26593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:11.860106+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26607,7 +26607,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476695+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191958+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of advertise_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -26668,7 +26668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.860146+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620419+00:00"
               },
               "deterministic": true
             },
@@ -26681,7 +26681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476729+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191976+00:00"
           },
           "port": {
             "type": "integer",
@@ -26701,7 +26701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.860185+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620436+00:00"
               },
               "deterministic": true
             },
@@ -26726,7 +26726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:11.860229+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26738,7 +26738,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.476770+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.191997+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26776,8 +26776,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for advertise_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for advertise_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/advertise_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -26789,8 +26789,8 @@
           "description": "Minimum configuration for advertise_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for advertise_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for advertise_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/advertise_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -26826,7 +26826,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.860317+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26861,7 +26861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.860358+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620511+00:00"
               },
               "deterministic": true
             },
@@ -26906,7 +26906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.860445+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26939,7 +26939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:11.860495+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27090,8 +27090,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -27121,7 +27121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:11.860741+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27159,7 +27159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.860817+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27171,7 +27171,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.477004+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.192120+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -27190,7 +27190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:11.860870+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27241,7 +27241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:11.860918+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27253,7 +27253,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.477046+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.192142+00:00"
           },
           "url": {
             "type": "string",
@@ -27291,7 +27291,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.860998+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620795+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -27368,7 +27368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.861364+00:00"
+                "validatedAt": "2026-05-09T01:32:00.620954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27414,8 +27414,8 @@
           "description": "Minimum configuration for schemaHashAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_hash_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -27461,7 +27461,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.861487+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27519,7 +27519,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.861620+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27638,7 +27638,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.862311+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621369+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -27654,7 +27654,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.477810+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.192571+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -27724,7 +27724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.862366+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621391+00:00"
               },
               "deterministic": true
             },
@@ -27737,7 +27737,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.477861+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.192598+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27768,7 +27768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.862402+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621407+00:00"
               },
               "deterministic": true
             },
@@ -27781,7 +27781,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.477890+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.192613+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -27817,8 +27817,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -27895,7 +27895,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.862478+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27967,7 +27967,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.863377+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27999,7 +27999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:11.863443+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28011,7 +28011,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.478339+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.192849+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -28076,7 +28076,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.863513+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28149,8 +28149,8 @@
           "description": "Minimum configuration for schemaTlsProtocol",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tls_protocols\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28208,7 +28208,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.863650+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28288,7 +28288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.863734+00:00"
+                "validatedAt": "2026-05-09T01:32:00.621967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28355,7 +28355,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:11.863799+00:00"
+                "validatedAt": "2026-05-09T01:32:00.622002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28410,8 +28410,8 @@
           "description": "Minimum configuration for schemaVirtualNetworkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_virtual_network_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28437,8 +28437,8 @@
           "description": "Minimum configuration for schemaXfccElement",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_xfcc_elements\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28607,7 +28607,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.630531+00:00"
+                "validatedAt": "2026-05-09T01:32:22.288840+00:00"
               },
               "deterministic": true
             },
@@ -28665,8 +28665,8 @@
           "description": "Minimum configuration for bgpBgpPeerProtocolState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgpBgpPeerProtocolState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgpBgpPeerProtocolState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_bgp_peer_protocol_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -28721,7 +28721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.630670+00:00"
+                "validatedAt": "2026-05-09T01:32:22.288882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28745,7 +28745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.630724+00:00"
+                "validatedAt": "2026-05-09T01:32:22.288905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28798,7 +28798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.630813+00:00"
+                "validatedAt": "2026-05-09T01:32:22.288941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28845,7 +28845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.630897+00:00"
+                "validatedAt": "2026-05-09T01:32:22.288976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28897,8 +28897,8 @@
           "description": "Minimum configuration for bgpBgpPeerUpDownType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgpBgpPeerUpDownType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgpBgpPeerUpDownType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_bgp_peer_up_down_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -28934,7 +28934,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.630979+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29008,7 +29008,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.631056+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29073,7 +29073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.631132+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289078+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29123,7 +29123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.631212+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29170,8 +29170,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgpCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgpCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgps\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -29241,7 +29241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.631296+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29321,7 +29321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.631350+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289183+00:00"
               },
               "deterministic": true
             },
@@ -29334,7 +29334,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.593326+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.727783+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29364,7 +29364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.631389+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289201+00:00"
               },
               "deterministic": true
             },
@@ -29377,7 +29377,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.593359+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.727800+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29638,7 +29638,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.593599+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.727916+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -29701,7 +29701,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.631608+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29757,7 +29757,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.593674+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.727954+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29813,7 +29813,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.631700+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29878,7 +29878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:10:00.631757+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29940,7 +29940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:10:00.631829+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29952,7 +29952,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.593753+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.727995+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -30017,7 +30017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.631883+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289406+00:00"
               },
               "deterministic": true
             },
@@ -30030,7 +30030,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.593823+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728032+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30059,7 +30059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.631921+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289424+00:00"
               },
               "deterministic": true
             },
@@ -30072,7 +30072,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.593852+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728048+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -30111,7 +30111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.631988+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30124,7 +30124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.593910+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728087+00:00"
           },
           "uid": {
             "type": "string",
@@ -30141,7 +30141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.632022+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30155,7 +30155,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.593941+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728104+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of BGP is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -30260,7 +30260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.632091+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30338,7 +30338,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.632182+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30379,7 +30379,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.632261+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30465,7 +30465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.632360+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30508,7 +30508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.632406+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289631+00:00"
               },
               "deterministic": true
             },
@@ -30694,8 +30694,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgpReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgpReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -30707,8 +30707,8 @@
           "description": "Minimum configuration for bgpReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgpReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgpReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -30750,7 +30750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.632566+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30865,7 +30865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.632697+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30878,7 +30878,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.594352+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728341+00:00"
           },
           "name": {
             "type": "string",
@@ -30911,7 +30911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.632740+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289755+00:00"
               },
               "deterministic": true
             },
@@ -30924,7 +30924,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.594381+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728357+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30955,7 +30955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.632778+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289771+00:00"
               },
               "deterministic": true
             },
@@ -30968,7 +30968,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.594410+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728372+00:00"
           },
           "tenant": {
             "type": "string",
@@ -30987,7 +30987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.632822+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31001,7 +31001,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.594439+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728388+00:00"
           },
           "uid": {
             "type": "string",
@@ -31020,7 +31020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:00.632856+00:00"
+                "validatedAt": "2026-05-09T01:32:22.289805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31035,7 +31035,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.594469+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728404+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -31117,7 +31117,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.633425+00:00"
+                "validatedAt": "2026-05-09T01:32:22.290062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31171,7 +31171,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.633496+00:00"
+                "validatedAt": "2026-05-09T01:32:22.290096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31227,7 +31227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.633621+00:00"
+                "validatedAt": "2026-05-09T01:32:22.290140+00:00"
               },
               "deterministic": true
             },
@@ -31240,7 +31240,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.594786+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728563+00:00"
           },
           "name": {
             "type": "string",
@@ -31284,7 +31284,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.633692+00:00"
+                "validatedAt": "2026-05-09T01:32:22.290186+00:00"
               },
               "deterministic": true
             },
@@ -31296,7 +31296,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.594814+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.728578+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -31394,7 +31394,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.635439+00:00"
+                "validatedAt": "2026-05-09T01:32:22.290942+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -31410,7 +31410,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.595790+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.729102+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31447,7 +31447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.635505+00:00"
+                "validatedAt": "2026-05-09T01:32:22.290974+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -31463,7 +31463,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.595819+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.729117+00:00"
           },
           "tenant": {
             "type": "string",
@@ -31492,7 +31492,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:00.635579+00:00"
+                "validatedAt": "2026-05-09T01:32:22.291009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31506,7 +31506,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.595849+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.729133+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -31551,7 +31551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:03.218352+00:00"
+                "validatedAt": "2026-05-09T01:32:23.424314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31583,7 +31583,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:03.218491+00:00"
+                "validatedAt": "2026-05-09T01:32:23.424359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31627,7 +31627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:03.218611+00:00"
+                "validatedAt": "2026-05-09T01:32:23.424382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31711,8 +31711,8 @@
           "description": "Minimum configuration for bgpBfdPeerState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgpBfdPeerState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgpBfdPeerState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_bfd_peer_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -31743,7 +31743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:03.218833+00:00"
+                "validatedAt": "2026-05-09T01:32:23.424450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31799,7 +31799,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:03.221022+00:00"
+                "validatedAt": "2026-05-09T01:32:23.425411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31878,8 +31878,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgp_asn_setCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgp_asn_setCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_asn_sets\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -31956,7 +31956,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:05.533157+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32030,7 +32030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:05.533224+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443510+00:00"
               },
               "deterministic": true
             },
@@ -32043,7 +32043,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.708529+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.783389+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32073,7 +32073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:05.533265+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443533+00:00"
               },
               "deterministic": true
             },
@@ -32086,7 +32086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.708563+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.783406+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32189,7 +32189,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.708683+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.783461+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -32259,7 +32259,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:05.533429+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32325,7 +32325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:10:05.533487+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32388,7 +32388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:10:05.533561+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32400,7 +32400,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.708773+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.783509+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -32466,7 +32466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:05.533638+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443697+00:00"
               },
               "deterministic": true
             },
@@ -32479,7 +32479,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.708843+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.783547+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32508,7 +32508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:05.533674+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443715+00:00"
               },
               "deterministic": true
             },
@@ -32521,7 +32521,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.708875+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.783563+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -32560,7 +32560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:05.533742+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32573,7 +32573,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.708934+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.783594+00:00"
           },
           "uid": {
             "type": "string",
@@ -32590,7 +32590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:05.533777+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32604,7 +32604,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.708966+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.783611+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bgp_asn_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -32654,8 +32654,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgp_asn_setReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgp_asn_setReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_asn_set_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -32667,8 +32667,8 @@
           "description": "Minimum configuration for bgp_asn_setReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgp_asn_setReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgp_asn_setReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_asn_set_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -32717,7 +32717,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:05.533857+00:00"
+                "validatedAt": "2026-05-09T01:32:24.443802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32816,7 +32816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:09.783780+00:00"
+                "validatedAt": "2026-05-09T01:32:26.309022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32880,7 +32880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:09.783899+00:00"
+                "validatedAt": "2026-05-09T01:32:26.309068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32981,7 +32981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:09.783980+00:00"
+                "validatedAt": "2026-05-09T01:32:26.309100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33070,7 +33070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:09.784063+00:00"
+                "validatedAt": "2026-05-09T01:32:26.309134+00:00"
               },
               "deterministic": true
             },
@@ -33083,7 +33083,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.783901+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.819946+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33158,7 +33158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:09.784136+00:00"
+                "validatedAt": "2026-05-09T01:32:26.309175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33233,7 +33233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:09.784515+00:00"
+                "validatedAt": "2026-05-09T01:32:26.309348+00:00"
               },
               "deterministic": true
             },
@@ -33246,7 +33246,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.784090+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.820044+00:00"
           },
           "peer": {
             "type": "array",
@@ -33314,7 +33314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:09.784568+00:00"
+                "validatedAt": "2026-05-09T01:32:26.309370+00:00"
               },
               "deterministic": true
             },
@@ -33327,7 +33327,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.784132+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.820066+00:00"
           },
           "ri_table": {
             "type": "array",
@@ -33405,7 +33405,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.003005+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33463,7 +33463,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.003121+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33530,7 +33530,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.003196+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33583,7 +33583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:12.003254+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33700,7 +33700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:12.003344+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33787,8 +33787,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgp_routing_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgp_routing_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_routing_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -33871,7 +33871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.003430+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281289+00:00"
               },
               "deterministic": true
             },
@@ -33884,7 +33884,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.806392+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.830085+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33914,7 +33914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.003469+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281307+00:00"
               },
               "deterministic": true
             },
@@ -33927,7 +33927,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.806425+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.830101+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34076,7 +34076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:10:12.003614+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34139,7 +34139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:10:12.003686+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34151,7 +34151,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.806572+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.830183+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34217,7 +34217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.003741+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281417+00:00"
               },
               "deterministic": true
             },
@@ -34230,7 +34230,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.806684+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.830221+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34259,7 +34259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.003778+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281433+00:00"
               },
               "deterministic": true
             },
@@ -34272,7 +34272,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.806714+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.830236+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -34295,7 +34295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:12.003827+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34308,7 +34308,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.806763+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.830262+00:00"
           },
           "uid": {
             "type": "string",
@@ -34326,7 +34326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:10:12.003861+00:00"
+                "validatedAt": "2026-05-09T01:32:27.281469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34340,7 +34340,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.806794+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.830278+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bgp_routing_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -34389,8 +34389,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgp_routing_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgp_routing_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_routing_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -34402,8 +34402,8 @@
           "description": "Minimum configuration for bgp_routing_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for bgp_routing_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for bgp_routing_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/bgp_routing_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -34447,7 +34447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.005534+00:00"
+                "validatedAt": "2026-05-09T01:32:27.282220+00:00"
               },
               "deterministic": true
             },
@@ -34512,7 +34512,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.005619+00:00"
+                "validatedAt": "2026-05-09T01:32:27.282254+00:00"
               },
               "deterministic": true
             },
@@ -34577,7 +34577,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:10:12.005690+00:00"
+                "validatedAt": "2026-05-09T01:32:27.282288+00:00"
               },
               "deterministic": true
             },
@@ -34624,8 +34624,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dc_cluster_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dc_cluster_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dc_cluster_groups\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -34761,7 +34761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:49.272490+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849326+00:00"
               },
               "deterministic": true
             },
@@ -34774,7 +34774,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.614087+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.074511+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34804,7 +34804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:49.272542+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849350+00:00"
               },
               "deterministic": true
             },
@@ -34817,7 +34817,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.614120+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.074528+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34920,7 +34920,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.614220+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.074581+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -35013,7 +35013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:49.272731+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35076,7 +35076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:49.272807+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35088,7 +35088,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.614309+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.074628+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35154,7 +35154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:49.272865+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849477+00:00"
               },
               "deterministic": true
             },
@@ -35167,7 +35167,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.614379+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.074665+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35196,7 +35196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:49.272904+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849495+00:00"
               },
               "deterministic": true
             },
@@ -35209,7 +35209,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.614409+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.074681+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -35248,7 +35248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.272972+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35261,7 +35261,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.614467+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.074713+00:00"
           },
           "uid": {
             "type": "string",
@@ -35279,7 +35279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.273005+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35293,7 +35293,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.614499+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.074729+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dc_cluster_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -35383,8 +35383,8 @@
           "description": "Minimum configuration for dc_cluster_groupMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dc_cluster_groupMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dc_cluster_groupMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dc_cluster_group_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -35419,7 +35419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.273084+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35464,7 +35464,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:49.273159+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35491,7 +35491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.273204+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35544,7 +35544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:49.273258+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849660+00:00"
               },
               "deterministic": true
             },
@@ -35557,7 +35557,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.614619+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.074785+00:00"
           },
           "range": {
             "type": "string",
@@ -35582,7 +35582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.273303+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35615,7 +35615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.273354+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35648,7 +35648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.273396+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35726,7 +35726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.273452+00:00"
+                "validatedAt": "2026-05-09T01:34:29.849746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35771,8 +35771,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dc_cluster_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dc_cluster_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dc_cluster_group_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -35784,8 +35784,8 @@
           "description": "Minimum configuration for dc_cluster_groupReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for dc_cluster_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for dc_cluster_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/dc_cluster_group_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -35960,7 +35960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.274115+00:00"
+                "validatedAt": "2026-05-09T01:34:29.850021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35972,7 +35972,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.615045+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.075030+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -36047,7 +36047,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:49.274959+00:00"
+                "validatedAt": "2026-05-09T01:34:29.850416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36088,8 +36088,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -36121,7 +36121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:49.275802+00:00"
+                "validatedAt": "2026-05-09T01:34:29.850785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36133,7 +36133,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.616355+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.075550+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -36151,7 +36151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.275854+00:00"
+                "validatedAt": "2026-05-09T01:34:29.850806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36179,7 +36179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:49.275898+00:00"
+                "validatedAt": "2026-05-09T01:34:29.850826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36191,7 +36191,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.616434+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.075576+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -36252,8 +36252,8 @@
           "description": "Minimum configuration for schemaUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -36274,8 +36274,8 @@
           "description": "Minimum configuration for schemadc_cluster_groupMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemadc_cluster_groupMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemadc_cluster_groupMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemadc_cluster_group_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -36303,7 +36303,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.616625+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.075659+00:00"
           },
           "value": {
             "type": "array",
@@ -36322,7 +36322,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.616660+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.075675+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -36361,8 +36361,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forwarding_classCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forwarding_classCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forwarding_classes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -36491,8 +36491,8 @@
           "description": "Minimum configuration for forwarding_classDSCPAFDropPrecedenceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forwarding_classDSCPAFDropPrecedenceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forwarding_classDSCPAFDropPrecedenceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forwarding_class_d_s_c_p_a_f_drop_precedence_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -36520,8 +36520,8 @@
           "description": "Minimum configuration for forwarding_classDSCPClassType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forwarding_classDSCPClassType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forwarding_classDSCPClassType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forwarding_class_d_s_c_p_class_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -36603,7 +36603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:23.026461+00:00"
+                "validatedAt": "2026-05-09T01:35:38.138780+00:00"
               },
               "deterministic": true
             },
@@ -36616,7 +36616,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.728343+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.531564+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36646,7 +36646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:23.026509+00:00"
+                "validatedAt": "2026-05-09T01:35:38.138802+00:00"
               },
               "deterministic": true
             },
@@ -36659,7 +36659,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.728377+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.531581+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -36762,7 +36762,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.728480+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.531632+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -36885,8 +36885,8 @@
           "description": "Minimum configuration for forwarding_classInterfaceGroupType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forwarding_classInterfaceGroupType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forwarding_classInterfaceGroupType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forwarding_class_interface_group_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -36933,7 +36933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:17:23.026732+00:00"
+                "validatedAt": "2026-05-09T01:35:38.138893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36996,7 +36996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:17:23.026804+00:00"
+                "validatedAt": "2026-05-09T01:35:38.138929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37008,7 +37008,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.728658+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.531711+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -37074,7 +37074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:23.026858+00:00"
+                "validatedAt": "2026-05-09T01:35:38.138954+00:00"
               },
               "deterministic": true
             },
@@ -37087,7 +37087,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.728730+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.531747+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37116,7 +37116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:23.026899+00:00"
+                "validatedAt": "2026-05-09T01:35:38.138973+00:00"
               },
               "deterministic": true
             },
@@ -37129,7 +37129,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.728760+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.531763+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -37168,7 +37168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:23.026968+00:00"
+                "validatedAt": "2026-05-09T01:35:38.139002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37181,7 +37181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.728819+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.531793+00:00"
           },
           "uid": {
             "type": "string",
@@ -37199,7 +37199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:23.027002+00:00"
+                "validatedAt": "2026-05-09T01:35:38.139018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37213,7 +37213,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.728852+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.531809+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of forwarding_class is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -37263,8 +37263,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forwarding_classReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forwarding_classReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forwarding_class_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -37276,8 +37276,8 @@
           "description": "Minimum configuration for forwarding_classReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forwarding_classReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forwarding_classReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forwarding_class_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -37437,8 +37437,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike1CreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike1CreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike1s\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -37521,7 +37521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:55.244095+00:00"
+                "validatedAt": "2026-05-09T01:35:52.504444+00:00"
               },
               "deterministic": true
             },
@@ -37534,7 +37534,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.354519+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.835061+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37564,7 +37564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:55.244175+00:00"
+                "validatedAt": "2026-05-09T01:35:52.504467+00:00"
               },
               "deterministic": true
             },
@@ -37577,7 +37577,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.354551+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.835077+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -37680,7 +37680,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.354669+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.835130+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -37748,7 +37748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:17:55.244426+00:00"
+                "validatedAt": "2026-05-09T01:35:52.504526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37810,7 +37810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:17:55.244504+00:00"
+                "validatedAt": "2026-05-09T01:35:52.504556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37822,7 +37822,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.354748+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.835176+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -37887,7 +37887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:55.244561+00:00"
+                "validatedAt": "2026-05-09T01:35:52.504579+00:00"
               },
               "deterministic": true
             },
@@ -37900,7 +37900,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.354818+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.835213+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37929,7 +37929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:55.244623+00:00"
+                "validatedAt": "2026-05-09T01:35:52.504598+00:00"
               },
               "deterministic": true
             },
@@ -37942,7 +37942,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.354847+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.835228+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -37981,7 +37981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:55.244693+00:00"
+                "validatedAt": "2026-05-09T01:35:52.504626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37994,7 +37994,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.354905+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.835259+00:00"
           },
           "uid": {
             "type": "string",
@@ -38011,7 +38011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:55.244728+00:00"
+                "validatedAt": "2026-05-09T01:35:52.504641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38025,7 +38025,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.354936+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.835275+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike1 is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -38075,8 +38075,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike1ReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike1ReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike1_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -38088,8 +38088,8 @@
           "description": "Minimum configuration for ike1ReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike1ReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike1ReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike1_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -38433,8 +38433,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike_phase1_profileCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike_phase1_profileCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike_phase1_profiles\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -38657,7 +38657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:59.846630+00:00"
+                "validatedAt": "2026-05-09T01:35:54.537973+00:00"
               },
               "deterministic": true
             },
@@ -38670,7 +38670,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.438046+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.875096+00:00"
           },
           "namespace": {
             "type": "string",
@@ -38700,7 +38700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:59.846678+00:00"
+                "validatedAt": "2026-05-09T01:35:54.537995+00:00"
               },
               "deterministic": true
             },
@@ -38713,7 +38713,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.438081+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.875112+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38816,7 +38816,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.438182+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.875171+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -39024,7 +39024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:17:59.846980+00:00"
+                "validatedAt": "2026-05-09T01:35:54.538121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39087,7 +39087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:17:59.847051+00:00"
+                "validatedAt": "2026-05-09T01:35:54.538161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39099,7 +39099,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.438394+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.875283+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -39165,7 +39165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:59.847105+00:00"
+                "validatedAt": "2026-05-09T01:35:54.538185+00:00"
               },
               "deterministic": true
             },
@@ -39178,7 +39178,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.438466+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.875320+00:00"
           },
           "namespace": {
             "type": "string",
@@ -39207,7 +39207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:59.847146+00:00"
+                "validatedAt": "2026-05-09T01:35:54.538203+00:00"
               },
               "deterministic": true
             },
@@ -39220,7 +39220,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.438495+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.875336+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -39259,7 +39259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:59.847215+00:00"
+                "validatedAt": "2026-05-09T01:35:54.538231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39272,7 +39272,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.438553+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.875367+00:00"
           },
           "uid": {
             "type": "string",
@@ -39290,7 +39290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:59.847249+00:00"
+                "validatedAt": "2026-05-09T01:35:54.538247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39304,7 +39304,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.438600+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.875383+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike_phase1_profile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -39354,8 +39354,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike_phase1_profileReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike_phase1_profileReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike_phase1_profile_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -39367,8 +39367,8 @@
           "description": "Minimum configuration for ike_phase1_profileReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike_phase1_profileReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike_phase1_profileReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike_phase1_profile_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -39590,8 +39590,8 @@
           "description": "Minimum configuration for schemaAuthenticationAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAuthenticationAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAuthenticationAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_authentication_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -39621,8 +39621,8 @@
           "description": "Minimum configuration for schemaDHGroup",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaDHGroup\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaDHGroup\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_d_h_groups\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -39650,8 +39650,8 @@
           "description": "Minimum configuration for schemaEncryptionAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEncryptionAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEncryptionAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_encryption_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -39675,8 +39675,8 @@
           "description": "Minimum configuration for schemaPseudoRandomFunction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaPseudoRandomFunction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaPseudoRandomFunction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_pseudo_random_functions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -39702,8 +39702,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike2CreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike2CreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike2s\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -39824,7 +39824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:03.976020+00:00"
+                "validatedAt": "2026-05-09T01:35:56.370195+00:00"
               },
               "deterministic": true
             },
@@ -39837,7 +39837,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.495326+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.902244+00:00"
           },
           "namespace": {
             "type": "string",
@@ -39867,7 +39867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:03.976096+00:00"
+                "validatedAt": "2026-05-09T01:35:56.370216+00:00"
               },
               "deterministic": true
             },
@@ -39880,7 +39880,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.495360+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.902263+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -39983,7 +39983,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.495463+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.902324+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -40051,7 +40051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:03.976320+00:00"
+                "validatedAt": "2026-05-09T01:35:56.370280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40113,7 +40113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:03.976394+00:00"
+                "validatedAt": "2026-05-09T01:35:56.370314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40125,7 +40125,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.495543+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.902365+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -40190,7 +40190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:03.976450+00:00"
+                "validatedAt": "2026-05-09T01:35:56.370338+00:00"
               },
               "deterministic": true
             },
@@ -40203,7 +40203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.495631+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.902403+00:00"
           },
           "namespace": {
             "type": "string",
@@ -40232,7 +40232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:03.976489+00:00"
+                "validatedAt": "2026-05-09T01:35:56.370356+00:00"
               },
               "deterministic": true
             },
@@ -40245,7 +40245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.495662+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.902418+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -40284,7 +40284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:03.976556+00:00"
+                "validatedAt": "2026-05-09T01:35:56.370384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40297,7 +40297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.495721+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.902449+00:00"
           },
           "uid": {
             "type": "string",
@@ -40314,7 +40314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:03.976609+00:00"
+                "validatedAt": "2026-05-09T01:35:56.370400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40328,7 +40328,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.495753+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.902466+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike2 is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -40378,8 +40378,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike2ReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike2ReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike2_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -40391,8 +40391,8 @@
           "description": "Minimum configuration for ike2ReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike2ReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike2ReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike2_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -40601,8 +40601,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike_phase2_profileCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike_phase2_profileCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike_phase2_profiles\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -40732,7 +40732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:08.929736+00:00"
+                "validatedAt": "2026-05-09T01:35:58.565974+00:00"
               },
               "deterministic": true
             },
@@ -40745,7 +40745,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.604117+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.953770+00:00"
           },
           "namespace": {
             "type": "string",
@@ -40775,7 +40775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:08.929783+00:00"
+                "validatedAt": "2026-05-09T01:35:58.565995+00:00"
               },
               "deterministic": true
             },
@@ -40788,7 +40788,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.604150+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.953787+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -40891,7 +40891,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.604252+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.953839+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -40959,7 +40959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:08.929928+00:00"
+                "validatedAt": "2026-05-09T01:35:58.566055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41022,7 +41022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:08.930001+00:00"
+                "validatedAt": "2026-05-09T01:35:58.566086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41034,7 +41034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.604331+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.953879+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -41100,7 +41100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:08.930053+00:00"
+                "validatedAt": "2026-05-09T01:35:58.566109+00:00"
               },
               "deterministic": true
             },
@@ -41113,7 +41113,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.604402+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.953915+00:00"
           },
           "namespace": {
             "type": "string",
@@ -41142,7 +41142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:08.930093+00:00"
+                "validatedAt": "2026-05-09T01:35:58.566127+00:00"
               },
               "deterministic": true
             },
@@ -41155,7 +41155,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.604433+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.953930+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -41194,7 +41194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:08.930162+00:00"
+                "validatedAt": "2026-05-09T01:35:58.566162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41207,7 +41207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.604492+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.953961+00:00"
           },
           "uid": {
             "type": "string",
@@ -41225,7 +41225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:08.930197+00:00"
+                "validatedAt": "2026-05-09T01:35:58.566178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41239,7 +41239,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.604525+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.953978+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike_phase2_profile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -41289,8 +41289,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike_phase2_profileReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike_phase2_profileReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike_phase2_profile_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -41302,8 +41302,8 @@
           "description": "Minimum configuration for ike_phase2_profileReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ike_phase2_profileReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ike_phase2_profileReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ike_phase2_profile_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -41653,8 +41653,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ip_prefix_setCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ip_prefix_setCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ip_prefix_sets\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -41719,7 +41719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:11.187477+00:00"
+                "validatedAt": "2026-05-09T01:35:59.566983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41793,7 +41793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:11.187540+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567011+00:00"
               },
               "deterministic": true
             },
@@ -41806,7 +41806,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.647637+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.973633+00:00"
           },
           "namespace": {
             "type": "string",
@@ -41836,7 +41836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:11.187597+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567032+00:00"
               },
               "deterministic": true
             },
@@ -41849,7 +41849,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.647672+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.973649+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41952,7 +41952,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.647776+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.973705+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -42010,7 +42010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:11.187781+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42066,7 +42066,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:11.187882+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567165+00:00"
               },
               "byteLength": {
                 "max": 64
@@ -42082,7 +42082,7 @@
             "x-original-maxLength": 64,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.647832+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.973739+00:00"
           },
           "ipv4_prefix": {
             "type": "string",
@@ -42110,7 +42110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:11.187940+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42176,7 +42176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:18:11.187999+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42239,7 +42239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:11.188068+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42251,7 +42251,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.647914+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.973781+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -42317,7 +42317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:11.188120+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567267+00:00"
               },
               "deterministic": true
             },
@@ -42330,7 +42330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.647989+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.973818+00:00"
           },
           "namespace": {
             "type": "string",
@@ -42359,7 +42359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:11.188159+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567285+00:00"
               },
               "deterministic": true
             },
@@ -42372,7 +42372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.648019+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.973833+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -42411,7 +42411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:11.188225+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42424,7 +42424,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.648078+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.973864+00:00"
           },
           "uid": {
             "type": "string",
@@ -42441,7 +42441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:11.188258+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42455,7 +42455,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.648111+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.973880+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ip_prefix_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -42505,8 +42505,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ip_prefix_setReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ip_prefix_setReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ip_prefix_set_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -42518,8 +42518,8 @@
           "description": "Minimum configuration for ip_prefix_setReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ip_prefix_setReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ip_prefix_setReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ip_prefix_set_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -42556,7 +42556,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:18:11.188333+00:00"
+                "validatedAt": "2026-05-09T01:35:59.567361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42657,8 +42657,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_connectorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_connectorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_connectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -42783,7 +42783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.428446+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013332+00:00"
               },
               "deterministic": true
             },
@@ -42796,7 +42796,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.078851+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.565122+00:00"
           },
           "namespace": {
             "type": "string",
@@ -42826,7 +42826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.428483+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013349+00:00"
               },
               "deterministic": true
             },
@@ -42839,7 +42839,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.078881+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.565137+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -42942,7 +42942,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.078983+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.565194+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -43052,7 +43052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:21:11.428661+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43115,7 +43115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:11.428732+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43127,7 +43127,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.079112+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.565260+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -43193,7 +43193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.428786+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013473+00:00"
               },
               "deterministic": true
             },
@@ -43206,7 +43206,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.079183+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.565297+00:00"
           },
           "namespace": {
             "type": "string",
@@ -43235,7 +43235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.428823+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013490+00:00"
               },
               "deterministic": true
             },
@@ -43248,7 +43248,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.079213+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.565313+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -43287,7 +43287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:11.428890+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43300,7 +43300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.079273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.565344+00:00"
           },
           "uid": {
             "type": "string",
@@ -43318,7 +43318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:11.428924+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43332,7 +43332,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.079304+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.565360+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_connector is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -43382,7 +43382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:11.428974+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43428,8 +43428,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_connectorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_connectorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_connector_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -43441,8 +43441,8 @@
           "description": "Minimum configuration for network_connectorReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_connectorReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_connectorReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_connector_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -43616,7 +43616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.429851+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43659,7 +43659,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.429934+00:00"
+                "validatedAt": "2026-05-09T01:37:21.013984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43704,7 +43704,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.430017+00:00"
+                "validatedAt": "2026-05-09T01:37:21.014023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43822,7 +43822,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.430187+00:00"
+                "validatedAt": "2026-05-09T01:37:21.014103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43864,7 +43864,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.430250+00:00"
+                "validatedAt": "2026-05-09T01:37:21.014134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43936,7 +43936,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.431953+00:00"
+                "validatedAt": "2026-05-09T01:37:21.014910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44041,7 +44041,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:11.432059+00:00"
+                "validatedAt": "2026-05-09T01:37:21.014959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44186,7 +44186,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.660769+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.288984+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -44245,7 +44245,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:34.871723+00:00"
+                "validatedAt": "2026-05-09T01:37:58.464923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44278,7 +44278,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:34.871796+00:00"
+                "validatedAt": "2026-05-09T01:37:58.464958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44345,7 +44345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:22:34.871857+00:00"
+                "validatedAt": "2026-05-09T01:37:58.464987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44407,7 +44407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:22:34.871935+00:00"
+                "validatedAt": "2026-05-09T01:37:58.465027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44419,7 +44419,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.660872+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.289036+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -44485,7 +44485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:34.871991+00:00"
+                "validatedAt": "2026-05-09T01:37:58.465053+00:00"
               },
               "deterministic": true
             },
@@ -44498,7 +44498,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.660943+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.289073+00:00"
           },
           "namespace": {
             "type": "string",
@@ -44527,7 +44527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:34.872030+00:00"
+                "validatedAt": "2026-05-09T01:37:58.465071+00:00"
               },
               "deterministic": true
             },
@@ -44540,7 +44540,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.660973+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.289088+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -44579,7 +44579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:34.872099+00:00"
+                "validatedAt": "2026-05-09T01:37:58.465099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44592,7 +44592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.661031+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.289119+00:00"
           },
           "uid": {
             "type": "string",
@@ -44609,7 +44609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:34.872134+00:00"
+                "validatedAt": "2026-05-09T01:37:58.465115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44623,7 +44623,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.661062+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.289135+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of public_ip is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -44673,8 +44673,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for public_ipReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for public_ipReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/public_ip_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -44686,8 +44686,8 @@
           "description": "Minimum configuration for public_ipReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for public_ipReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for public_ipReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/public_ip_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -44722,7 +44722,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:34.872209+00:00"
+                "validatedAt": "2026-05-09T01:37:58.465158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44839,7 +44839,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.298948+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44910,7 +44910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.299063+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129250+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -44926,7 +44926,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.572056+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.709728+00:00"
           },
           "presence": {
             "type": "boolean",
@@ -44971,7 +44971,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.299162+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129295+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -45043,7 +45043,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.299453+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129424+00:00"
               },
               "deterministic": true
             },
@@ -45083,7 +45083,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.299529+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45124,7 +45124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.299640+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129502+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -45197,7 +45197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.299695+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129525+00:00"
               },
               "deterministic": true
             },
@@ -45241,7 +45241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.299782+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45293,7 +45293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.299827+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45340,7 +45340,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.299896+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45351,7 +45351,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.572339+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.709880+00:00"
           },
           "regex": {
             "type": "string",
@@ -45379,7 +45379,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.299984+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129658+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -45431,8 +45431,8 @@
           "description": "Minimum configuration for policyHTMLPosition",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyHTMLPosition\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyHTMLPosition\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_h_t_m_l_positions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -45482,7 +45482,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.300153+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45575,7 +45575,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.300245+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129780+00:00"
               },
               "deterministic": true
             },
@@ -45587,7 +45587,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.572495+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.709961+00:00"
           },
           "path": {
             "type": "string",
@@ -45608,7 +45608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:18.300296+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45690,8 +45690,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for routeCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for routeCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/routes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -45774,7 +45774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.300381+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129843+00:00"
               },
               "deterministic": true
             },
@@ -45787,7 +45787,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.572654+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710034+00:00"
           },
           "namespace": {
             "type": "string",
@@ -45817,7 +45817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.300418+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129860+00:00"
               },
               "deterministic": true
             },
@@ -45830,7 +45830,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.572685+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710049+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -45933,7 +45933,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.572784+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710131+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -45998,7 +45998,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.300608+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46081,8 +46081,8 @@
           "description": "Minimum configuration for routeJavaScriptLocation",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for routeJavaScriptLocation\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for routeJavaScriptLocation\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/route_java_script_locations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -46128,7 +46128,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.300709+00:00"
+                "validatedAt": "2026-05-09T01:38:18.129995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46165,7 +46165,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.300775+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46231,7 +46231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:18.300832+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46293,7 +46293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:18.300902+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46305,7 +46305,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.572925+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710217+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -46371,7 +46371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.300956+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130120+00:00"
               },
               "deterministic": true
             },
@@ -46384,7 +46384,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.572996+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710254+00:00"
           },
           "namespace": {
             "type": "string",
@@ -46413,7 +46413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.300994+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130137+00:00"
               },
               "deterministic": true
             },
@@ -46426,7 +46426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.573025+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710270+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -46465,7 +46465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.301059+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46478,7 +46478,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.573083+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710301+00:00"
           },
           "uid": {
             "type": "string",
@@ -46495,7 +46495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.301094+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46509,7 +46509,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.573113+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710317+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of route is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -46574,7 +46574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.301155+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46639,7 +46639,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.301251+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46693,8 +46693,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for routeReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for routeReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/route_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -46706,8 +46706,8 @@
           "description": "Minimum configuration for routeReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for routeReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for routeReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/route_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -46748,7 +46748,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.301326+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46805,7 +46805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:18.301382+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46840,7 +46840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:18.301424+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46934,7 +46934,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.301501+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46994,7 +46994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.301569+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47032,7 +47032,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.301671+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47074,7 +47074,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.301757+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47130,7 +47130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:23:18.301821+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130579+00:00"
               },
               "deterministic": true
             },
@@ -47213,7 +47213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.301918+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47287,7 +47287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.301991+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47322,7 +47322,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302072+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47361,7 +47361,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302153+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47397,7 +47397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.302207+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47435,7 +47435,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302294+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47554,7 +47554,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302390+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47591,7 +47591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302452+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47634,7 +47634,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302514+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47669,7 +47669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302575+00:00"
+                "validatedAt": "2026-05-09T01:38:18.130972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47711,7 +47711,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302654+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47749,7 +47749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302718+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47793,7 +47793,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302782+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47828,7 +47828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302845+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47870,7 +47870,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.302908+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48113,7 +48113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.303072+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48159,8 +48159,8 @@
           "description": "Minimum configuration for routeTagAttributeName",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for routeTagAttributeName\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for routeTagAttributeName\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/route_tag_attribute_names\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -48188,7 +48188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.303118+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48200,7 +48200,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.573864+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710692+00:00"
           },
           "status": {
             "type": "string",
@@ -48225,7 +48225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.303164+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48237,7 +48237,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.573897+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710708+00:00"
           }
         },
         "x-f5xc-description-short": "Status information sent for each route entry within route.",
@@ -48450,7 +48450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.303893+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131596+00:00"
               },
               "deterministic": true
             },
@@ -48463,7 +48463,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.574174+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710850+00:00"
           },
           "overwrite": {
             "type": "boolean",
@@ -48504,7 +48504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.303971+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48516,7 +48516,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.574223+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:11.710876+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -48576,7 +48576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.304028+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48608,7 +48608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.304080+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48654,7 +48654,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.304145+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48702,7 +48702,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.304207+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48744,7 +48744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:18.304263+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48781,7 +48781,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.304327+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48865,8 +48865,8 @@
           "description": "Minimum configuration for schemaDenominatorType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaDenominatorType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaDenominatorType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_denominator_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -48922,7 +48922,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.304417+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131842+00:00"
               },
               "deterministic": true
             },
@@ -49058,7 +49058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.304567+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131910+00:00"
               },
               "deterministic": true
             },
@@ -49071,7 +49071,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.574444+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.710990+00:00"
           },
           "secret_value": {
             "$ref": "#/components/schemas/schemaSecretType"
@@ -49097,7 +49097,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.304657+00:00"
+                "validatedAt": "2026-05-09T01:38:18.131947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49109,7 +49109,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.574483+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:11.711011+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -49156,8 +49156,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -49198,7 +49198,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.305344+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49232,7 +49232,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.305425+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49406,7 +49406,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.305573+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49455,7 +49455,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.305652+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49518,7 +49518,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.305730+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132456+00:00"
               },
               "deterministic": true
             },
@@ -49564,7 +49564,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.305800+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49610,8 +49610,8 @@
           "description": "Minimum configuration for schemaRoutingPriority",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaRoutingPriority\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaRoutingPriority\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_routing_priorities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -49660,7 +49660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.305892+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49694,7 +49694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.305970+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49736,7 +49736,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.306052+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49843,7 +49843,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.306172+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132657+00:00"
               },
               "deterministic": true
             },
@@ -49856,7 +49856,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.575270+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.711436+00:00"
           },
           "overwrite": {
             "type": "boolean",
@@ -49906,7 +49906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.306258+00:00"
+                "validatedAt": "2026-05-09T01:38:18.132697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49918,7 +49918,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.575346+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:11.711476+00:00",
             "x-f5xc-conflicts-with": [
               "ignore_value",
               "secret_value"
@@ -50026,7 +50026,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.307261+00:00"
+                "validatedAt": "2026-05-09T01:38:18.133124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50084,7 +50084,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.307320+00:00"
+                "validatedAt": "2026-05-09T01:38:18.133157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50142,7 +50142,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:18.307378+00:00"
+                "validatedAt": "2026-05-09T01:38:18.133186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50192,7 +50192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910110+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50226,8 +50226,8 @@
           "description": "Minimum configuration for routeDropNH",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for routeDropNH\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for routeDropNH\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/route_drop_n_hs\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -50257,7 +50257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910226+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50301,7 +50301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910313+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50345,7 +50345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910410+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50472,7 +50472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910505+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50534,7 +50534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910563+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50578,7 +50578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910629+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50654,8 +50654,8 @@
           "description": "Minimum configuration for routeRouteFamily",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for routeRouteFamily\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for routeRouteFamily\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/route_route_families\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -50683,7 +50683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910695+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50738,7 +50738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910765+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50763,7 +50763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910810+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50833,7 +50833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:22.910863+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188865+00:00"
               },
               "deterministic": true
             },
@@ -50846,7 +50846,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.694026+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.768977+00:00"
           },
           "node": {
             "type": "string",
@@ -50875,7 +50875,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:22.910949+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50907,7 +50907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.910997+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50937,7 +50937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911036+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50963,7 +50963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911068+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51062,7 +51062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911130+00:00"
+                "validatedAt": "2026-05-09T01:38:20.188989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51121,7 +51121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911190+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51170,7 +51170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:23:22.911241+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51278,7 +51278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911320+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51339,7 +51339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911384+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51382,7 +51382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:22.911423+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189119+00:00"
               },
               "deterministic": true
             },
@@ -51395,7 +51395,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.694310+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.769118+00:00"
           },
           "node": {
             "type": "string",
@@ -51424,7 +51424,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:22.911498+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51456,7 +51456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911547+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51487,7 +51487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911600+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51586,7 +51586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911668+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51650,7 +51650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911734+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51695,7 +51695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911782+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51758,7 +51758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:22.911852+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51802,8 +51802,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -51843,7 +51843,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:22.912073+00:00"
+                "validatedAt": "2026-05-09T01:38:20.189420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51958,7 +51958,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:30.333188+00:00"
+                "validatedAt": "2026-05-09T01:38:23.505850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52075,7 +52075,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:30.333267+00:00"
+                "validatedAt": "2026-05-09T01:38:23.505887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52192,7 +52192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:30.333343+00:00"
+                "validatedAt": "2026-05-09T01:38:23.505922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52241,8 +52241,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for srv6_network_sliceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for srv6_network_sliceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/srv6_network_slices\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -52325,7 +52325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:30.333407+00:00"
+                "validatedAt": "2026-05-09T01:38:23.505948+00:00"
               },
               "deterministic": true
             },
@@ -52338,7 +52338,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.852293+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.843272+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52368,7 +52368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:30.333443+00:00"
+                "validatedAt": "2026-05-09T01:38:23.505964+00:00"
               },
               "deterministic": true
             },
@@ -52381,7 +52381,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.852322+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.843287+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -52484,7 +52484,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.852422+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.843339+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -52552,7 +52552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:30.333613+00:00"
+                "validatedAt": "2026-05-09T01:38:23.506020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52615,7 +52615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:30.333682+00:00"
+                "validatedAt": "2026-05-09T01:38:23.506048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52627,7 +52627,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.852498+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.843379+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -52693,7 +52693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:30.333734+00:00"
+                "validatedAt": "2026-05-09T01:38:23.506069+00:00"
               },
               "deterministic": true
             },
@@ -52706,7 +52706,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.852568+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.843415+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52735,7 +52735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:30.333772+00:00"
+                "validatedAt": "2026-05-09T01:38:23.506085+00:00"
               },
               "deterministic": true
             },
@@ -52748,7 +52748,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.852612+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.843430+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -52787,7 +52787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:30.333841+00:00"
+                "validatedAt": "2026-05-09T01:38:23.506112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52800,7 +52800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.852670+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.843461+00:00"
           },
           "uid": {
             "type": "string",
@@ -52818,7 +52818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:30.333877+00:00"
+                "validatedAt": "2026-05-09T01:38:23.506127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52832,7 +52832,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.852702+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.843477+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of srv6_network_slice is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -52882,8 +52882,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for srv6_network_sliceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for srv6_network_sliceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/srv6_network_slice_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -52895,8 +52895,8 @@
           "description": "Minimum configuration for srv6_network_sliceReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for srv6_network_sliceReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for srv6_network_sliceReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/srv6_network_slice_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -53006,7 +53006,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:34.764489+00:00"
+                "validatedAt": "2026-05-09T01:39:19.519453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53065,7 +53065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:34.764547+00:00"
+                "validatedAt": "2026-05-09T01:39:19.519547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53123,7 +53123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:34.764630+00:00"
+                "validatedAt": "2026-05-09T01:39:19.519624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53196,7 +53196,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:34.764712+00:00"
+                "validatedAt": "2026-05-09T01:39:19.519733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53297,8 +53297,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subnetCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subnetCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subnets\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -53381,7 +53381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:34.765012+00:00"
+                "validatedAt": "2026-05-09T01:39:19.520544+00:00"
               },
               "deterministic": true
             },
@@ -53394,7 +53394,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.156277+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.419807+00:00"
           },
           "namespace": {
             "type": "string",
@@ -53424,7 +53424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:34.765051+00:00"
+                "validatedAt": "2026-05-09T01:39:19.520637+00:00"
               },
               "deterministic": true
             },
@@ -53437,7 +53437,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.156307+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.419823+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -53540,7 +53540,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.156405+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.419875+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -53608,7 +53608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:34.765198+00:00"
+                "validatedAt": "2026-05-09T01:39:19.520916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53670,7 +53670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:25:34.765269+00:00"
+                "validatedAt": "2026-05-09T01:39:19.521716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53682,7 +53682,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.156481+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.419915+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -53748,7 +53748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:34.765322+00:00"
+                "validatedAt": "2026-05-09T01:39:19.521781+00:00"
               },
               "deterministic": true
             },
@@ -53761,7 +53761,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.156550+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.419952+00:00"
           },
           "namespace": {
             "type": "string",
@@ -53790,7 +53790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:34.765360+00:00"
+                "validatedAt": "2026-05-09T01:39:19.521840+00:00"
               },
               "deterministic": true
             },
@@ -53803,7 +53803,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.156580+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.419968+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -53842,7 +53842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:34.765426+00:00"
+                "validatedAt": "2026-05-09T01:39:19.521912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53855,7 +53855,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.156650+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.419999+00:00"
           },
           "uid": {
             "type": "string",
@@ -53872,7 +53872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:34.765460+00:00"
+                "validatedAt": "2026-05-09T01:39:19.521955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53886,7 +53886,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.156682+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.420014+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of subnet is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -53936,8 +53936,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subnetReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subnetReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subnet_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -53949,8 +53949,8 @@
           "description": "Minimum configuration for subnetReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subnetReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subnetReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subnet_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -54086,7 +54086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:55.765531+00:00"
+                "validatedAt": "2026-05-09T01:39:56.621539+00:00"
               },
               "deterministic": true
             },
@@ -54124,7 +54124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:55.765703+00:00"
+                "validatedAt": "2026-05-09T01:39:56.621574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54190,7 +54190,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:55.765851+00:00"
+                "validatedAt": "2026-05-09T01:39:56.621613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54241,7 +54241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:55.765898+00:00"
+                "validatedAt": "2026-05-09T01:39:56.621632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54279,7 +54279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:55.765961+00:00"
+                "validatedAt": "2026-05-09T01:39:56.621660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54383,7 +54383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:55.766051+00:00"
+                "validatedAt": "2026-05-09T01:39:56.621698+00:00"
               },
               "deterministic": true
             },
@@ -54396,7 +54396,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.937251+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.245836+00:00"
           },
           "node": {
             "type": "string",
@@ -54428,7 +54428,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:55.766128+00:00"
+                "validatedAt": "2026-05-09T01:39:56.621733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54461,7 +54461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:55.766178+00:00"
+                "validatedAt": "2026-05-09T01:39:56.621756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54487,7 +54487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:55.766218+00:00"
+                "validatedAt": "2026-05-09T01:39:56.621773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54587,7 +54587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:02.307084+00:00"
+                "validatedAt": "2026-05-09T01:39:59.490339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54632,8 +54632,8 @@
           "description": "Minimum configuration for schemaTunnelEncapsulationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTunnelEncapsulationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTunnelEncapsulationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tunnel_encapsulation_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -54808,7 +54808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:02.308786+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54857,7 +54857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:02.308854+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54900,7 +54900,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:02.308925+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54923,7 +54923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:02.308973+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54955,7 +54955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:27:02.309014+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491165+00:00"
               },
               "deterministic": true
             },
@@ -54980,7 +54980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:02.309061+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55004,7 +55004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:02.309111+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55059,7 +55059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:02.309163+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55087,7 +55087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:27:02.309215+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491252+00:00"
               },
               "deterministic": true
             },
@@ -55130,8 +55130,8 @@
           "description": "Minimum configuration for siteTunnelRole",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteTunnelRole\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteTunnelRole\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_tunnel_roles\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -55155,8 +55155,8 @@
           "description": "Minimum configuration for siteTunnelState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteTunnelState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteTunnelState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_tunnel_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -55182,8 +55182,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tunnelCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tunnelCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tunnels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -55266,7 +55266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:02.309276+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491279+00:00"
               },
               "deterministic": true
             },
@@ -55279,7 +55279,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.012976+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.279469+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55309,7 +55309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:02.309312+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491295+00:00"
               },
               "deterministic": true
             },
@@ -55322,7 +55322,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.013007+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.279485+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -55425,7 +55425,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.013105+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.279537+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -55482,7 +55482,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:02.309460+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55572,7 +55572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:27:02.309520+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55634,7 +55634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:02.309601+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55646,7 +55646,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.013204+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.279588+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -55712,7 +55712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:02.309658+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491447+00:00"
               },
               "deterministic": true
             },
@@ -55725,7 +55725,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.013273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.279625+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55754,7 +55754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:02.309695+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491464+00:00"
               },
               "deterministic": true
             },
@@ -55767,7 +55767,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.013302+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.279640+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -55806,7 +55806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:02.309762+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55819,7 +55819,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.013360+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.279671+00:00"
           },
           "uid": {
             "type": "string",
@@ -55836,7 +55836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:02.309796+00:00"
+                "validatedAt": "2026-05-09T01:39:59.491505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55850,7 +55850,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.013391+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.279687+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tunnel is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -56040,8 +56040,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tunnelReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tunnelReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tunnel_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -56053,8 +56053,8 @@
           "description": "Minimum configuration for tunnelReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tunnelReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tunnelReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tunnel_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -56175,8 +56175,8 @@
           "description": "Minimum configuration for tunnelTunnelType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tunnelTunnelType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tunnelTunnelType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tunnel_tunnel_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -56213,7 +56213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.664737+00:00"
+                "validatedAt": "2026-05-09T01:40:33.657994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56257,8 +56257,8 @@
           "description": "Minimum configuration for schemaRouteAttrType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaRouteAttrType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaRouteAttrType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_route_attr_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -56329,7 +56329,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.538364+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.979574+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Route Target\" BGP Two-Octet AS Specific Route Target as per RFC 4360.",
@@ -56382,7 +56382,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.538404+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.979595+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Four-Octet AS Specific Route Target\" BGP Four-Octet AS Specific Route Target as per RFC 5668.",
@@ -56419,7 +56419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.665440+00:00"
+                "validatedAt": "2026-05-09T01:40:33.658311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56446,7 +56446,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.538446+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.979617+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"IPv4 Address Specific Route Target\" BGP IPv4 Address Specific Route Target as per RFC 4360.",
@@ -56507,8 +56507,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_networks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -56588,7 +56588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.666821+00:00"
+                "validatedAt": "2026-05-09T01:40:33.658913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56666,7 +56666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.666866+00:00"
+                "validatedAt": "2026-05-09T01:40:33.658941+00:00"
               },
               "deterministic": true
             },
@@ -56679,7 +56679,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539245+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980029+00:00"
           },
           "namespace": {
             "type": "string",
@@ -56709,7 +56709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.666904+00:00"
+                "validatedAt": "2026-05-09T01:40:33.658960+00:00"
               },
               "deterministic": true
             },
@@ -56722,7 +56722,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980045+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -56825,7 +56825,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539371+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980097+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -56898,7 +56898,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667069+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56935,7 +56935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667132+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57006,7 +57006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:28:20.667189+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57069,7 +57069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:28:20.667258+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57081,7 +57081,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539504+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980174+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -57147,7 +57147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667312+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659141+00:00"
               },
               "deterministic": true
             },
@@ -57160,7 +57160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539574+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980211+00:00"
           },
           "namespace": {
             "type": "string",
@@ -57189,7 +57189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667349+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659166+00:00"
               },
               "deterministic": true
             },
@@ -57202,7 +57202,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539626+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980227+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -57241,7 +57241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667417+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57254,7 +57254,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539686+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980257+00:00"
           },
           "uid": {
             "type": "string",
@@ -57271,7 +57271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667452+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57285,7 +57285,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539717+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980273+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_network is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -57335,8 +57335,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_network_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -57348,8 +57348,8 @@
           "description": "Minimum configuration for virtual_networkReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_network_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -57401,7 +57401,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667544+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57491,8 +57491,8 @@
           "description": "Minimum configuration for virtual_networkSIDCounterLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkSIDCounterLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkSIDCounterLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_network_s_i_d_counter_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -57527,7 +57527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667637+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57572,7 +57572,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667707+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57599,7 +57599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667752+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57652,7 +57652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667807+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659357+00:00"
               },
               "deterministic": true
             },
@@ -57665,7 +57665,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539893+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980365+00:00"
           },
           "range": {
             "type": "string",
@@ -57690,7 +57690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667852+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57723,7 +57723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667903+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57756,7 +57756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667946+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57832,7 +57832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.668003+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57874,8 +57874,8 @@
           "description": "Minimum configuration for virtual_networkSIDCounterType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkSIDCounterType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkSIDCounterType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_network_s_i_d_counter_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -57903,7 +57903,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539979+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980409+00:00"
           },
           "value": {
             "type": "array",
@@ -57922,7 +57922,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.540011+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980426+00:00"
           }
         },
         "x-f5xc-description-short": "SID Counter Type Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -58024,7 +58024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668077+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659475+00:00"
               },
               "deterministic": true
             },
@@ -58037,7 +58037,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.540072+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980456+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Srv6 Network Namespace Parameters\" Configure the how namespace network is connected to srv6 network.",
@@ -58089,7 +58089,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668138+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58128,7 +58128,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668220+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659542+00:00"
               },
               "deterministic": true
             },
@@ -58181,7 +58181,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668289+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58247,7 +58247,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668352+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58286,7 +58286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668431+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659643+00:00"
               },
               "deterministic": true
             },
@@ -58339,7 +58339,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668496+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659673+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/network_security.json
+++ b/docs/specifications/api/network_security.json
@@ -16990,8 +16990,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forward_proxy_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forward_proxy_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forward_proxy_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -17074,7 +17074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.190350+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614218+00:00"
               },
               "deterministic": true
             },
@@ -17087,7 +17087,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.259606+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950039+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17117,7 +17117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.190434+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614240+00:00"
               },
               "deterministic": true
             },
@@ -17130,7 +17130,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.259641+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950055+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17179,7 +17179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.190537+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17355,7 +17355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.190690+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17393,7 +17393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.190738+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614348+00:00"
               },
               "deterministic": true
             },
@@ -17406,7 +17406,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.259878+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950184+00:00"
           },
           "policy": {
             "type": "string",
@@ -17423,7 +17423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.190786+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17448,7 +17448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.190837+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17473,7 +17473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.190876+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17498,7 +17498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.190927+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17558,7 +17558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.190982+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17630,7 +17630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.191054+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614480+00:00"
               },
               "deterministic": true
             },
@@ -17643,7 +17643,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.259977+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950237+00:00"
           },
           "start_time": {
             "type": "string",
@@ -17668,7 +17668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.191105+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17701,7 +17701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.191147+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17776,7 +17776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.191206+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17822,8 +17822,8 @@
           "description": "Minimum configuration for forward_proxy_policyForwardProxyPolicyMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forward_proxy_policyForwardProxyPolicyMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forward_proxy_policyForwardProxyPolicyMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forward_proxy_policy_forward_proxy_policy_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -17856,7 +17856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.191257+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17868,7 +17868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260071+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950286+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -17926,7 +17926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.191338+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614606+00:00"
               },
               "deterministic": true
             },
@@ -17995,7 +17995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.191413+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18031,7 +18031,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.191476+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18067,7 +18067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.191538+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18182,7 +18182,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260244+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950376+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -18250,7 +18250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:13:27.191705+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18313,7 +18313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:27.191776+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18325,7 +18325,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260320+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950415+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18391,7 +18391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.191830+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614809+00:00"
               },
               "deterministic": true
             },
@@ -18404,7 +18404,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260391+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950452+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18433,7 +18433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.191867+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614825+00:00"
               },
               "deterministic": true
             },
@@ -18446,7 +18446,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260421+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950468+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -18485,7 +18485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.191935+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18498,7 +18498,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260478+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950498+00:00"
           },
           "uid": {
             "type": "string",
@@ -18516,7 +18516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.191973+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18530,7 +18530,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260510+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950515+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of forward_proxy_policy is returned in 'List'.",
@@ -18580,8 +18580,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forward_proxy_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forward_proxy_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forward_proxy_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -18593,8 +18593,8 @@
           "description": "Minimum configuration for forward_proxy_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for forward_proxy_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for forward_proxy_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/forward_proxy_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -18694,7 +18694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192090+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18749,7 +18749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192154+00:00"
+                "validatedAt": "2026-05-09T01:33:53.614957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18814,7 +18814,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192246+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18857,7 +18857,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192333+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18902,7 +18902,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192419+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18947,7 +18947,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192505+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18991,7 +18991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192618+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19036,7 +19036,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192709+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19080,8 +19080,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19110,7 +19110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.192752+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19123,7 +19123,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260704+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950609+00:00"
           },
           "name": {
             "type": "string",
@@ -19156,7 +19156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192792+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615233+00:00"
               },
               "deterministic": true
             },
@@ -19169,7 +19169,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260733+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950625+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19200,7 +19200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192829+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615250+00:00"
               },
               "deterministic": true
             },
@@ -19213,7 +19213,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260762+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950640+00:00"
           },
           "tenant": {
             "type": "string",
@@ -19232,7 +19232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.192872+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19246,7 +19246,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260791+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950656+00:00"
           },
           "uid": {
             "type": "string",
@@ -19265,7 +19265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.192906+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19280,7 +19280,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260822+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950672+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -19346,7 +19346,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.192974+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19389,8 +19389,8 @@
           "description": "Minimum configuration for policyRuleAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyRuleAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyRuleAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_rule_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19493,8 +19493,8 @@
           "description": "Minimum configuration for policyURLCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyURLCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyURLCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_u_r_l_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19516,7 +19516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.193022+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19539,7 +19539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.193066+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19551,7 +19551,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260879+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950702+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -19597,7 +19597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:13:27.193112+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615372+00:00"
               },
               "deterministic": true
             },
@@ -19623,7 +19623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.193164+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19650,7 +19650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.193207+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19662,7 +19662,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260930+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950729+00:00"
           },
           "service_name": {
             "type": "string",
@@ -19679,7 +19679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.193258+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19712,7 +19712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.193304+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19724,7 +19724,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.260969+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950750+00:00"
           },
           "type": {
             "type": "string",
@@ -19749,7 +19749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.193346+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19817,7 +19817,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.193432+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19860,7 +19860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.193514+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19905,7 +19905,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.193611+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19958,8 +19958,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19992,7 +19992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.193665+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20054,7 +20054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.193705+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615623+00:00"
               },
               "deterministic": true
             },
@@ -20067,7 +20067,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261073+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950804+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -20164,7 +20164,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.193792+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20207,7 +20207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.193880+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20249,7 +20249,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.193940+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20319,7 +20319,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194003+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20376,7 +20376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194093+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615803+00:00"
               },
               "deterministic": true
             },
@@ -20389,7 +20389,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261170+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950855+00:00"
           },
           "name": {
             "type": "string",
@@ -20433,7 +20433,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194158+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615834+00:00"
               },
               "deterministic": true
             },
@@ -20445,7 +20445,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261198+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950871+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -20479,8 +20479,8 @@
           "description": "Minimum configuration for schemaMetricLabelOp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaMetricLabelOp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaMetricLabelOp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_metric_label_ops\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "label"
@@ -20525,7 +20525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.194223+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20537,7 +20537,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261249+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950898+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -20615,7 +20615,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194322+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615909+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -20631,7 +20631,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261292+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950921+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -20701,7 +20701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194373+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615930+00:00"
               },
               "deterministic": true
             },
@@ -20714,7 +20714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261343+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950948+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20745,7 +20745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194410+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615946+00:00"
               },
               "deterministic": true
             },
@@ -20758,7 +20758,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261372+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950964+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -20840,7 +20840,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194508+00:00"
+                "validatedAt": "2026-05-09T01:33:53.615991+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -20856,7 +20856,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261414+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.950986+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -20928,7 +20928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194556+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616011+00:00"
               },
               "deterministic": true
             },
@@ -20941,7 +20941,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261465+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951013+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20972,7 +20972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194605+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616027+00:00"
               },
               "deterministic": true
             },
@@ -20985,7 +20985,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261494+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951029+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -21067,7 +21067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194709+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616072+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -21083,7 +21083,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261536+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951051+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -21153,7 +21153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194759+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616093+00:00"
               },
               "deterministic": true
             },
@@ -21166,7 +21166,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261600+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951078+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21197,7 +21197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.194794+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616109+00:00"
               },
               "deterministic": true
             },
@@ -21210,7 +21210,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261630+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951093+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -21255,7 +21255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.194850+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21283,7 +21283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.194900+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21311,7 +21311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.194947+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21340,7 +21340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.194997+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21367,7 +21367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195030+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21381,7 +21381,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261711+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951136+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -21397,7 +21397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195073+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21460,8 +21460,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21506,7 +21506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195134+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21518,7 +21518,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261773+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951173+00:00"
           },
           "status": {
             "type": "string",
@@ -21536,7 +21536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195177+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21548,7 +21548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261802+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951189+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -21590,7 +21590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195231+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21617,7 +21617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195284+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21644,7 +21644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195330+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21672,7 +21672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195383+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21737,7 +21737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195462+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21786,7 +21786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195524+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21799,7 +21799,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261930+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951258+00:00"
           },
           "uid": {
             "type": "string",
@@ -21818,7 +21818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195557+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21832,7 +21832,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261960+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951273+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -21877,8 +21877,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21910,7 +21910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:27.195631+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21922,7 +21922,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.261992+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951291+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -21940,7 +21940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195683+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21968,7 +21968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195727+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21980,7 +21980,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.262040+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951316+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -22022,7 +22022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195767+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22034,7 +22034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.262071+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951333+00:00"
           },
           "name": {
             "type": "string",
@@ -22067,7 +22067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.195803+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616534+00:00"
               },
               "deterministic": true
             },
@@ -22080,7 +22080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.262100+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951348+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22111,7 +22111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.195839+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616550+00:00"
               },
               "deterministic": true
             },
@@ -22124,7 +22124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.262129+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951364+00:00"
           },
           "uid": {
             "type": "string",
@@ -22141,7 +22141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:27.195871+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22155,7 +22155,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.262159+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951380+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -22229,7 +22229,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.195936+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22305,7 +22305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.196008+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616627+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22321,7 +22321,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.262212+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951408+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22358,7 +22358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.196072+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616658+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22374,7 +22374,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.262242+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951424+00:00"
           },
           "tenant": {
             "type": "string",
@@ -22403,7 +22403,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.196145+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22417,7 +22417,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:34.262271+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:05.951440+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -22474,7 +22474,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:27.196205+00:00"
+                "validatedAt": "2026-05-09T01:33:53.616720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22712,8 +22712,8 @@
           "description": "Minimum configuration for network_policyApplicationEnumType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policyApplicationEnumType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policyApplicationEnumType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_application_enum_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -22913,7 +22913,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.231349+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22945,7 +22945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.231402+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22986,8 +22986,8 @@
           "description": "Minimum configuration for network_policy_ruleLogAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policy_ruleLogAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policy_ruleLogAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_rule_log_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -23009,8 +23009,8 @@
           "description": "Minimum configuration for network_policy_ruleNetworkPolicyRuleAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policy_ruleNetworkPolicyRuleAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policy_ruleNetworkPolicyRuleAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_rule_network_policy_rule_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -23061,8 +23061,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policy_viewCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policy_viewCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_views\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -23145,7 +23145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.231476+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181653+00:00"
               },
               "deterministic": true
             },
@@ -23158,7 +23158,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.074647+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341080+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23188,7 +23188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.231514+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181670+00:00"
               },
               "deterministic": true
             },
@@ -23201,7 +23201,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.074678+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341096+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23304,7 +23304,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.074777+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341148+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -23372,7 +23372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:13:51.231679+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23435,7 +23435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:13:51.231750+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23447,7 +23447,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.074854+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341193+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23513,7 +23513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.231803+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181780+00:00"
               },
               "deterministic": true
             },
@@ -23526,7 +23526,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.074923+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341229+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23555,7 +23555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.231840+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181797+00:00"
               },
               "deterministic": true
             },
@@ -23568,7 +23568,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.074952+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341245+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -23607,7 +23607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.231906+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23620,7 +23620,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.075009+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341275+00:00"
           },
           "uid": {
             "type": "string",
@@ -23638,7 +23638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.231939+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23652,7 +23652,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.075039+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341291+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy_view is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23743,7 +23743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.232003+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23781,7 +23781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.232042+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181884+00:00"
               },
               "deterministic": true
             },
@@ -23794,7 +23794,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.075102+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341324+00:00"
           },
           "policy": {
             "type": "string",
@@ -23811,7 +23811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.232086+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23836,7 +23836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.232134+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23861,7 +23861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.232171+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23920,7 +23920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.232222+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23992,7 +23992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.232291+00:00"
+                "validatedAt": "2026-05-09T01:34:04.181992+00:00"
               },
               "deterministic": true
             },
@@ -24005,7 +24005,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.075191+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341371+00:00"
           },
           "start_time": {
             "type": "string",
@@ -24030,7 +24030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.232341+00:00"
+                "validatedAt": "2026-05-09T01:34:04.182013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24063,7 +24063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.232382+00:00"
+                "validatedAt": "2026-05-09T01:34:04.182031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24138,7 +24138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.232439+00:00"
+                "validatedAt": "2026-05-09T01:34:04.182054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24182,8 +24182,8 @@
           "description": "Minimum configuration for network_policy_viewNetworkPolicyMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policy_viewNetworkPolicyMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policy_viewNetworkPolicyMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_view_network_policy_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -24216,7 +24216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:13:51.232490+00:00"
+                "validatedAt": "2026-05-09T01:34:04.182076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24228,7 +24228,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:35.075284+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.341419+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -24267,8 +24267,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policy_viewReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policy_viewReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_view_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -24280,8 +24280,8 @@
           "description": "Minimum configuration for network_policy_viewReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policy_viewReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policy_viewReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_view_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -24375,7 +24375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.233126+00:00"
+                "validatedAt": "2026-05-09T01:34:04.182339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24441,7 +24441,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.233187+00:00"
+                "validatedAt": "2026-05-09T01:34:04.182368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24499,7 +24499,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.235242+00:00"
+                "validatedAt": "2026-05-09T01:34:04.183358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24538,7 +24538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.235305+00:00"
+                "validatedAt": "2026-05-09T01:34:04.183390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24597,7 +24597,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.235363+00:00"
+                "validatedAt": "2026-05-09T01:34:04.183420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24636,7 +24636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.235426+00:00"
+                "validatedAt": "2026-05-09T01:34:04.183454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24695,7 +24695,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.235484+00:00"
+                "validatedAt": "2026-05-09T01:34:04.183485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24734,7 +24734,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:13:51.235546+00:00"
+                "validatedAt": "2026-05-09T01:34:04.183516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24782,7 +24782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:25.112223+00:00"
+                "validatedAt": "2026-05-09T01:35:12.378968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24808,7 +24808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:25.112326+00:00"
+                "validatedAt": "2026-05-09T01:35:12.379002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24834,7 +24834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:25.112413+00:00"
+                "validatedAt": "2026-05-09T01:35:12.379025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24860,7 +24860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:25.112489+00:00"
+                "validatedAt": "2026-05-09T01:35:12.379043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24886,7 +24886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:25.112553+00:00"
+                "validatedAt": "2026-05-09T01:35:12.379065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24940,7 +24940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:25.112619+00:00"
+                "validatedAt": "2026-05-09T01:35:12.379091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24984,8 +24984,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fast_aclCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fast_aclCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fast_acls\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -25068,7 +25068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.240570+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437243+00:00"
               },
               "deterministic": true
             },
@@ -25081,7 +25081,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.175614+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282032+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25111,7 +25111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.240638+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437266+00:00"
               },
               "deterministic": true
             },
@@ -25124,7 +25124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.175649+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282049+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25189,7 +25189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.240721+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25325,7 +25325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.240817+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25350,7 +25350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.240868+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25388,7 +25388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.240910+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437385+00:00"
               },
               "deterministic": true
             },
@@ -25401,7 +25401,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.175828+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282139+00:00"
           },
           "site": {
             "type": "string",
@@ -25418,7 +25418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.240949+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25476,7 +25476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.241003+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25548,7 +25548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.241075+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437457+00:00"
               },
               "deterministic": true
             },
@@ -25561,7 +25561,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.175901+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282181+00:00"
           },
           "start_time": {
             "type": "string",
@@ -25586,7 +25586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.241129+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25619,7 +25619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.241170+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25694,7 +25694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.241227+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25737,8 +25737,8 @@
           "description": "Minimum configuration for fast_aclFastACLMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fast_aclFastACLMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fast_aclFastACLMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fast_acl_fast_a_c_l_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -25771,7 +25771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.241277+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25783,7 +25783,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.175998+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282229+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -25844,7 +25844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.241355+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25960,7 +25960,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.176151+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282306+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -26028,7 +26028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:52.241500+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26090,7 +26090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:52.241569+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26102,7 +26102,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.176229+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282346+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26168,7 +26168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.241640+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437696+00:00"
               },
               "deterministic": true
             },
@@ -26181,7 +26181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.176299+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282382+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26210,7 +26210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.241679+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437714+00:00"
               },
               "deterministic": true
             },
@@ -26223,7 +26223,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.176330+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282397+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26262,7 +26262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.241745+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26275,7 +26275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.176388+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282427+00:00"
           },
           "uid": {
             "type": "string",
@@ -26292,7 +26292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.241778+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26306,7 +26306,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.176420+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.282443+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of fast_acl is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -26375,7 +26375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.241850+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26425,8 +26425,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fast_aclReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fast_aclReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fast_acl_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -26438,8 +26438,8 @@
           "description": "Minimum configuration for fast_aclReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fast_aclReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fast_aclReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fast_acl_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -26496,7 +26496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.241933+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26593,7 +26593,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.242016+00:00"
+                "validatedAt": "2026-05-09T01:35:24.437865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26742,8 +26742,8 @@
           "description": "Minimum configuration for fast_acl_ruleFastAclRuleSimpleAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fast_acl_ruleFastAclRuleSimpleAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fast_acl_ruleFastAclRuleSimpleAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fast_acl_rule_fast_acl_rule_simple_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -26793,7 +26793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.242870+00:00"
+                "validatedAt": "2026-05-09T01:35:24.438242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26837,7 +26837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:52.242909+00:00"
+                "validatedAt": "2026-05-09T01:35:24.438260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26891,7 +26891,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.243748+00:00"
+                "validatedAt": "2026-05-09T01:35:24.438692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27005,7 +27005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.243836+00:00"
+                "validatedAt": "2026-05-09T01:35:24.438736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27060,7 +27060,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:52.243890+00:00"
+                "validatedAt": "2026-05-09T01:35:24.438763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27234,8 +27234,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fast_acl_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fast_acl_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fast_acl_rules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -27310,7 +27310,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:56.367324+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27390,7 +27390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:56.367395+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269272+00:00"
               },
               "deterministic": true
             },
@@ -27403,7 +27403,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.242786+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.312551+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27433,7 +27433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:56.367436+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269290+00:00"
               },
               "deterministic": true
             },
@@ -27446,7 +27446,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.242820+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.312567+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27549,7 +27549,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.242957+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.312658+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -27617,7 +27617,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:56.367627+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27688,7 +27688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:56.367688+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27751,7 +27751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:56.367762+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27763,7 +27763,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.243079+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.312727+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27829,7 +27829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:56.367815+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269442+00:00"
               },
               "deterministic": true
             },
@@ -27842,7 +27842,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.243151+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.312765+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27871,7 +27871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:56.367852+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269459+00:00"
               },
               "deterministic": true
             },
@@ -27884,7 +27884,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.243182+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.312781+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27923,7 +27923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:56.367917+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27936,7 +27936,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.243243+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.312811+00:00"
           },
           "uid": {
             "type": "string",
@@ -27953,7 +27953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:56.367952+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27967,7 +27967,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.243276+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.312827+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of fast_acl_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -28017,8 +28017,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fast_acl_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fast_acl_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fast_acl_rule_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -28030,8 +28030,8 @@
           "description": "Minimum configuration for fast_acl_ruleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for fast_acl_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for fast_acl_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/fast_acl_rule_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -28078,7 +28078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:56.368027+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28191,7 +28191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:56.369025+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28204,7 +28204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.243936+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.313163+00:00"
           },
           "name": {
             "type": "string",
@@ -28237,7 +28237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:56.369060+00:00"
+                "validatedAt": "2026-05-09T01:35:26.269987+00:00"
               },
               "deterministic": true
             },
@@ -28250,7 +28250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.243966+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.313179+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28281,7 +28281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:56.369096+00:00"
+                "validatedAt": "2026-05-09T01:35:26.270003+00:00"
               },
               "deterministic": true
             },
@@ -28294,7 +28294,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.243996+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.313195+00:00"
           },
           "tenant": {
             "type": "string",
@@ -28313,7 +28313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:56.369139+00:00"
+                "validatedAt": "2026-05-09T01:35:26.270021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28327,7 +28327,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.244026+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.313210+00:00"
           },
           "uid": {
             "type": "string",
@@ -28346,7 +28346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:56.369171+00:00"
+                "validatedAt": "2026-05-09T01:35:26.270035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28361,7 +28361,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.244057+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.313226+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -28403,8 +28403,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for filter_setCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for filter_setCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/filter_sets\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -28465,7 +28465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.778047+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28504,7 +28504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.778140+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28578,7 +28578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.778194+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337250+00:00"
               },
               "deterministic": true
             },
@@ -28591,7 +28591,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.289748+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334043+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28621,7 +28621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.778235+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337269+00:00"
               },
               "deterministic": true
             },
@@ -28634,7 +28634,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.289782+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334059+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28681,7 +28681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.778293+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28736,7 +28736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.778351+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28836,7 +28836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.778431+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28902,7 +28902,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.778497+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28947,7 +28947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.778540+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337403+00:00"
               },
               "deterministic": true
             },
@@ -28960,7 +28960,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.289914+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334127+00:00"
           }
         },
         "x-f5xc-description-short": "Find Filter Sets API returns FilterSets that match the given context key(s).",
@@ -29099,7 +29099,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.290026+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334191+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -29153,7 +29153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.778729+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29192,7 +29192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.778793+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29245,7 +29245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.778848+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29285,7 +29285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.778911+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29351,7 +29351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:58.778968+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29414,7 +29414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:58.779036+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29426,7 +29426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.290149+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334257+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -29492,7 +29492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.779087+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337631+00:00"
               },
               "deterministic": true
             },
@@ -29505,7 +29505,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.290220+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334294+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29534,7 +29534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.779123+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337648+00:00"
               },
               "deterministic": true
             },
@@ -29547,7 +29547,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.290249+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334310+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -29586,7 +29586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.779189+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29599,7 +29599,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.290307+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334341+00:00"
           },
           "uid": {
             "type": "string",
@@ -29616,7 +29616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.779223+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29630,7 +29630,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.290339+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334357+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of filter_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -29711,8 +29711,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for filter_setReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for filter_setReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/filter_set_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -29724,8 +29724,8 @@
           "description": "Minimum configuration for filter_setReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for filter_setReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for filter_setReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/filter_set_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -29758,7 +29758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.779296+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29797,7 +29797,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.779358+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29930,7 +29930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.779829+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29962,7 +29962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.779879+00:00"
+                "validatedAt": "2026-05-09T01:35:27.337976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30048,7 +30048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.780452+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338246+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -30064,7 +30064,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.291024+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334700+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -30136,7 +30136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.780499+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338267+00:00"
               },
               "deterministic": true
             },
@@ -30149,7 +30149,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.291075+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334727+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30180,7 +30180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.780534+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338284+00:00"
               },
               "deterministic": true
             },
@@ -30193,7 +30193,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.291105+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334742+00:00"
           },
           "uid": {
             "type": "string",
@@ -30212,7 +30212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.780567+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30227,7 +30227,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.291136+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.334758+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -30274,7 +30274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.781781+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30302,7 +30302,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.781829+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30331,7 +30331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.781878+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30358,7 +30358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.781924+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30387,7 +30387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.781976+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30412,7 +30412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.782026+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30477,7 +30477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.782103+00:00"
+                "validatedAt": "2026-05-09T01:35:27.338975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30515,7 +30515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:58.782164+00:00"
+                "validatedAt": "2026-05-09T01:35:27.339005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30527,7 +30527,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.291890+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.335146+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -30568,7 +30568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.782227+00:00"
+                "validatedAt": "2026-05-09T01:35:27.339032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30612,7 +30612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.782273+00:00"
+                "validatedAt": "2026-05-09T01:35:27.339052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30626,7 +30626,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.291958+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.335187+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -30645,7 +30645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.782319+00:00"
+                "validatedAt": "2026-05-09T01:35:27.339072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30672,7 +30672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.782353+00:00"
+                "validatedAt": "2026-05-09T01:35:27.339087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30687,7 +30687,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.291999+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.335209+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -30702,7 +30702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:58.782395+00:00"
+                "validatedAt": "2026-05-09T01:35:27.339106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30795,7 +30795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.700953+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30844,8 +30844,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nat_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nat_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nat_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -30915,7 +30915,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.701056+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792459+00:00"
               },
               "deterministic": true
             },
@@ -30994,7 +30994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.701104+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792481+00:00"
               },
               "deterministic": true
             },
@@ -31007,7 +31007,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.231869+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.181314+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31037,7 +31037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.701141+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792500+00:00"
               },
               "deterministic": true
             },
@@ -31050,7 +31050,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.231899+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.181330+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31181,7 +31181,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.232022+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.181392+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -31244,7 +31244,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.701308+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792578+00:00"
               },
               "deterministic": true
             },
@@ -31316,7 +31316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:26.701363+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31379,7 +31379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:26.701431+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31391,7 +31391,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.232124+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.181443+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -31457,7 +31457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.701482+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792657+00:00"
               },
               "deterministic": true
             },
@@ -31470,7 +31470,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.232195+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.181479+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31499,7 +31499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.701518+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792675+00:00"
               },
               "deterministic": true
             },
@@ -31512,7 +31512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.232225+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.181495+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -31551,7 +31551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:26.701614+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31564,7 +31564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.232284+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.181525+00:00"
           },
           "uid": {
             "type": "string",
@@ -31581,7 +31581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:26.701653+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31595,7 +31595,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.232315+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.181541+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nat_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -31779,8 +31779,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nat_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nat_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nat_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -31792,8 +31792,8 @@
           "description": "Minimum configuration for nat_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nat_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nat_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nat_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -31835,7 +31835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.701816+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792802+00:00"
               },
               "deterministic": true
             },
@@ -31925,7 +31925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.701879+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792829+00:00"
               },
               "deterministic": true
             },
@@ -31938,7 +31938,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.232573+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.181671+00:00"
           },
           "network_interface": {
             "$ref": "#/components/schemas/schemaNetworkInterfaceRefType"
@@ -32062,7 +32062,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.702076+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32119,7 +32119,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.702134+00:00"
+                "validatedAt": "2026-05-09T01:37:00.792954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32177,7 +32177,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.702579+00:00"
+                "validatedAt": "2026-05-09T01:37:00.793173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32234,7 +32234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:26.702654+00:00"
+                "validatedAt": "2026-05-09T01:37:00.793201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32298,7 +32298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.703246+00:00"
+                "validatedAt": "2026-05-09T01:37:00.793489+00:00"
               },
               "deterministic": true
             },
@@ -32342,7 +32342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.703332+00:00"
+                "validatedAt": "2026-05-09T01:37:00.793529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32389,8 +32389,8 @@
           "description": "Minimum configuration for schemaProtocolEnumType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaProtocolEnumType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaProtocolEnumType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_protocol_enum_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -32429,7 +32429,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.703389+00:00"
+                "validatedAt": "2026-05-09T01:37:00.793558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32524,7 +32524,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:26.704390+00:00"
+                "validatedAt": "2026-05-09T01:37:00.794074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32580,7 +32580,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:52.395424+00:00"
+                "validatedAt": "2026-05-09T01:37:12.425789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32642,7 +32642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:15.948853+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32705,7 +32705,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:15.948922+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32766,7 +32766,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:15.948990+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32828,7 +32828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:15.949056+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32872,8 +32872,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_firewallCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_firewallCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_firewalls\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -33007,7 +33007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:15.949152+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065180+00:00"
               },
               "deterministic": true
             },
@@ -33020,7 +33020,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.176948+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.605389+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33050,7 +33050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:15.949191+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065198+00:00"
               },
               "deterministic": true
             },
@@ -33063,7 +33063,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.176982+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.605406+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33166,7 +33166,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.177083+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.605458+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -33285,7 +33285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:21:15.949359+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33348,7 +33348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:15.949429+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33360,7 +33360,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.177226+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.605535+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -33426,7 +33426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:15.949481+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065323+00:00"
               },
               "deterministic": true
             },
@@ -33439,7 +33439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.177296+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.605571+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33468,7 +33468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:15.949519+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065342+00:00"
               },
               "deterministic": true
             },
@@ -33481,7 +33481,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.177325+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.605587+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -33520,7 +33520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:15.949608+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33533,7 +33533,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.177383+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.605618+00:00"
           },
           "uid": {
             "type": "string",
@@ -33551,7 +33551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:15.949644+00:00"
+                "validatedAt": "2026-05-09T01:37:23.065386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33565,7 +33565,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.177414+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.605635+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_firewall is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -33649,8 +33649,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_firewallReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_firewallReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_firewall_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -33662,8 +33662,8 @@
           "description": "Minimum configuration for network_firewallReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_firewallReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_firewallReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_firewall_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -33800,8 +33800,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -33884,7 +33884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.459815+00:00"
+                "validatedAt": "2026-05-09T01:37:28.748911+00:00"
               },
               "deterministic": true
             },
@@ -33897,7 +33897,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.476847+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747450+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33927,7 +33927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.459853+00:00"
+                "validatedAt": "2026-05-09T01:37:28.748929+00:00"
               },
               "deterministic": true
             },
@@ -33940,7 +33940,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.476878+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747466+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34043,7 +34043,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.477028+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747544+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -34105,7 +34105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.460034+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34144,7 +34144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.460098+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34210,7 +34210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:21:28.460157+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34273,7 +34273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:28.460227+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34285,7 +34285,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.477129+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747595+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34351,7 +34351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.460279+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749124+00:00"
               },
               "deterministic": true
             },
@@ -34364,7 +34364,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.477200+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747632+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34393,7 +34393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.460316+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749141+00:00"
               },
               "deterministic": true
             },
@@ -34406,7 +34406,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.477229+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747647+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -34445,7 +34445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460383+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34458,7 +34458,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.477288+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747684+00:00"
           },
           "uid": {
             "type": "string",
@@ -34475,7 +34475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460417+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34489,7 +34489,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.477320+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747703+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -34580,7 +34580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460482+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34618,7 +34618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.460519+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749244+00:00"
               },
               "deterministic": true
             },
@@ -34631,7 +34631,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.477384+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747738+00:00"
           },
           "policy": {
             "type": "string",
@@ -34648,7 +34648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460564+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34673,7 +34673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460631+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34698,7 +34698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460681+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34723,7 +34723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460720+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34783,7 +34783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460773+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34855,7 +34855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.460844+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749382+00:00"
               },
               "deterministic": true
             },
@@ -34868,7 +34868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.477487+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747791+00:00"
           },
           "start_time": {
             "type": "string",
@@ -34893,7 +34893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460895+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34926,7 +34926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460937+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35001,7 +35001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.460996+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35046,8 +35046,8 @@
           "description": "Minimum configuration for network_policyNetworkPolicyMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policyNetworkPolicyMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policyNetworkPolicyMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_network_policy_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -35080,7 +35080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:28.461045+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35092,7 +35092,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.477595+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.747839+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -35144,7 +35144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.461109+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35181,7 +35181,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:28.461171+00:00"
+                "validatedAt": "2026-05-09T01:37:28.749537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35226,8 +35226,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -35239,8 +35239,8 @@
           "description": "Minimum configuration for network_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -35417,8 +35417,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policy_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policy_ruleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_rules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -35499,7 +35499,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:32.918995+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35536,7 +35536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:32.919057+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35617,7 +35617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:32.919104+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794209+00:00"
               },
               "deterministic": true
             },
@@ -35630,7 +35630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.592354+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.796149+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35660,7 +35660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:32.919141+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794227+00:00"
               },
               "deterministic": true
             },
@@ -35673,7 +35673,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.592384+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.796170+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35776,7 +35776,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.592484+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.796225+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -35850,7 +35850,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:32.919302+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35887,7 +35887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:32.919359+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35960,7 +35960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:21:32.919416+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36023,7 +36023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:32.919484+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36035,7 +36035,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.592659+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.796307+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -36101,7 +36101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:32.919536+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794405+00:00"
               },
               "deterministic": true
             },
@@ -36114,7 +36114,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.592731+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.796343+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36143,7 +36143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:32.919572+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794422+00:00"
               },
               "deterministic": true
             },
@@ -36156,7 +36156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.592760+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.796359+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -36195,7 +36195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:32.919654+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36208,7 +36208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.592818+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.796390+00:00"
           },
           "uid": {
             "type": "string",
@@ -36226,7 +36226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:32.919688+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36240,7 +36240,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.592849+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.796406+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -36290,8 +36290,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policy_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policy_ruleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_rule_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -36303,8 +36303,8 @@
           "description": "Minimum configuration for network_policy_ruleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for network_policy_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for network_policy_ruleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/network_policy_rule_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -36357,7 +36357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:32.919778+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36394,7 +36394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:32.919836+00:00"
+                "validatedAt": "2026-05-09T01:37:30.794534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36562,7 +36562,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.632572+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.815599+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -36616,7 +36616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:35.037713+00:00"
+                "validatedAt": "2026-05-09T01:37:31.756932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36682,7 +36682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:21:35.037832+00:00"
+                "validatedAt": "2026-05-09T01:37:31.756963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36745,7 +36745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:35.037933+00:00"
+                "validatedAt": "2026-05-09T01:37:31.756997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36757,7 +36757,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.632683+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.815646+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -36823,7 +36823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:35.037998+00:00"
+                "validatedAt": "2026-05-09T01:37:31.757024+00:00"
               },
               "deterministic": true
             },
@@ -36836,7 +36836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.632756+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.815683+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36865,7 +36865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:35.038038+00:00"
+                "validatedAt": "2026-05-09T01:37:31.757042+00:00"
               },
               "deterministic": true
             },
@@ -36878,7 +36878,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.632786+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.815699+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -36917,7 +36917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:35.038110+00:00"
+                "validatedAt": "2026-05-09T01:37:31.757072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36930,7 +36930,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.632844+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.815730+00:00"
           },
           "uid": {
             "type": "string",
@@ -36948,7 +36948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:35.038144+00:00"
+                "validatedAt": "2026-05-09T01:37:31.757087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36962,7 +36962,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.632876+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.815746+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -37069,8 +37069,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policy_based_routingCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policy_based_routingCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_based_routings\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -37153,7 +37153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.871651+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449393+00:00"
               },
               "deterministic": true
             },
@@ -37166,7 +37166,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.332326+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.134738+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37196,7 +37196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.871689+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449409+00:00"
               },
               "deterministic": true
             },
@@ -37209,7 +37209,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.332356+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.134753+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -37272,7 +37272,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.871770+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37355,7 +37355,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.871858+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37464,7 +37464,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.332555+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.134859+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -37532,7 +37532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:22:16.872004+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37595,7 +37595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:22:16.872075+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37607,7 +37607,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.332649+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.134899+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -37673,7 +37673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.872128+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449590+00:00"
               },
               "deterministic": true
             },
@@ -37686,7 +37686,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.332721+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.134936+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37715,7 +37715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.872166+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449606+00:00"
               },
               "deterministic": true
             },
@@ -37728,7 +37728,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.332751+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.134951+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -37767,7 +37767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:16.872234+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37780,7 +37780,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.332809+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.134982+00:00"
           },
           "uid": {
             "type": "string",
@@ -37798,7 +37798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:16.872267+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37812,7 +37812,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.332841+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.134999+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of policy_based_routing is returned in 'List'.",
@@ -37898,7 +37898,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.872364+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449689+00:00"
               },
               "deterministic": true
             },
@@ -37945,7 +37945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.872432+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38030,7 +38030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.872517+00:00"
+                "validatedAt": "2026-05-09T01:37:50.449756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38080,8 +38080,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policy_based_routingReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policy_based_routingReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_based_routing_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -38093,8 +38093,8 @@
           "description": "Minimum configuration for policy_based_routingReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policy_based_routingReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policy_based_routingReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_based_routing_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -38199,7 +38199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.875551+00:00"
+                "validatedAt": "2026-05-09T01:37:50.451026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38270,7 +38270,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.875645+00:00"
+                "validatedAt": "2026-05-09T01:37:50.451060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38341,7 +38341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:16.875726+00:00"
+                "validatedAt": "2026-05-09T01:37:50.451094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38411,8 +38411,8 @@
           "description": "Minimum configuration for schemaUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -38534,7 +38534,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:55.037401+00:00"
+                "validatedAt": "2026-05-09T01:38:34.445855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38566,7 +38566,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:55.037460+00:00"
+                "validatedAt": "2026-05-09T01:38:34.445882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38650,8 +38650,8 @@
           "description": "Minimum configuration for schemasegmentLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemasegmentLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemasegmentLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemasegment_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -38683,7 +38683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.037533+00:00"
+                "validatedAt": "2026-05-09T01:38:34.445912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38695,7 +38695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.420983+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111467+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter. Filters that will use segment labels to filter out timeseries.",
@@ -38742,7 +38742,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421034+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111494+00:00"
           }
         },
         "x-f5xc-description-short": "Node Metric Data. Metric Data for each metric type in the segments node.",
@@ -38809,7 +38809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.037632+00:00"
+                "validatedAt": "2026-05-09T01:38:34.445946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38832,7 +38832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.037686+00:00"
+                "validatedAt": "2026-05-09T01:38:34.445968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38870,7 +38870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:55.037725+00:00"
+                "validatedAt": "2026-05-09T01:38:34.445984+00:00"
               },
               "deterministic": true
             },
@@ -38883,7 +38883,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421108+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111533+00:00"
           },
           "site": {
             "type": "string",
@@ -38898,7 +38898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.037765+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38921,7 +38921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.037804+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38969,8 +38969,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for segmentCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for segmentCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/segments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -39053,7 +39053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:55.037866+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446046+00:00"
               },
               "deterministic": true
             },
@@ -39066,7 +39066,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421219+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111591+00:00"
           },
           "namespace": {
             "type": "string",
@@ -39096,7 +39096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:55.037902+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446063+00:00"
               },
               "deterministic": true
             },
@@ -39109,7 +39109,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421248+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111608+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -39212,7 +39212,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421346+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111660+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -39280,7 +39280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:55.038041+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39342,7 +39342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:55.038105+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39354,7 +39354,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421422+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111699+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -39420,7 +39420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:55.038158+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446179+00:00"
               },
               "deterministic": true
             },
@@ -39433,7 +39433,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421490+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111736+00:00"
           },
           "namespace": {
             "type": "string",
@@ -39462,7 +39462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:55.038193+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446196+00:00"
               },
               "deterministic": true
             },
@@ -39475,7 +39475,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421520+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111752+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -39514,7 +39514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.038258+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39527,7 +39527,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111782+00:00"
           },
           "uid": {
             "type": "string",
@@ -39544,7 +39544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.038290+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39558,7 +39558,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421648+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111798+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of segment is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -39606,8 +39606,8 @@
           "description": "Minimum configuration for segmentMetricSelector",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for segmentMetricSelector\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for segmentMetricSelector\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/segment_metric_selectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -39632,7 +39632,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.038346+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39706,8 +39706,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for segmentReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for segmentReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/segment_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -39719,8 +39719,8 @@
           "description": "Minimum configuration for segmentReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for segmentReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for segmentReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/segment_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -39755,7 +39755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.038425+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39830,7 +39830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:55.038500+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446327+00:00"
               },
               "deterministic": true
             },
@@ -39843,7 +39843,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.421779+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.111865+00:00"
           },
           "start_time": {
             "type": "string",
@@ -39868,7 +39868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.038552+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39901,7 +39901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.038607+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39993,7 +39993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:55.038677+00:00"
+                "validatedAt": "2026-05-09T01:38:34.446398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40160,7 +40160,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.466600+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.133751+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -40215,7 +40215,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:57.231097+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40281,7 +40281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:57.231153+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40344,7 +40344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:57.231220+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40356,7 +40356,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.466693+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.133797+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -40422,7 +40422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:57.231270+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423614+00:00"
               },
               "deterministic": true
             },
@@ -40435,7 +40435,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.466763+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.133834+00:00"
           },
           "namespace": {
             "type": "string",
@@ -40464,7 +40464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:57.231306+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423631+00:00"
               },
               "deterministic": true
             },
@@ -40477,7 +40477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.466793+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.133850+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -40516,7 +40516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:57.231371+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40529,7 +40529,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.466850+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.133880+00:00"
           },
           "uid": {
             "type": "string",
@@ -40547,7 +40547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:57.231404+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40561,7 +40561,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.466881+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.133896+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of segment_connection is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -40611,8 +40611,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for segment_connectionReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for segment_connectionReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/segment_connection_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -40624,8 +40624,8 @@
           "description": "Minimum configuration for segment_connectionReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for segment_connectionReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for segment_connectionReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/segment_connection_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -40660,7 +40660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:57.231476+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40725,7 +40725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:57.231543+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40771,7 +40771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:57.231629+00:00"
+                "validatedAt": "2026-05-09T01:38:35.423773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40909,8 +40909,8 @@
           "description": "Minimum configuration for app_firewallAppFirewallViolationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_firewallAppFirewallViolationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_firewallAppFirewallViolationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_firewall_app_firewall_violation_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -40957,8 +40957,8 @@
           "description": "Minimum configuration for app_firewallAttackType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_firewallAttackType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_firewallAttackType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_firewall_attack_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -40997,7 +40997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.205729+00:00"
+                "validatedAt": "2026-05-09T01:38:43.328988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41060,7 +41060,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.205809+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41098,7 +41098,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.205876+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41135,7 +41135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.205945+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41172,7 +41172,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.206010+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41234,7 +41234,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.206099+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41323,7 +41323,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.206211+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41367,8 +41367,8 @@
           "description": "Minimum configuration for policyAppTrafficType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyAppTrafficType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyAppTrafficType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_app_traffic_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -41445,7 +41445,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.206304+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329264+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -41461,7 +41461,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.827913+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.304545+00:00"
           }
         },
         "x-f5xc-description-short": "Argument matcher specifies the name of a single argument in the body and the criteria to match it.",
@@ -41516,7 +41516,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.206429+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41607,7 +41607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.206502+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41619,7 +41619,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.828002+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.304592+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"BotAdvanced Domain Matcher Type\" Bot Advanced Domain Matcher Type.",
@@ -41794,7 +41794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.206632+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41806,7 +41806,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.828146+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.304669+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Bot Advanced Path Matcher Type\" Bot Advanced Path Matcher Type.",
@@ -41888,7 +41888,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.206701+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41930,8 +41930,8 @@
           "description": "Minimum configuration for policyChallengeAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyChallengeAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyChallengeAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_challenge_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -41953,8 +41953,8 @@
           "description": "Minimum configuration for policyComparisonOperator",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyComparisonOperator\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyComparisonOperator\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_comparison_operators\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -41978,7 +41978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.206760+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42002,7 +42002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.206811+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42116,7 +42116,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.206913+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329520+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -42132,7 +42132,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.828315+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.304758+00:00"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -42420,8 +42420,8 @@
           "description": "Minimum configuration for policyCountryCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyCountryCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyCountryCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_country_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -42450,8 +42450,8 @@
           "description": "Minimum configuration for policyDetectionContext",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyDetectionContext\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyDetectionContext\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_detection_contexts\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -42540,7 +42540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.207041+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42587,8 +42587,8 @@
           "description": "Minimum configuration for policyHTMLPosition",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyHTMLPosition\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyHTMLPosition\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_h_t_m_l_positions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -42644,7 +42644,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207107+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42697,8 +42697,8 @@
           "description": "Minimum configuration for policyIPThreatCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_i_p_threat_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -42750,7 +42750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207173+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42812,7 +42812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207236+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42906,7 +42906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207323+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329712+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -42922,7 +42922,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.828514+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.304863+00:00"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -42972,8 +42972,8 @@
           "description": "Minimum configuration for policyKnownTlsFingerprintClass",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyKnownTlsFingerprintClass\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyKnownTlsFingerprintClass\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_known_tls_fingerprint_classes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -43086,7 +43086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207413+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43132,7 +43132,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207471+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43170,7 +43170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207531+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43238,7 +43238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207608+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43284,7 +43284,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207672+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43423,8 +43423,8 @@
           "description": "Minimum configuration for policyOasValidationActionType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyOasValidationActionType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyOasValidationActionType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_oas_validation_action_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -43541,7 +43541,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.207808+00:00"
+                "validatedAt": "2026-05-09T01:38:43.329934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44027,7 +44027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208195+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44114,7 +44114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208256+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44138,7 +44138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208303+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44212,7 +44212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208373+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44236,7 +44236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208429+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44315,7 +44315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208480+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44374,7 +44374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208538+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44478,7 +44478,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.208627+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44539,7 +44539,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.208689+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44580,7 +44580,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.208754+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44622,7 +44622,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.208814+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44672,8 +44672,8 @@
           "description": "Minimum configuration for policyTransformer",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_transformers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -44697,7 +44697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208867+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44721,7 +44721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208917+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44745,7 +44745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.208966+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44769,7 +44769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.209013+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44793,7 +44793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.209060+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45009,8 +45009,8 @@
           "description": "Minimum configuration for rate_limiterLeakyBucketRateLimiter",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterLeakyBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterLeakyBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_leaky_bucket_rate_limiters\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -45063,8 +45063,8 @@
           "description": "Minimum configuration for rate_limiterRateLimitPeriodUnit",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_rate_limit_period_units\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -45170,8 +45170,8 @@
           "description": "Minimum configuration for rate_limiterRateLimiterMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterRateLimiterMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterRateLimiterMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_rate_limiter_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -45186,8 +45186,8 @@
           "description": "Minimum configuration for rate_limiterTokenBucketRateLimiter",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterTokenBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterTokenBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_token_bucket_rate_limiters\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -45250,7 +45250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.209365+00:00"
+                "validatedAt": "2026-05-09T01:38:43.330605+00:00"
               },
               "deterministic": true
             },
@@ -45263,7 +45263,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.829640+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.305460+00:00"
           },
           "regex_values": {
             "type": "array",
@@ -45375,8 +45375,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -45451,8 +45451,8 @@
           "description": "Minimum configuration for schemaHttpStatusCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpStatusCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpStatusCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_status_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -45478,8 +45478,8 @@
           "description": "Minimum configuration for schemaOpenApiValidationProperties",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_open_api_validation_propertieses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -45586,7 +45586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.211931+00:00"
+                "validatedAt": "2026-05-09T01:38:43.331746+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -45602,7 +45602,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.831025+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306211+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -45666,7 +45666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.211993+00:00"
+                "validatedAt": "2026-05-09T01:38:43.331775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45725,7 +45725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212061+00:00"
+                "validatedAt": "2026-05-09T01:38:43.331806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45771,7 +45771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212122+00:00"
+                "validatedAt": "2026-05-09T01:38:43.331835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45815,7 +45815,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212182+00:00"
+                "validatedAt": "2026-05-09T01:38:43.331864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45853,7 +45853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212241+00:00"
+                "validatedAt": "2026-05-09T01:38:43.331893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45943,7 +45943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212392+00:00"
+                "validatedAt": "2026-05-09T01:38:43.331961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45955,7 +45955,7 @@
             "x-original-maxLength": 256,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.831176+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306291+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -46088,7 +46088,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212536+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46184,7 +46184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212669+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46280,7 +46280,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212786+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46373,7 +46373,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212875+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46422,7 +46422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.212973+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46469,7 +46469,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.213040+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46501,7 +46501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.213103+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46538,7 +46538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.213180+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332312+00:00"
               },
               "deterministic": true
             },
@@ -46589,7 +46589,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.213257+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46636,7 +46636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.213331+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46750,7 +46750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.213416+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46878,7 +46878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.213709+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332548+00:00"
               },
               "deterministic": true
             },
@@ -46891,7 +46891,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832002+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306719+00:00"
           },
           "namespace": {
             "type": "string",
@@ -46921,7 +46921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.213745+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332565+00:00"
               },
               "deterministic": true
             },
@@ -46934,7 +46934,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832031+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306734+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -47037,7 +47037,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832132+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306786+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -47097,7 +47097,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.213904+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332635+00:00"
               },
               "deterministic": true
             },
@@ -47165,7 +47165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:24:15.213956+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47228,7 +47228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:24:15.214022+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47240,7 +47240,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832219+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306832+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -47306,7 +47306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.214075+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332707+00:00"
               },
               "deterministic": true
             },
@@ -47319,7 +47319,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832289+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306868+00:00"
           },
           "namespace": {
             "type": "string",
@@ -47348,7 +47348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.214110+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332725+00:00"
               },
               "deterministic": true
             },
@@ -47361,7 +47361,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832320+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306883+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -47400,7 +47400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214177+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47413,7 +47413,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832377+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306914+00:00"
           },
           "uid": {
             "type": "string",
@@ -47430,7 +47430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214209+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47444,7 +47444,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832408+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306934+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of service_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -47507,8 +47507,8 @@
           "description": "Minimum configuration for service_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for service_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for service_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/service_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -47536,8 +47536,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for service_policyRule\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for service_policyRule\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/service_policy_rules\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -47578,7 +47578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.214299+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332809+00:00"
               },
               "deterministic": true
             },
@@ -47665,7 +47665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214364+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47703,7 +47703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.214399+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332852+00:00"
               },
               "deterministic": true
             },
@@ -47716,7 +47716,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832526+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.306997+00:00"
           },
           "policy": {
             "type": "string",
@@ -47733,7 +47733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214444+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47758,7 +47758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214493+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47783,7 +47783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214541+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47808,7 +47808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214578+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47833,7 +47833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214643+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47894,7 +47894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214695+00:00"
+                "validatedAt": "2026-05-09T01:38:43.332979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47966,7 +47966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.214773+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333009+00:00"
               },
               "deterministic": true
             },
@@ -47979,7 +47979,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832651+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.307054+00:00"
           },
           "start_time": {
             "type": "string",
@@ -48004,7 +48004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214826+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48037,7 +48037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214868+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48112,7 +48112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214928+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48158,8 +48158,8 @@
           "description": "Minimum configuration for service_policyServicePolicyMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for service_policyServicePolicyMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for service_policyServicePolicyMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/service_policy_service_policy_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network_security"
@@ -48192,7 +48192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:15.214988+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48204,7 +48204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.832745+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.307102+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -48262,7 +48262,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.215062+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48304,7 +48304,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.215128+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48350,7 +48350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.215204+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48390,7 +48390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.215272+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48431,7 +48431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:15.215334+00:00"
+                "validatedAt": "2026-05-09T01:38:43.333267+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/nginx_one.json
+++ b/docs/specifications/api/nginx_one.json
@@ -3311,8 +3311,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3341,7 +3341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.190635+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3354,7 +3354,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.449859+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284140+00:00"
           },
           "name": {
             "type": "string",
@@ -3387,7 +3387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.190733+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153788+00:00"
               },
               "deterministic": true
             },
@@ -3400,7 +3400,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.449893+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284162+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3431,7 +3431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.190779+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153807+00:00"
               },
               "deterministic": true
             },
@@ -3444,7 +3444,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.449924+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284178+00:00"
           },
           "tenant": {
             "type": "string",
@@ -3463,7 +3463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.190826+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3477,7 +3477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.449954+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284194+00:00"
           },
           "uid": {
             "type": "string",
@@ -3496,7 +3496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.190861+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3511,7 +3511,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.449987+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284211+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -3656,7 +3656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:36.190999+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3718,7 +3718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:36.191070+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3730,7 +3730,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450121+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284277+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -3796,7 +3796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.191125+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153947+00:00"
               },
               "deterministic": true
             },
@@ -3809,7 +3809,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450192+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284314+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3838,7 +3838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.191163+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153964+00:00"
               },
               "deterministic": true
             },
@@ -3851,7 +3851,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450223+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284329+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -3874,7 +3874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.191215+00:00"
+                "validatedAt": "2026-05-09T01:37:05.153985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3887,7 +3887,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450272+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284355+00:00"
           },
           "uid": {
             "type": "string",
@@ -3904,7 +3904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.191249+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3918,7 +3918,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450304+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284371+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_csg is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -4013,7 +4013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.191338+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4045,7 +4045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.191392+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4130,7 +4130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.191468+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4153,7 +4153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.191517+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4200,7 +4200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.191569+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4223,7 +4223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.191634+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4235,7 +4235,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450503+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284473+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4277,8 +4277,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -4311,7 +4311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.191693+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4373,7 +4373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.191733+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154206+00:00"
               },
               "deterministic": true
             },
@@ -4386,7 +4386,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450570+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284507+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -4505,7 +4505,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.191863+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154263+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4521,7 +4521,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450655+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284541+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4593,7 +4593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.191914+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154285+00:00"
               },
               "deterministic": true
             },
@@ -4606,7 +4606,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450710+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284568+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4637,7 +4637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.191951+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154302+00:00"
               },
               "deterministic": true
             },
@@ -4650,7 +4650,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450741+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284583+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -4711,7 +4711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192011+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4723,7 +4723,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450786+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284606+00:00"
           },
           "status": {
             "type": "string",
@@ -4741,7 +4741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192054+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4753,7 +4753,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450817+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284621+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -4795,7 +4795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192111+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4822,7 +4822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192165+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4849,7 +4849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192215+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4877,7 +4877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192270+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4942,7 +4942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192350+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4991,7 +4991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192413+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5004,7 +5004,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450950+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284698+00:00"
           },
           "uid": {
             "type": "string",
@@ -5023,7 +5023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192446+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5037,7 +5037,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.450981+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284718+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -5087,7 +5087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192486+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5099,7 +5099,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.451014+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284735+00:00"
           },
           "name": {
             "type": "string",
@@ -5132,7 +5132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.192524+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154541+00:00"
               },
               "deterministic": true
             },
@@ -5145,7 +5145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.451044+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284753+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5176,7 +5176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:36.192563+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154558+00:00"
               },
               "deterministic": true
             },
@@ -5189,7 +5189,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.451074+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284769+00:00"
           },
           "uid": {
             "type": "string",
@@ -5206,7 +5206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:36.192612+00:00"
+                "validatedAt": "2026-05-09T01:37:05.154572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5220,7 +5220,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.451104+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.284785+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -5345,7 +5345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:40.062256+00:00"
+                "validatedAt": "2026-05-09T01:37:06.892953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5368,7 +5368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:40.062304+00:00"
+                "validatedAt": "2026-05-09T01:37:06.892975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5440,7 +5440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:40.062368+00:00"
+                "validatedAt": "2026-05-09T01:37:06.893005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5503,7 +5503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:40.062438+00:00"
+                "validatedAt": "2026-05-09T01:37:06.893037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5515,7 +5515,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.487674+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.301094+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -5581,7 +5581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:40.062493+00:00"
+                "validatedAt": "2026-05-09T01:37:06.893061+00:00"
               },
               "deterministic": true
             },
@@ -5594,7 +5594,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.487748+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.301131+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5623,7 +5623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:40.062529+00:00"
+                "validatedAt": "2026-05-09T01:37:06.893079+00:00"
               },
               "deterministic": true
             },
@@ -5636,7 +5636,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.487779+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.301146+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -5659,7 +5659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:40.062598+00:00"
+                "validatedAt": "2026-05-09T01:37:06.893101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5672,7 +5672,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.487829+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.301177+00:00"
           },
           "uid": {
             "type": "string",
@@ -5689,7 +5689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:40.062635+00:00"
+                "validatedAt": "2026-05-09T01:37:06.893116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5703,7 +5703,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.487860+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.301193+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_instance is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -5823,7 +5823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:44.173429+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736208+00:00"
               },
               "deterministic": true
             },
@@ -5836,7 +5836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.536483+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322462+00:00"
           }
         },
         "x-f5xc-description-short": "GET NGINX One Dataplane servers request.",
@@ -5886,7 +5886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:44.173477+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5990,7 +5990,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.536577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322511+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -6056,7 +6056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:44.173636+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6119,7 +6119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:44.173707+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6131,7 +6131,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.536675+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322551+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -6197,7 +6197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:44.173761+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736337+00:00"
               },
               "deterministic": true
             },
@@ -6210,7 +6210,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.536746+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322588+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6239,7 +6239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:44.173798+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736354+00:00"
               },
               "deterministic": true
             },
@@ -6252,7 +6252,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.536776+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322604+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -6291,7 +6291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.173862+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6304,7 +6304,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.536835+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322635+00:00"
           },
           "uid": {
             "type": "string",
@@ -6321,7 +6321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.173896+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6335,7 +6335,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.536866+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322651+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_server is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -6397,7 +6397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.173942+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6431,7 +6431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:44.174008+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6455,7 +6455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.174065+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6481,7 +6481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.174120+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6518,7 +6518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:44.174168+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736515+00:00"
               },
               "deterministic": true
             },
@@ -6545,7 +6545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.174217+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6708,7 +6708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.174342+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6755,7 +6755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:44.174388+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736605+00:00"
               },
               "deterministic": true
             },
@@ -6768,7 +6768,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.537063+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322753+00:00"
           },
           "waf_spec": {
             "$ref": "#/components/schemas/nginx_instanceWAFSpec"
@@ -6817,7 +6817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:20:44.174525+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736664+00:00"
               },
               "deterministic": true
             },
@@ -6843,7 +6843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.174577+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6870,7 +6870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.174636+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6882,7 +6882,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.537169+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322809+00:00"
           },
           "service_name": {
             "type": "string",
@@ -6899,7 +6899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.174686+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6932,7 +6932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.174734+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6944,7 +6944,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.537208+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.322830+00:00"
           },
           "type": {
             "type": "string",
@@ -6969,7 +6969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.174777+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7023,7 +7023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.175137+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7051,7 +7051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.175188+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7079,7 +7079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.175235+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7108,7 +7108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.175285+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7135,7 +7135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.175318+00:00"
+                "validatedAt": "2026-05-09T01:37:08.736995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7149,7 +7149,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.537515+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.323001+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -7165,7 +7165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:44.175362+00:00"
+                "validatedAt": "2026-05-09T01:37:08.737016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7228,8 +7228,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7284,7 +7284,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:44.176102+00:00"
+                "validatedAt": "2026-05-09T01:37:08.737324+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -7300,7 +7300,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.537938+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.323225+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7337,7 +7337,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:44.176169+00:00"
+                "validatedAt": "2026-05-09T01:37:08.737356+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -7353,7 +7353,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.537967+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.323241+00:00"
           },
           "tenant": {
             "type": "string",
@@ -7382,7 +7382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:44.176243+00:00"
+                "validatedAt": "2026-05-09T01:37:08.737389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7396,7 +7396,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.537997+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.323259+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -7425,8 +7425,8 @@
           "description": "Minimum configuration for subscriptionSubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionSubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionSubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_subscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -7441,8 +7441,8 @@
           "description": "Minimum configuration for subscriptionSubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_subscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -7457,8 +7457,8 @@
           "description": "Minimum configuration for subscriptionUnsubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_unsubscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -7473,8 +7473,8 @@
           "description": "Minimum configuration for subscriptionUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -7513,7 +7513,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.686083+00:00"
+                "validatedAt": "2026-05-09T01:37:13.452865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7558,8 +7558,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nginx_service_discoveryCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nginx_service_discoveryCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nginx_service_discoveries\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "nginx_one"
@@ -7630,7 +7630,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.686200+00:00"
+                "validatedAt": "2026-05-09T01:37:13.452916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7705,7 +7705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.686255+00:00"
+                "validatedAt": "2026-05-09T01:37:13.452944+00:00"
               },
               "deterministic": true
             },
@@ -7718,7 +7718,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.712787+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399067+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7748,7 +7748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.686296+00:00"
+                "validatedAt": "2026-05-09T01:37:13.452963+00:00"
               },
               "deterministic": true
             },
@@ -7761,7 +7761,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.712820+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399083+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7891,7 +7891,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.712943+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399146+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -7939,7 +7939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:54.686460+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7964,7 +7964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:54.686520+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8002,7 +8002,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.686601+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8071,7 +8071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:54.686662+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8134,7 +8134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:54.686733+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8146,7 +8146,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713061+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399213+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8213,7 +8213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.686787+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453186+00:00"
               },
               "deterministic": true
             },
@@ -8226,7 +8226,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713131+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399249+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8255,7 +8255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.686823+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453203+00:00"
               },
               "deterministic": true
             },
@@ -8268,7 +8268,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713160+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399265+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8307,7 +8307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:54.686890+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8320,7 +8320,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713218+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399296+00:00"
           },
           "uid": {
             "type": "string",
@@ -8338,7 +8338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:54.686924+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8352,7 +8352,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713250+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399316+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_service_discovery is returned in 'List'.",
@@ -8415,7 +8415,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.686989+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8460,8 +8460,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nginx_service_discoveryReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nginx_service_discoveryReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nginx_service_discovery_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "nginx_one"
@@ -8473,8 +8473,8 @@
           "description": "Minimum configuration for nginx_service_discoveryReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nginx_service_discoveryReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nginx_service_discoveryReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nginx_service_discovery_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "nginx_one"
@@ -8517,7 +8517,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.687067+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8572,7 +8572,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.687154+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8612,7 +8612,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.687233+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8752,7 +8752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.687876+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453692+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8768,7 +8768,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713651+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399517+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8838,7 +8838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.687926+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453715+00:00"
               },
               "deterministic": true
             },
@@ -8851,7 +8851,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713703+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399544+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8882,7 +8882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.687961+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453732+00:00"
               },
               "deterministic": true
             },
@@ -8895,7 +8895,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713733+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399560+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -8940,7 +8940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:54.688187+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8953,7 +8953,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713889+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399648+00:00"
           },
           "name": {
             "type": "string",
@@ -8986,7 +8986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.688223+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453854+00:00"
               },
               "deterministic": true
             },
@@ -8999,7 +8999,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713918+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399664+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9030,7 +9030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.688259+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453872+00:00"
               },
               "deterministic": true
             },
@@ -9043,7 +9043,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713948+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399679+00:00"
           },
           "tenant": {
             "type": "string",
@@ -9062,7 +9062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:54.688302+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9076,7 +9076,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.713977+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399694+00:00"
           },
           "uid": {
             "type": "string",
@@ -9095,7 +9095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:54.688335+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9110,7 +9110,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.714007+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399710+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -9192,7 +9192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.688435+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453953+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -9208,7 +9208,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.714051+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399733+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -9278,7 +9278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.688483+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453976+00:00"
               },
               "deterministic": true
             },
@@ -9291,7 +9291,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.714101+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399760+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9322,7 +9322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:54.688518+00:00"
+                "validatedAt": "2026-05-09T01:37:13.453995+00:00"
               },
               "deterministic": true
             },
@@ -9335,7 +9335,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.714129+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.399776+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",

--- a/docs/specifications/api/object_storage.json
+++ b/docs/specifications/api/object_storage.json
@@ -2810,8 +2810,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -2841,8 +2841,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -2879,7 +2879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.937404+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2914,7 +2914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.937521+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2950,7 +2950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.937702+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480256+00:00"
               },
               "deterministic": true
             },
@@ -2963,7 +2963,7 @@
             "x-original-maxLength": 512,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.054937+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372255+00:00"
           },
           "mobile_app_shield": {
             "$ref": "#/components/schemas/stored_objectMobileAppShieldAttributes"
@@ -3018,7 +3018,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.937796+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480301+00:00"
               },
               "deterministic": true
             },
@@ -3030,7 +3030,7 @@
             },
             "x-original-maxLength": 512,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.054998+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372286+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3067,7 +3067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.937840+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480321+00:00"
               },
               "deterministic": true
             },
@@ -3080,7 +3080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.055030+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372302+00:00"
           },
           "no_attributes": {
             "$ref": "#/components/schemas/schemaEmpty"
@@ -3110,7 +3110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.937905+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3141,7 +3141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.937988+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3283,7 +3283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.938084+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3313,7 +3313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.938135+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3351,7 +3351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.938227+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3427,7 +3427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.938276+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480516+00:00"
               },
               "deterministic": true
             },
@@ -3440,7 +3440,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.055227+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372403+00:00"
           },
           "no_attributes": {
             "$ref": "#/components/schemas/schemaEmpty"
@@ -3460,7 +3460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.938324+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3473,7 +3473,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.055268+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372423+00:00"
           },
           "versions": {
             "type": "array",
@@ -3536,7 +3536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:29.938383+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3593,7 +3593,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.938473+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3652,7 +3652,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.938562+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3702,7 +3702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.938652+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3744,8 +3744,8 @@
           "description": "Minimum configuration for stored_objectOSType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for stored_objectOSType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for stored_objectOSType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/stored_object_o_s_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "object_storage"
@@ -3806,7 +3806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:25:29.938708+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480694+00:00"
               },
               "deterministic": true
             },
@@ -3862,7 +3862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.938771+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3897,7 +3897,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.938865+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480765+00:00"
               },
               "deterministic": true
             },
@@ -3910,7 +3910,7 @@
             "x-original-maxLength": 512,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.055434+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372506+00:00"
           },
           "mobile_app_shield": {
             "$ref": "#/components/schemas/stored_objectMobileAppShieldAttributes"
@@ -3957,7 +3957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.938916+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480787+00:00"
               },
               "deterministic": true
             },
@@ -3970,7 +3970,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.055493+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372536+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4006,7 +4006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.938957+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480807+00:00"
               },
               "deterministic": true
             },
@@ -4019,7 +4019,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.055523+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372552+00:00"
           },
           "no_attributes": {
             "$ref": "#/components/schemas/schemaEmpty"
@@ -4052,7 +4052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:25:29.939004+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480828+00:00"
               },
               "deterministic": true
             },
@@ -4085,7 +4085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.939052+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4097,7 +4097,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.055573+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372577+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4140,8 +4140,8 @@
           "description": "Minimum configuration for stored_objectStoredObjectResponseStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for stored_objectStoredObjectResponseStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for stored_objectStoredObjectResponseStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/stored_object_stored_object_response_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "object_storage"
@@ -4176,7 +4176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.939113+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4211,7 +4211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:29.939209+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480922+00:00"
               },
               "deterministic": true
             },
@@ -4224,7 +4224,7 @@
             "x-original-maxLength": 512,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.055633+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372599+00:00"
           },
           "latest_version": {
             "type": "boolean",
@@ -4268,7 +4268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:25:29.939256+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480944+00:00"
               },
               "deterministic": true
             },
@@ -4293,7 +4293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:29.939299+00:00"
+                "validatedAt": "2026-05-09T01:39:16.480963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4305,7 +4305,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.055686+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.372625+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {

--- a/docs/specifications/api/observability.json
+++ b/docs/specifications/api/observability.json
@@ -14894,7 +14894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736051+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14920,7 +14920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736147+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14959,7 +14959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:18.736224+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705097+00:00"
               },
               "deterministic": true
             },
@@ -14972,7 +14972,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.631793+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267127+00:00"
           },
           "start_time": {
             "type": "string",
@@ -14997,7 +14997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736311+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15064,7 +15064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736374+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15131,7 +15131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736446+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15160,7 +15160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736496+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15220,7 +15220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:18.736541+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705220+00:00"
               },
               "deterministic": true
             },
@@ -15233,7 +15233,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.631895+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267186+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -15251,7 +15251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736612+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15321,7 +15321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736664+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15416,8 +15416,8 @@
           "description": "Minimum configuration for alertKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alertKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alertKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -15509,7 +15509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736766+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15607,7 +15607,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632071+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267279+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -15643,7 +15643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736847+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15692,7 +15692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736894+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15731,7 +15731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:09:18.736951+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705379+00:00"
               },
               "deterministic": true
             },
@@ -15798,7 +15798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737013+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15843,7 +15843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737056+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15866,7 +15866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737090+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15878,7 +15878,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632203+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267348+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -15971,7 +15971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737165+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15995,7 +15995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737198+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16007,7 +16007,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632289+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267394+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -16049,7 +16049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737245+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16073,7 +16073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737278+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16085,7 +16085,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632341+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267421+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -16123,7 +16123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737321+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16180,7 +16180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737368+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16204,7 +16204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737401+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16216,7 +16216,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632407+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267456+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -16266,7 +16266,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632449+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267479+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -16323,7 +16323,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632492+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267501+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -16359,7 +16359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737483+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16470,7 +16470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737556+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16536,7 +16536,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632622+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267565+00:00"
           },
           "value": {
             "type": "number",
@@ -16552,7 +16552,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632651+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267583+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -16589,7 +16589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737645+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16645,8 +16645,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -16674,7 +16674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:18.737727+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16686,7 +16686,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632707+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267612+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -16701,7 +16701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737779+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16727,7 +16727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737826+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16739,7 +16739,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632757+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267639+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -16769,8 +16769,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -16792,7 +16792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.883196+00:00"
+                "validatedAt": "2026-05-09T01:34:41.629921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16815,7 +16815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.883260+00:00"
+                "validatedAt": "2026-05-09T01:34:41.629951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16827,7 +16827,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.158954+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334194+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -16873,7 +16873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:15.883311+00:00"
+                "validatedAt": "2026-05-09T01:34:41.629977+00:00"
               },
               "deterministic": true
             },
@@ -16899,7 +16899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.883367+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16926,7 +16926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.883411+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16938,7 +16938,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159010+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334222+00:00"
           },
           "service_name": {
             "type": "string",
@@ -16955,7 +16955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.883463+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16988,7 +16988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.883512+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17000,7 +17000,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159050+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334243+00:00"
           },
           "type": {
             "type": "string",
@@ -17025,7 +17025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.883555+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17079,8 +17079,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -17113,7 +17113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.883628+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17175,7 +17175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.883672+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630135+00:00"
               },
               "deterministic": true
             },
@@ -17188,7 +17188,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159124+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334282+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -17306,7 +17306,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.883805+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630202+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17322,7 +17322,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159191+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334317+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17392,7 +17392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.883859+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630225+00:00"
               },
               "deterministic": true
             },
@@ -17405,7 +17405,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159241+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334343+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17436,7 +17436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.883895+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630241+00:00"
               },
               "deterministic": true
             },
@@ -17449,7 +17449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159272+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334359+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -17531,7 +17531,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.883995+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630287+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17547,7 +17547,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159315+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334382+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17619,7 +17619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884043+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630308+00:00"
               },
               "deterministic": true
             },
@@ -17632,7 +17632,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159366+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334409+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17663,7 +17663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884078+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630324+00:00"
               },
               "deterministic": true
             },
@@ -17676,7 +17676,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159396+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334424+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -17758,7 +17758,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884178+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630368+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17774,7 +17774,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159442+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334447+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17846,7 +17846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884227+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630389+00:00"
               },
               "deterministic": true
             },
@@ -17859,7 +17859,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159493+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334474+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17890,7 +17890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884263+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630405+00:00"
               },
               "deterministic": true
             },
@@ -17903,7 +17903,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159522+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334489+00:00"
           },
           "uid": {
             "type": "string",
@@ -17922,7 +17922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884296+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17937,7 +17937,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159554+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334505+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -17984,7 +17984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884338+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17997,7 +17997,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159602+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334522+00:00"
           },
           "name": {
             "type": "string",
@@ -18030,7 +18030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884372+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630451+00:00"
               },
               "deterministic": true
             },
@@ -18043,7 +18043,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159633+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334537+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18074,7 +18074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884407+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630467+00:00"
               },
               "deterministic": true
             },
@@ -18087,7 +18087,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159662+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334553+00:00"
           },
           "tenant": {
             "type": "string",
@@ -18106,7 +18106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884449+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18120,7 +18120,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159691+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334568+00:00"
           },
           "uid": {
             "type": "string",
@@ -18139,7 +18139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884481+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18154,7 +18154,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159721+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334584+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -18236,7 +18236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884594+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630543+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -18252,7 +18252,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159765+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334607+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -18322,7 +18322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884646+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630564+00:00"
               },
               "deterministic": true
             },
@@ -18335,7 +18335,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159816+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334634+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18366,7 +18366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.884682+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630580+00:00"
               },
               "deterministic": true
             },
@@ -18379,7 +18379,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159846+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334650+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -18424,7 +18424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884737+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18452,7 +18452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884787+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18480,7 +18480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884835+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18509,7 +18509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884885+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18536,7 +18536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884917+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18550,7 +18550,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159927+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334692+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -18566,7 +18566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.884962+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18629,8 +18629,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18675,7 +18675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885024+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18687,7 +18687,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.159989+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334725+00:00"
           },
           "status": {
             "type": "string",
@@ -18705,7 +18705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885066+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18717,7 +18717,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160019+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334741+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -18759,7 +18759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885121+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18786,7 +18786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885172+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18813,7 +18813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885219+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18841,7 +18841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885272+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18906,7 +18906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885350+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18955,7 +18955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885414+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18968,7 +18968,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160152+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334809+00:00"
           },
           "uid": {
             "type": "string",
@@ -18987,7 +18987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885446+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19001,7 +19001,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160182+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334824+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -19053,7 +19053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885501+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19081,7 +19081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885551+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19110,7 +19110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885615+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19137,7 +19137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885664+00:00"
+                "validatedAt": "2026-05-09T01:34:41.630986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19166,7 +19166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885717+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19191,7 +19191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885768+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19256,7 +19256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885847+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19294,7 +19294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.885908+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19306,7 +19306,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160313+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334893+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -19347,7 +19347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.885972+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19391,7 +19391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.886018+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19405,7 +19405,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160382+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334928+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -19424,7 +19424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.886067+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19451,7 +19451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.886099+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19466,7 +19466,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160421+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334950+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -19481,7 +19481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.886142+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19562,7 +19562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.886187+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19574,7 +19574,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160472+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334976+00:00"
           },
           "name": {
             "type": "string",
@@ -19607,7 +19607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.886224+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631232+00:00"
               },
               "deterministic": true
             },
@@ -19620,7 +19620,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160501+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.334992+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19651,7 +19651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.886259+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631248+00:00"
               },
               "deterministic": true
             },
@@ -19664,7 +19664,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160531+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335007+00:00"
           },
           "uid": {
             "type": "string",
@@ -19681,7 +19681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.886291+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19695,7 +19695,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160561+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335023+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -19751,7 +19751,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.886348+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19812,7 +19812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.886404+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19881,8 +19881,8 @@
           "description": "Minimum configuration for synthetic_monitorEvalPeriod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for synthetic_monitorEvalPeriod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for synthetic_monitorEvalPeriod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/synthetic_monitor_eval_periods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "observability"
@@ -19969,7 +19969,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.886490+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20030,7 +20030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.886545+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20231,8 +20231,8 @@
           "description": "Minimum configuration for synthetic_monitorStdDevVal",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for synthetic_monitorStdDevVal\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for synthetic_monitorStdDevVal\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/synthetic_monitor_std_dev_vals\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "observability"
@@ -20258,8 +20258,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for v1_dns_monitorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for v1_dns_monitorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/v1_dns_monitors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20330,7 +20330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.886729+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20343,7 +20343,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.160872+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335183+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -20378,7 +20378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.886797+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20515,7 +20515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.886943+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20549,7 +20549,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.887018+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20582,7 +20582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.887070+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20702,7 +20702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.887136+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631635+00:00"
               },
               "deterministic": true
             },
@@ -20715,7 +20715,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161102+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335304+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20745,7 +20745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.887172+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631651+00:00"
               },
               "deterministic": true
             },
@@ -20758,7 +20758,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161131+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335320+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20817,7 +20817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:15.887228+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20928,7 +20928,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161251+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335382+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -20992,7 +20992,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.887389+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21005,7 +21005,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161294+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335404+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -21040,7 +21040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.887454+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21177,7 +21177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.887613+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21211,7 +21211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.887688+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21244,7 +21244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.887741+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21353,7 +21353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.887844+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21366,7 +21366,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161514+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335520+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -21402,7 +21402,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.887912+00:00"
+                "validatedAt": "2026-05-09T01:34:41.631969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21543,7 +21543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.888053+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21578,7 +21578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.888128+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21612,7 +21612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.888182+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21725,7 +21725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:15.888260+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21788,7 +21788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:15.888326+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21800,7 +21800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161805+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335653+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21866,7 +21866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.888377+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632185+00:00"
               },
               "deterministic": true
             },
@@ -21879,7 +21879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161878+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335689+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21908,7 +21908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.888413+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632203+00:00"
               },
               "deterministic": true
             },
@@ -21921,7 +21921,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161908+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335704+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21960,7 +21960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.888478+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21973,7 +21973,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161966+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335735+00:00"
           },
           "uid": {
             "type": "string",
@@ -21990,7 +21990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.888512+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22004,7 +22004,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.161997+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335751+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of v1_dns_monitor is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22067,7 +22067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.888606+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22105,7 +22105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.888649+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632300+00:00"
               },
               "deterministic": true
             },
@@ -22183,8 +22183,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for v1_dns_monitorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for v1_dns_monitorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/v1_dns_monitor_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22196,8 +22196,8 @@
           "description": "Minimum configuration for v1_dns_monitorReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for v1_dns_monitorReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for v1_dns_monitorReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/v1_dns_monitor_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22240,7 +22240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.888746+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22253,7 +22253,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.162105+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.335806+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -22288,7 +22288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.888811+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22425,7 +22425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.888956+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22459,7 +22459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:15.889032+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22492,7 +22492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:15.889084+00:00"
+                "validatedAt": "2026-05-09T01:34:41.632485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22664,8 +22664,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for v1_http_monitorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for v1_http_monitorCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/v1_http_monitors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22743,7 +22743,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.261237+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22881,7 +22881,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.261397+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22942,7 +22942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.261476+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22999,7 +22999,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.261575+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23069,7 +23069,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.261687+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515425+00:00"
               },
               "deterministic": true
             },
@@ -23170,7 +23170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.261731+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515447+00:00"
               },
               "deterministic": true
             },
@@ -23183,7 +23183,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.184193+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.754503+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23213,7 +23213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.261766+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515464+00:00"
               },
               "deterministic": true
             },
@@ -23226,7 +23226,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.184223+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.754519+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23285,7 +23285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:17:46.261823+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23396,7 +23396,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.184345+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.754581+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -23467,7 +23467,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.261980+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23605,7 +23605,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262136+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23666,7 +23666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262214+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23723,7 +23723,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262312+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23793,7 +23793,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262408+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515761+00:00"
               },
               "deterministic": true
             },
@@ -23890,7 +23890,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262481+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24032,7 +24032,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262649+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24095,7 +24095,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262731+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24154,7 +24154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262829+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24226,7 +24226,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262924+00:00"
+                "validatedAt": "2026-05-09T01:35:48.515989+00:00"
               },
               "deterministic": true
             },
@@ -24309,7 +24309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.262987+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24321,7 +24321,7 @@
             "x-original-maxLength": 2048,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.184975+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.754882+00:00"
           },
           "value": {
             "type": "string",
@@ -24344,7 +24344,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.263057+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24356,7 +24356,7 @@
             "x-original-maxLength": 8192,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.185008+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.754897+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24414,7 +24414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:17:46.263109+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24477,7 +24477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:17:46.263176+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24489,7 +24489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.185076+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.754931+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -24555,7 +24555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.263227+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516125+00:00"
               },
               "deterministic": true
             },
@@ -24568,7 +24568,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.185146+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.754967+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24597,7 +24597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.263263+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516142+00:00"
               },
               "deterministic": true
             },
@@ -24610,7 +24610,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.185175+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.754983+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -24649,7 +24649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:46.263332+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24662,7 +24662,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.185233+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.755014+00:00"
           },
           "uid": {
             "type": "string",
@@ -24679,7 +24679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:46.263365+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24693,7 +24693,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.185263+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.755029+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of v1_http_monitor is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -24774,8 +24774,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for v1_http_monitorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for v1_http_monitorReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/v1_http_monitor_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -24787,8 +24787,8 @@
           "description": "Minimum configuration for v1_http_monitorReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for v1_http_monitorReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for v1_http_monitorReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/v1_http_monitor_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -24838,7 +24838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.263456+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24976,7 +24976,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.263628+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25037,7 +25037,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.263708+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25094,7 +25094,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.263809+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25164,7 +25164,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.263904+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516437+00:00"
               },
               "deterministic": true
             },
@@ -25243,7 +25243,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:46.263987+00:00"
+                "validatedAt": "2026-05-09T01:35:48.516475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25484,8 +25484,8 @@
           "description": "Minimum configuration for access_logMultiKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for access_logMultiKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for access_logMultiKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/access_log_multi_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -25505,8 +25505,8 @@
           "description": "Minimum configuration for access_logNumKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for access_logNumKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for access_logNumKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/access_log_num_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -25555,7 +25555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.119899+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25593,7 +25593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.119991+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742654+00:00"
               },
               "deterministic": true
             },
@@ -25606,7 +25606,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589443+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881670+00:00"
           },
           "query": {
             "type": "string",
@@ -25626,7 +25626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120048+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25659,7 +25659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120102+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25731,7 +25731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120163+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25760,7 +25760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120213+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25798,7 +25798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.120252+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742778+00:00"
               },
               "deterministic": true
             },
@@ -25811,7 +25811,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589532+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881717+00:00"
           },
           "query": {
             "type": "string",
@@ -25831,7 +25831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120304+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25884,7 +25884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120362+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25958,7 +25958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120418+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25996,7 +25996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.120455+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742870+00:00"
               },
               "deterministic": true
             },
@@ -26009,7 +26009,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589671+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881767+00:00"
           },
           "query": {
             "type": "string",
@@ -26029,7 +26029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120507+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26062,7 +26062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120557+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26134,7 +26134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120634+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26163,7 +26163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120678+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26200,7 +26200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.120716+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742976+00:00"
               },
               "deterministic": true
             },
@@ -26213,7 +26213,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589759+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881811+00:00"
           },
           "query": {
             "type": "string",
@@ -26233,7 +26233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120768+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26286,7 +26286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120829+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26346,7 +26346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121103+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26372,7 +26372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121156+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26410,7 +26410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.121223+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26445,7 +26445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.121272+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26483,7 +26483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.121310+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743257+00:00"
               },
               "deterministic": true
             },
@@ -26496,7 +26496,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589995+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881934+00:00"
           },
           "site": {
             "type": "string",
@@ -26513,7 +26513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121349+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26546,7 +26546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121401+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26620,7 +26620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121867+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26658,7 +26658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.121906+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743528+00:00"
               },
               "deterministic": true
             },
@@ -26671,7 +26671,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590332+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882122+00:00"
           },
           "query": {
             "type": "string",
@@ -26691,7 +26691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.121958+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26724,7 +26724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122010+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26796,7 +26796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122064+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26825,7 +26825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122105+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26863,7 +26863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.122143+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743639+00:00"
               },
               "deterministic": true
             },
@@ -26876,7 +26876,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590417+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882174+00:00"
           },
           "query": {
             "type": "string",
@@ -26896,7 +26896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122194+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26949,7 +26949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122251+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27023,7 +27023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122305+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27061,7 +27061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.122342+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743733+00:00"
               },
               "deterministic": true
             },
@@ -27074,7 +27074,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590512+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882224+00:00"
           },
           "query": {
             "type": "string",
@@ -27094,7 +27094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122393+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27119,7 +27119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122431+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27152,7 +27152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122483+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27225,7 +27225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122537+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27254,7 +27254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122579+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27292,7 +27292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.122631+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743856+00:00"
               },
               "deterministic": true
             },
@@ -27305,7 +27305,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590620+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882273+00:00"
           },
           "query": {
             "type": "string",
@@ -27325,7 +27325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122684+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27367,7 +27367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122727+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27403,7 +27403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122783+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27478,7 +27478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122838+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27516,7 +27516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.122875+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743961+00:00"
               },
               "deterministic": true
             },
@@ -27529,7 +27529,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590722+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882328+00:00"
           },
           "query": {
             "type": "string",
@@ -27549,7 +27549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122926+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27574,7 +27574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122963+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27607,7 +27607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123014+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27680,7 +27680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123067+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27709,7 +27709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.123108+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27747,7 +27747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.123146+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744084+00:00"
               },
               "deterministic": true
             },
@@ -27760,7 +27760,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590814+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882378+00:00"
           },
           "query": {
             "type": "string",
@@ -27780,7 +27780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.123197+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27822,7 +27822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123239+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27858,7 +27858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123293+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27927,7 +27927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.123376+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27939,7 +27939,7 @@
             "x-original-maxLength": 256,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590913+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882432+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter is used to filter th that match the logs specified label key/value and the operator.",
@@ -27996,7 +27996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123434+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28078,7 +28078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123500+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28107,7 +28107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123548+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28169,7 +28169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.123599+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744289+00:00"
               },
               "deterministic": true
             },
@@ -28182,7 +28182,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591013+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882485+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -28200,7 +28200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123649+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28271,7 +28271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123888+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28309,7 +28309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.123926+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744428+00:00"
               },
               "deterministic": true
             },
@@ -28322,7 +28322,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591300+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882651+00:00"
           },
           "query": {
             "type": "string",
@@ -28342,7 +28342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.123978+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28375,7 +28375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124029+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28447,7 +28447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124083+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28491,7 +28491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124127+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28528,7 +28528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.124162+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744534+00:00"
               },
               "deterministic": true
             },
@@ -28541,7 +28541,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591393+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882703+00:00"
           },
           "query": {
             "type": "string",
@@ -28561,7 +28561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124212+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28614,7 +28614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124268+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28689,7 +28689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124382+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28727,7 +28727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.124418+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744652+00:00"
               },
               "deterministic": true
             },
@@ -28740,7 +28740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591506+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882764+00:00"
           },
           "query": {
             "type": "string",
@@ -28760,7 +28760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124469+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28793,7 +28793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124519+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28865,7 +28865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124572+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28894,7 +28894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124647+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28932,7 +28932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.124688+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744757+00:00"
               },
               "deterministic": true
             },
@@ -28945,7 +28945,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591600+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882813+00:00"
           },
           "query": {
             "type": "string",
@@ -28965,7 +28965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124741+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29018,7 +29018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124801+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29093,7 +29093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124857+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29131,7 +29131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.124893+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744845+00:00"
               },
               "deterministic": true
             },
@@ -29144,7 +29144,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591694+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882863+00:00"
           },
           "query": {
             "type": "string",
@@ -29164,7 +29164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124944+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29197,7 +29197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124994+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29269,7 +29269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125049+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29298,7 +29298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.125089+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29336,7 +29336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.125124+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744948+00:00"
               },
               "deterministic": true
             },
@@ -29349,7 +29349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591776+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882908+00:00"
           },
           "query": {
             "type": "string",
@@ -29369,7 +29369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.125174+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29422,7 +29422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125231+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29495,7 +29495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125276+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29627,8 +29627,8 @@
           "description": "Minimum configuration for logaccess_logKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logaccess_logKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logaccess_logKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logaccess_log_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -29653,7 +29653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125342+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29741,8 +29741,8 @@
           "description": "Minimum configuration for logaudit_logKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logaudit_logKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logaudit_logKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logaudit_log_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -29790,7 +29790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125403+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29884,8 +29884,8 @@
           "description": "Minimum configuration for logfirewall_logKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logfirewall_logKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logfirewall_logKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logfirewall_log_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -29910,7 +29910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125465+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29954,7 +29954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125506+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30034,8 +30034,8 @@
           "description": "Minimum configuration for logk8s_eventsKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logk8s_eventsKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logk8s_eventsKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logk8s_events_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -30060,7 +30060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125562+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30136,8 +30136,8 @@
           "description": "Minimum configuration for logplatform_eventKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logplatform_eventKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logplatform_eventKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logplatform_event_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -30162,7 +30162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125635+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30206,7 +30206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125674+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30287,8 +30287,8 @@
           "description": "Minimum configuration for logvk8s_eventsKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logvk8s_eventsKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logvk8s_eventsKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logvk8s_events_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -30309,8 +30309,8 @@
           "description": "Minimum configuration for schemaMetricLabelOp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaMetricLabelOp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaMetricLabelOp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_metric_label_ops\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "label"
@@ -30331,8 +30331,8 @@
           "description": "Minimum configuration for schemaSortOrder",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_sort_orders\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -30355,8 +30355,8 @@
           "description": "Minimum configuration for schemalogLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemalogLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemalogLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemalog_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -30384,7 +30384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:18.042879+00:00"
+                "validatedAt": "2026-05-09T01:36:56.698816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30462,8 +30462,8 @@
           "description": "Minimum configuration for subscriptionSubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionSubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_subscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -30479,8 +30479,8 @@
           "description": "Minimum configuration for subscriptionSyntheticMonitors",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionSyntheticMonitors\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionSyntheticMonitors\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_synthetic_monitorses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -30521,8 +30521,8 @@
           "description": "Minimum configuration for subscriptionUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for subscriptionUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/subscription_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "billing_and_usage"
@@ -30537,8 +30537,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -30566,7 +30566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.807665+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30592,7 +30592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.807759+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30638,7 +30638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.807824+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30663,7 +30663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.807877+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30689,7 +30689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.807935+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30714,7 +30714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.807986+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30739,7 +30739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808036+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30764,7 +30764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808082+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30789,7 +30789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808132+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30836,7 +30836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808177+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30861,7 +30861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808224+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30887,7 +30887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808274+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30912,7 +30912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808333+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30938,7 +30938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808387+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30963,7 +30963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808446+00:00"
+                "validatedAt": "2026-05-09T01:39:26.030993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30988,7 +30988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808496+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31015,7 +31015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808547+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31041,7 +31041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808630+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31067,7 +31067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808692+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31093,7 +31093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808746+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31119,7 +31119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808799+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31145,7 +31145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808850+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31170,7 +31170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808894+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31196,7 +31196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808941+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31221,7 +31221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.808989+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31246,7 +31246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809033+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31304,8 +31304,8 @@
           "description": "Minimum configuration for synthetic_monitorFunction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for synthetic_monitorFunction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for synthetic_monitorFunction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/synthetic_monitor_functions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "observability"
@@ -31336,7 +31336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:48.809083+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31462,7 +31462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:48.809172+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031312+00:00"
               },
               "deterministic": true
             },
@@ -31475,7 +31475,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.655092+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.645952+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31514,7 +31514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809218+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31539,7 +31539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809270+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31608,7 +31608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:48.809326+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31654,7 +31654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809379+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31679,7 +31679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809423+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31705,7 +31705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809484+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31730,7 +31730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809527+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31755,7 +31755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809578+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31780,7 +31780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809636+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31835,7 +31835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:48.809678+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31952,7 +31952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:48.809778+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32041,7 +32041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:48.809842+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031599+00:00"
               },
               "deterministic": true
             },
@@ -32054,7 +32054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.655310+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646063+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32093,7 +32093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809887+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32118,7 +32118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.809938+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32187,7 +32187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:48.809993+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32233,7 +32233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810044+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32258,7 +32258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810097+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32283,7 +32283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810140+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32309,7 +32309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810201+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32334,7 +32334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810245+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32359,7 +32359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810294+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32384,7 +32384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810341+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32409,7 +32409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810382+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32463,7 +32463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810430+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32517,7 +32517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:48.810484+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031893+00:00"
               },
               "deterministic": true
             },
@@ -32530,7 +32530,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.655489+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646160+00:00"
           },
           "start_time": {
             "type": "string",
@@ -32548,7 +32548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810532+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32573,7 +32573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810579+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32696,7 +32696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810671+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32708,7 +32708,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.655566+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646200+00:00"
           },
           "segments": {
             "type": "array",
@@ -32743,7 +32743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810729+00:00"
+                "validatedAt": "2026-05-09T01:39:26.031996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32827,7 +32827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810792+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32852,7 +32852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810834+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32877,7 +32877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810884+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32903,7 +32903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.810932+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32955,7 +32955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:48.810972+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33040,7 +33040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811052+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33085,7 +33085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811098+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33110,7 +33110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811148+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33153,7 +33153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811204+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33205,7 +33205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:48.811243+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33247,7 +33247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811282+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33273,7 +33273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811333+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33299,7 +33299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811387+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33325,7 +33325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811438+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33350,7 +33350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811481+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33375,7 +33375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811523+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33401,7 +33401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811566+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33427,7 +33427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811635+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33452,7 +33452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811687+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33478,7 +33478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811741+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33503,7 +33503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811793+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33529,7 +33529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811844+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33555,7 +33555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811901+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33581,7 +33581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.811952+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33607,7 +33607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812008+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33632,7 +33632,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812060+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33657,7 +33657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812109+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33682,7 +33682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812153+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33708,7 +33708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812206+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33734,7 +33734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812256+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33849,7 +33849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812337+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33877,7 +33877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812388+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33905,7 +33905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:25:48.812426+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032749+00:00"
               },
               "deterministic": true
             },
@@ -33954,7 +33954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812470+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34016,7 +34016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812530+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34041,7 +34041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812579+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34066,7 +34066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812646+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34101,7 +34101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812709+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34126,7 +34126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812757+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34138,7 +34138,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.656114+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646478+00:00"
           },
           "source": {
             "type": "string",
@@ -34155,7 +34155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812798+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34265,7 +34265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812884+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34290,7 +34290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.812928+00:00"
+                "validatedAt": "2026-05-09T01:39:26.032984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34351,7 +34351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813000+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34390,7 +34390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813061+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34402,7 +34402,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.656241+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646543+00:00"
           },
           "region": {
             "type": "string",
@@ -34419,7 +34419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813104+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34471,8 +34471,8 @@
           "description": "Minimum configuration for synthetic_monitorProtocol",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for synthetic_monitorProtocol\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for synthetic_monitorProtocol\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/synthetic_monitor_protocols\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "observability"
@@ -34515,7 +34515,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.656295+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646571+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34554,7 +34554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:48.813181+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34579,7 +34579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813230+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34626,7 +34626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813280+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34652,7 +34652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813323+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34678,7 +34678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813366+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34704,7 +34704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813418+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34729,7 +34729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813462+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34741,7 +34741,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.656388+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646620+00:00"
           },
           "region": {
             "type": "string",
@@ -34758,7 +34758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813504+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34784,7 +34784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813545+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34836,7 +34836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813601+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34861,7 +34861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813646+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34886,7 +34886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813690+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34898,7 +34898,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.656458+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646657+00:00"
           },
           "source": {
             "type": "string",
@@ -34915,7 +34915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.813732+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34971,7 +34971,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:48.813820+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35005,7 +35005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:48.813905+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35043,7 +35043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:48.813944+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033442+00:00"
               },
               "deterministic": true
             },
@@ -35056,7 +35056,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.656520+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646690+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -35102,7 +35102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:48.813988+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35150,7 +35150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:25:48.814048+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35162,7 +35162,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.656576+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646719+00:00"
           },
           "value": {
             "type": "string",
@@ -35177,7 +35177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.814089+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35189,7 +35189,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.656624+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646735+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -35287,7 +35287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:48.814164+00:00"
+                "validatedAt": "2026-05-09T01:39:26.033553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35299,7 +35299,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.656689+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.646768+00:00"
           },
           "values": {
             "type": "array",

--- a/docs/specifications/api/rate_limiting.json
+++ b/docs/specifications/api/rate_limiting.json
@@ -3577,8 +3577,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -3743,7 +3743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.793684+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201508+00:00"
               },
               "deterministic": true
             },
@@ -3756,7 +3756,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.188923+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074218+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3786,7 +3786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.793734+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201528+00:00"
               },
               "deterministic": true
             },
@@ -3799,7 +3799,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.188957+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074235+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -3902,7 +3902,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189062+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074288+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -4051,7 +4051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:22:11.793931+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4113,7 +4113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:22:11.794001+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4125,7 +4125,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189193+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074350+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -4191,7 +4191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.794057+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201666+00:00"
               },
               "deterministic": true
             },
@@ -4204,7 +4204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189266+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074387+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4233,7 +4233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.794096+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201684+00:00"
               },
               "deterministic": true
             },
@@ -4246,7 +4246,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189296+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074403+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -4285,7 +4285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794162+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4298,7 +4298,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189357+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074434+00:00"
           },
           "uid": {
             "type": "string",
@@ -4315,7 +4315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794196+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4329,7 +4329,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189391+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074450+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of policer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -4375,8 +4375,8 @@
           "description": "Minimum configuration for policerPolicerMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policerPolicerMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policerPolicerMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policer_policer_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -4396,8 +4396,8 @@
           "description": "Minimum configuration for policerPolicerType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policerPolicerType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policerPolicerType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policer_policer_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -4423,8 +4423,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policer_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -4436,8 +4436,8 @@
           "description": "Minimum configuration for policerReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policerReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policerReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policer_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -4599,7 +4599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794341+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4622,7 +4622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794386+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4634,7 +4634,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189538+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074525+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4680,7 +4680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:22:11.794430+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201826+00:00"
               },
               "deterministic": true
             },
@@ -4706,7 +4706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794483+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4733,7 +4733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794526+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4745,7 +4745,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189607+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074552+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4762,7 +4762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794576+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4795,7 +4795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794640+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4807,7 +4807,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189649+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074573+00:00"
           },
           "type": {
             "type": "string",
@@ -4832,7 +4832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794683+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4886,8 +4886,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -4920,7 +4920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.794735+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4982,7 +4982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.794776+00:00"
+                "validatedAt": "2026-05-09T01:37:48.201971+00:00"
               },
               "deterministic": true
             },
@@ -4995,7 +4995,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189729+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074612+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -5113,7 +5113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.794901+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202026+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5129,7 +5129,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189798+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074647+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5199,7 +5199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.794951+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202047+00:00"
               },
               "deterministic": true
             },
@@ -5212,7 +5212,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189850+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074674+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5243,7 +5243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.794987+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202063+00:00"
               },
               "deterministic": true
             },
@@ -5256,7 +5256,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189881+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074690+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -5338,7 +5338,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.795087+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202109+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5354,7 +5354,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189927+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074712+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5426,7 +5426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.795136+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202129+00:00"
               },
               "deterministic": true
             },
@@ -5439,7 +5439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.189981+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074739+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5470,7 +5470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.795173+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202145+00:00"
               },
               "deterministic": true
             },
@@ -5483,7 +5483,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190012+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074755+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5528,7 +5528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795214+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5541,7 +5541,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190045+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074772+00:00"
           },
           "name": {
             "type": "string",
@@ -5574,7 +5574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.795252+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202188+00:00"
               },
               "deterministic": true
             },
@@ -5587,7 +5587,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190076+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074789+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5618,7 +5618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.795288+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202204+00:00"
               },
               "deterministic": true
             },
@@ -5631,7 +5631,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190105+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074805+00:00"
           },
           "tenant": {
             "type": "string",
@@ -5650,7 +5650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795331+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5664,7 +5664,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190135+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074820+00:00"
           },
           "uid": {
             "type": "string",
@@ -5683,7 +5683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795364+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5698,7 +5698,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190167+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074837+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -5780,7 +5780,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.795464+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202281+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5796,7 +5796,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190213+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074860+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5866,7 +5866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.795513+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202301+00:00"
               },
               "deterministic": true
             },
@@ -5879,7 +5879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190264+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074886+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5910,7 +5910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.795547+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202316+00:00"
               },
               "deterministic": true
             },
@@ -5923,7 +5923,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190295+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074902+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -5968,7 +5968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795617+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5996,7 +5996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795671+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6024,7 +6024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795719+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6053,7 +6053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795769+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6080,7 +6080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795802+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6094,7 +6094,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190377+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074945+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -6110,7 +6110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795845+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6173,8 +6173,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6219,7 +6219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795906+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6231,7 +6231,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190442+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074978+00:00"
           },
           "status": {
             "type": "string",
@@ -6249,7 +6249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.795947+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6261,7 +6261,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190471+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.074993+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -6303,7 +6303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.796001+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6330,7 +6330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.796052+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6357,7 +6357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.796099+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6385,7 +6385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.796151+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6450,7 +6450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.796229+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6499,7 +6499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.796291+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6512,7 +6512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190617+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.075062+00:00"
           },
           "uid": {
             "type": "string",
@@ -6531,7 +6531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.796324+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6545,7 +6545,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190650+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.075077+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -6595,7 +6595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.796363+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6607,7 +6607,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190684+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.075094+00:00"
           },
           "name": {
             "type": "string",
@@ -6640,7 +6640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.796399+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202677+00:00"
               },
               "deterministic": true
             },
@@ -6653,7 +6653,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190713+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.075110+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6684,7 +6684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:11.796436+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202693+00:00"
               },
               "deterministic": true
             },
@@ -6697,7 +6697,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190743+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.075125+00:00"
           },
           "uid": {
             "type": "string",
@@ -6714,7 +6714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:11.796469+00:00"
+                "validatedAt": "2026-05-09T01:37:48.202706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6728,7 +6728,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.190774+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.075141+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -6768,8 +6768,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for protocol_policerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for protocol_policerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/protocol_policers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -6836,7 +6836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:25.959818+00:00"
+                "validatedAt": "2026-05-09T01:37:54.477827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6911,7 +6911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:25.959893+00:00"
+                "validatedAt": "2026-05-09T01:37:54.477852+00:00"
               },
               "deterministic": true
             },
@@ -6924,7 +6924,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.505789+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.215753+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6954,7 +6954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:25.959934+00:00"
+                "validatedAt": "2026-05-09T01:37:54.477870+00:00"
               },
               "deterministic": true
             },
@@ -6967,7 +6967,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.505819+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.215769+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6995,8 +6995,8 @@
           "description": "Minimum configuration for protocol_policerDnsType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for protocol_policerDnsType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for protocol_policerDnsType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/protocol_policer_dns_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -7087,7 +7087,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.505922+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.215822+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -7147,7 +7147,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:25.960100+00:00"
+                "validatedAt": "2026-05-09T01:37:54.477937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7190,8 +7190,8 @@
           "description": "Minimum configuration for protocol_policerIcmpMsgType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for protocol_policerIcmpMsgType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for protocol_policerIcmpMsgType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/protocol_policer_icmp_msg_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -7274,7 +7274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:22:25.960172+00:00"
+                "validatedAt": "2026-05-09T01:37:54.477969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7337,7 +7337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:22:25.960243+00:00"
+                "validatedAt": "2026-05-09T01:37:54.478000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7349,7 +7349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.506026+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.215875+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7415,7 +7415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:25.960297+00:00"
+                "validatedAt": "2026-05-09T01:37:54.478022+00:00"
               },
               "deterministic": true
             },
@@ -7428,7 +7428,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.506097+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.215918+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7457,7 +7457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:25.960337+00:00"
+                "validatedAt": "2026-05-09T01:37:54.478040+00:00"
               },
               "deterministic": true
             },
@@ -7470,7 +7470,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.506126+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.215934+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7509,7 +7509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:25.960404+00:00"
+                "validatedAt": "2026-05-09T01:37:54.478067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7522,7 +7522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.506184+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.215964+00:00"
           },
           "uid": {
             "type": "string",
@@ -7540,7 +7540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:25.960438+00:00"
+                "validatedAt": "2026-05-09T01:37:54.478082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7554,7 +7554,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.506216+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.215981+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of protocol_policer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -7621,7 +7621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:25.960505+00:00"
+                "validatedAt": "2026-05-09T01:37:54.478114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7708,8 +7708,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for protocol_policerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for protocol_policerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/protocol_policer_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -7721,8 +7721,8 @@
           "description": "Minimum configuration for protocol_policerReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for protocol_policerReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for protocol_policerReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/protocol_policer_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -7761,7 +7761,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:25.960619+00:00"
+                "validatedAt": "2026-05-09T01:37:54.478163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7867,8 +7867,8 @@
           "description": "Minimum configuration for protocol_policerTcpFlags",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for protocol_policerTcpFlags\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for protocol_policerTcpFlags\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/protocol_policer_tcp_flagses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -7919,8 +7919,8 @@
           "description": "Minimum configuration for protocol_policerUdpType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for protocol_policerUdpType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for protocol_policerUdpType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/protocol_policer_udp_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -7935,8 +7935,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7962,8 +7962,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiters\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -8030,7 +8030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.377823+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8064,7 +8064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.377889+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8142,7 +8142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.377938+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954133+00:00"
               },
               "deterministic": true
             },
@@ -8155,7 +8155,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.867361+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.384890+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8185,7 +8185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.377979+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954160+00:00"
               },
               "deterministic": true
             },
@@ -8198,7 +8198,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.867392+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.384906+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8301,7 +8301,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.867493+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.384958+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8361,7 +8361,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.378127+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8395,7 +8395,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.378188+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8557,8 +8557,8 @@
           "description": "Minimum configuration for rate_limiterLeakyBucketRateLimiter",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterLeakyBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterLeakyBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_leaky_bucket_rate_limiters\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -8605,7 +8605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:22:46.378309+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8668,7 +8668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:22:46.378380+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8680,7 +8680,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.867649+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.385028+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8746,7 +8746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.378430+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954371+00:00"
               },
               "deterministic": true
             },
@@ -8759,7 +8759,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.867724+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.385065+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8788,7 +8788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.378467+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954387+00:00"
               },
               "deterministic": true
             },
@@ -8801,7 +8801,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.867754+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.385081+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8840,7 +8840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:46.378534+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8853,7 +8853,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.867814+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.385111+00:00"
           },
           "uid": {
             "type": "string",
@@ -8870,7 +8870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:46.378568+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8884,7 +8884,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.867846+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.385127+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of rate_limiter is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -8964,8 +8964,8 @@
           "description": "Minimum configuration for rate_limiterRateLimitPeriodUnit",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_rate_limit_period_units\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -9110,8 +9110,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -9123,8 +9123,8 @@
           "description": "Minimum configuration for rate_limiterReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -9163,7 +9163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.378748+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9197,7 +9197,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:46.378809+00:00"
+                "validatedAt": "2026-05-09T01:38:03.954532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9293,8 +9293,8 @@
           "description": "Minimum configuration for rate_limiterTokenBucketRateLimiter",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterTokenBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterTokenBucketRateLimiter\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_token_bucket_rate_limiters\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"

--- a/docs/specifications/api/secops_and_incident_response.json
+++ b/docs/specifications/api/secops_and_incident_response.json
@@ -1284,8 +1284,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -1421,7 +1421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.340888+00:00"
+                "validatedAt": "2026-05-09T01:36:47.675823+00:00"
               },
               "deterministic": true
             },
@@ -1434,7 +1434,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.705822+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938326+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1464,7 +1464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.340961+00:00"
+                "validatedAt": "2026-05-09T01:36:47.675846+00:00"
               },
               "deterministic": true
             },
@@ -1477,7 +1477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.705856+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938343+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -1580,7 +1580,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.705959+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938396+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -1673,7 +1673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:19:58.341195+00:00"
+                "validatedAt": "2026-05-09T01:36:47.675912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1736,7 +1736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:58.341273+00:00"
+                "validatedAt": "2026-05-09T01:36:47.675945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1748,7 +1748,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706052+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938443+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -1815,7 +1815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.341326+00:00"
+                "validatedAt": "2026-05-09T01:36:47.675968+00:00"
               },
               "deterministic": true
             },
@@ -1828,7 +1828,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706124+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938480+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1857,7 +1857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.341366+00:00"
+                "validatedAt": "2026-05-09T01:36:47.675987+00:00"
               },
               "deterministic": true
             },
@@ -1870,7 +1870,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706154+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938496+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -1909,7 +1909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.341435+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1922,7 +1922,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706214+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938527+00:00"
           },
           "uid": {
             "type": "string",
@@ -1940,7 +1940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.341469+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1954,7 +1954,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706246+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938544+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of malicious_user_mitigation is returned in 'List'.",
@@ -2085,7 +2085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.341574+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676084+00:00"
               },
               "deterministic": true
             },
@@ -2178,8 +2178,8 @@
           "description": "Minimum configuration for malicious_user_mitigationReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for malicious_user_mitigationReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for malicious_user_mitigationReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/malicious_user_mitigation_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "secops_and_incident_response"
@@ -2284,7 +2284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.341709+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2307,7 +2307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.341755+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2319,7 +2319,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706453+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938650+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -2365,7 +2365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:19:58.341799+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676177+00:00"
               },
               "deterministic": true
             },
@@ -2391,7 +2391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.341853+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2418,7 +2418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.341898+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2430,7 +2430,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706506+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938678+00:00"
           },
           "service_name": {
             "type": "string",
@@ -2447,7 +2447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.341948+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2480,7 +2480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.341997+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2492,7 +2492,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706547+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938699+00:00"
           },
           "type": {
             "type": "string",
@@ -2517,7 +2517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.342038+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2571,8 +2571,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -2605,7 +2605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.342092+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2667,7 +2667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342131+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676325+00:00"
               },
               "deterministic": true
             },
@@ -2680,7 +2680,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706638+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938738+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -2798,7 +2798,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342255+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676380+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -2814,7 +2814,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706708+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938772+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -2884,7 +2884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342304+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676402+00:00"
               },
               "deterministic": true
             },
@@ -2897,7 +2897,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706761+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938799+00:00"
           },
           "namespace": {
             "type": "string",
@@ -2928,7 +2928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342339+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676418+00:00"
               },
               "deterministic": true
             },
@@ -2941,7 +2941,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706791+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938815+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -3023,7 +3023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342438+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676466+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -3039,7 +3039,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706836+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938838+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -3111,7 +3111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342486+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676488+00:00"
               },
               "deterministic": true
             },
@@ -3124,7 +3124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706888+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938865+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3155,7 +3155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342521+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676505+00:00"
               },
               "deterministic": true
             },
@@ -3168,7 +3168,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706918+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938881+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -3213,7 +3213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.342562+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3226,7 +3226,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706952+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938898+00:00"
           },
           "name": {
             "type": "string",
@@ -3259,7 +3259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342612+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676541+00:00"
               },
               "deterministic": true
             },
@@ -3272,7 +3272,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.706982+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938913+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3303,7 +3303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342648+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676558+00:00"
               },
               "deterministic": true
             },
@@ -3316,7 +3316,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707012+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938930+00:00"
           },
           "tenant": {
             "type": "string",
@@ -3335,7 +3335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.342692+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3349,7 +3349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707042+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938946+00:00"
           },
           "uid": {
             "type": "string",
@@ -3368,7 +3368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.342725+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3383,7 +3383,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707074+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938963+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -3465,7 +3465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342823+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676638+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -3481,7 +3481,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707119+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.938986+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -3551,7 +3551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342872+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676660+00:00"
               },
               "deterministic": true
             },
@@ -3564,7 +3564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707171+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939013+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3595,7 +3595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.342907+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676677+00:00"
               },
               "deterministic": true
             },
@@ -3608,7 +3608,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707201+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939028+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -3653,7 +3653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.342964+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3681,7 +3681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343016+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3709,7 +3709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343064+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3738,7 +3738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343114+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3765,7 +3765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343147+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3779,7 +3779,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707284+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939071+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -3795,7 +3795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343191+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3858,8 +3858,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -3904,7 +3904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343253+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3916,7 +3916,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707347+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939103+00:00"
           },
           "status": {
             "type": "string",
@@ -3934,7 +3934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343296+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3946,7 +3946,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707378+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939119+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -3988,7 +3988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343354+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4015,7 +4015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343406+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4042,7 +4042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343453+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4070,7 +4070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343507+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4135,7 +4135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343601+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4184,7 +4184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343666+00:00"
+                "validatedAt": "2026-05-09T01:36:47.676994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4197,7 +4197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707508+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939194+00:00"
           },
           "uid": {
             "type": "string",
@@ -4216,7 +4216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343698+00:00"
+                "validatedAt": "2026-05-09T01:36:47.677009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4230,7 +4230,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707539+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939210+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -4280,7 +4280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343738+00:00"
+                "validatedAt": "2026-05-09T01:36:47.677027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4292,7 +4292,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707571+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939227+00:00"
           },
           "name": {
             "type": "string",
@@ -4325,7 +4325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.343775+00:00"
+                "validatedAt": "2026-05-09T01:36:47.677044+00:00"
               },
               "deterministic": true
             },
@@ -4338,7 +4338,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707614+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939243+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4369,7 +4369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:58.343811+00:00"
+                "validatedAt": "2026-05-09T01:36:47.677061+00:00"
               },
               "deterministic": true
             },
@@ -4382,7 +4382,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707644+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939258+00:00"
           },
           "uid": {
             "type": "string",
@@ -4399,7 +4399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:58.343844+00:00"
+                "validatedAt": "2026-05-09T01:36:47.677076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4413,7 +4413,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.707675+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.939274+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",

--- a/docs/specifications/api/service_mesh.json
+++ b/docs/specifications/api/service_mesh.json
@@ -10234,7 +10234,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.763859+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10321,8 +10321,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_settingCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_settingCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_settings\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -10405,7 +10405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.764020+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861609+00:00"
               },
               "deterministic": true
             },
@@ -10418,7 +10418,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768097+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332104+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10448,7 +10448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.764094+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861629+00:00"
               },
               "deterministic": true
             },
@@ -10461,7 +10461,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768129+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332120+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -10659,7 +10659,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768256+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332190+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -10727,7 +10727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:25.764309+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10790,7 +10790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:25.764381+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10802,7 +10802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768333+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332230+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10868,7 +10868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.764437+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861770+00:00"
               },
               "deterministic": true
             },
@@ -10881,7 +10881,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768403+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332267+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10910,7 +10910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.764475+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861787+00:00"
               },
               "deterministic": true
             },
@@ -10923,7 +10923,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768432+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332283+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10962,7 +10962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.764541+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10975,7 +10975,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768490+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332314+00:00"
           },
           "uid": {
             "type": "string",
@@ -10992,7 +10992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.764575+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11006,7 +11006,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768521+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332330+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_setting is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11177,8 +11177,8 @@
           "description": "Minimum configuration for app_settingMetric",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_settingMetric\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_settingMetric\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_setting_metrics\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -11213,7 +11213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.764745+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11260,8 +11260,8 @@
           "description": "Minimum configuration for app_settingMetricsSource",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_settingMetricsSource\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_settingMetricsSource\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_setting_metrics_sources\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -11365,8 +11365,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_settingReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_settingReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_setting_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -11378,8 +11378,8 @@
           "description": "Minimum configuration for app_settingReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_settingReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_settingReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_setting_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -11497,7 +11497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.764911+00:00"
+                "validatedAt": "2026-05-09T01:32:06.861964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11591,7 +11591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.764991+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11662,8 +11662,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11692,7 +11692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765050+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11705,7 +11705,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768960+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332550+00:00"
           },
           "name": {
             "type": "string",
@@ -11738,7 +11738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.765088+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862047+00:00"
               },
               "deterministic": true
             },
@@ -11751,7 +11751,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.768991+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332565+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11782,7 +11782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.765125+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862069+00:00"
               },
               "deterministic": true
             },
@@ -11795,7 +11795,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769021+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332580+00:00"
           },
           "tenant": {
             "type": "string",
@@ -11814,7 +11814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765168+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11828,7 +11828,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769050+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332596+00:00"
           },
           "uid": {
             "type": "string",
@@ -11847,7 +11847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765202+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11862,7 +11862,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769080+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332612+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11900,7 +11900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765257+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11923,7 +11923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765300+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11935,7 +11935,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769123+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332634+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -11981,7 +11981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:09:25.765343+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862175+00:00"
               },
               "deterministic": true
             },
@@ -12007,7 +12007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765395+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12033,7 +12033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765437+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12045,7 +12045,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769174+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332661+00:00"
           },
           "service_name": {
             "type": "string",
@@ -12062,7 +12062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765487+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12095,7 +12095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765534+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12107,7 +12107,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769212+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332681+00:00"
           },
           "type": {
             "type": "string",
@@ -12132,7 +12132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765575+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12186,8 +12186,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12220,7 +12220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.765644+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12282,7 +12282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.765684+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862332+00:00"
               },
               "deterministic": true
             },
@@ -12295,7 +12295,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769286+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332719+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -12413,7 +12413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.765808+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862391+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12429,7 +12429,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769350+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332753+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12499,7 +12499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.765858+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862414+00:00"
               },
               "deterministic": true
             },
@@ -12512,7 +12512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769400+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332780+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12543,7 +12543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.765894+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862431+00:00"
               },
               "deterministic": true
             },
@@ -12556,7 +12556,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769429+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332795+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -12638,7 +12638,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.765993+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862477+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12654,7 +12654,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769473+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332817+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12726,7 +12726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.766040+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862498+00:00"
               },
               "deterministic": true
             },
@@ -12739,7 +12739,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769523+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332844+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12770,7 +12770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.766074+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862514+00:00"
               },
               "deterministic": true
             },
@@ -12783,7 +12783,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769552+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332859+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -12865,7 +12865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.766174+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862562+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12881,7 +12881,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769608+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332882+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12951,7 +12951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.766221+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862583+00:00"
               },
               "deterministic": true
             },
@@ -12964,7 +12964,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769659+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332908+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12995,7 +12995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.766255+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862600+00:00"
               },
               "deterministic": true
             },
@@ -13008,7 +13008,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769688+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332924+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -13053,7 +13053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766310+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13081,7 +13081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766361+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13109,7 +13109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766409+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13138,7 +13138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766459+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13165,7 +13165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766493+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13179,7 +13179,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769769+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332966+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -13195,7 +13195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766538+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13258,8 +13258,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -13304,7 +13304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766615+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13316,7 +13316,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769831+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.332998+00:00"
           },
           "status": {
             "type": "string",
@@ -13334,7 +13334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766659+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13346,7 +13346,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769860+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.333014+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -13388,7 +13388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766715+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13415,7 +13415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766766+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13442,7 +13442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766813+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13470,7 +13470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766867+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13535,7 +13535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.766945+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13584,7 +13584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.767008+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13597,7 +13597,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.769989+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.333082+00:00"
           },
           "uid": {
             "type": "string",
@@ -13616,7 +13616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.767041+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13630,7 +13630,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.770019+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.333097+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -13680,7 +13680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.767081+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13692,7 +13692,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.770051+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.333114+00:00"
           },
           "name": {
             "type": "string",
@@ -13725,7 +13725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.767118+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862967+00:00"
               },
               "deterministic": true
             },
@@ -13738,7 +13738,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.770080+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.333129+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13769,7 +13769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.767156+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862986+00:00"
               },
               "deterministic": true
             },
@@ -13782,7 +13782,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.770109+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.333145+00:00"
           },
           "uid": {
             "type": "string",
@@ -13799,7 +13799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:25.767188+00:00"
+                "validatedAt": "2026-05-09T01:32:06.862999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13813,7 +13813,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.770139+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.333165+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -13870,7 +13870,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.767258+00:00"
+                "validatedAt": "2026-05-09T01:32:06.863033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13932,7 +13932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.767323+00:00"
+                "validatedAt": "2026-05-09T01:32:06.863064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13994,7 +13994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:25.767388+00:00"
+                "validatedAt": "2026-05-09T01:32:06.863095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14035,7 +14035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.501408+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14060,7 +14060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.501472+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14122,8 +14122,8 @@
           "description": "Minimum configuration for app_typeAPIEPCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -14169,7 +14169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.501572+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14220,7 +14220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.501651+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14315,7 +14315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.501774+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14357,7 +14357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.501842+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14403,7 +14403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.501900+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14466,7 +14466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.501982+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14507,7 +14507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.502037+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14547,7 +14547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.502099+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14644,7 +14644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.502223+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14797,7 +14797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.502349+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14989,8 +14989,8 @@
           "description": "Minimum configuration for app_typeAPIEPPIILevel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPPIILevel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPPIILevel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_p_i_i_levels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -15015,8 +15015,8 @@
           "description": "Minimum configuration for app_typeAPIEPSecurityRisk",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPSecurityRisk\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPSecurityRisk\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_security_risks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -15041,7 +15041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.502542+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15114,7 +15114,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.502640+00:00"
+                "validatedAt": "2026-05-09T01:32:08.100990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15139,7 +15139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.502695+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15165,7 +15165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.502746+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15191,7 +15191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.502790+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15229,7 +15229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.502836+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101073+00:00"
               },
               "deterministic": true
             },
@@ -15242,7 +15242,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.824315+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358348+00:00"
           }
         },
         "x-f5xc-description-short": "Shape of request to GET learnt schema request for a given API endpoint.",
@@ -15301,7 +15301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.502906+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15428,8 +15428,8 @@
           "description": "Minimum configuration for app_typeAPIType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -15451,8 +15451,8 @@
           "description": "Minimum configuration for app_typeApiEndpointInfoRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeApiEndpointInfoRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeApiEndpointInfoRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_api_endpoint_info_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -15476,8 +15476,8 @@
           "description": "Minimum configuration for app_typeAuthenticationLocation",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAuthenticationLocation\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAuthenticationLocation\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_authentication_locations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -15500,8 +15500,8 @@
           "description": "Minimum configuration for app_typeAuthenticationState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAuthenticationState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAuthenticationState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_authentication_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -15531,8 +15531,8 @@
           "description": "Minimum configuration for app_typeAuthenticationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAuthenticationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAuthenticationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_authentication_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -15560,7 +15560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.503001+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15625,7 +15625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.503048+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101166+00:00"
               },
               "deterministic": true
             },
@@ -15638,7 +15638,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.824465+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358424+00:00"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -15710,8 +15710,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -15776,7 +15776,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.503145+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15839,7 +15839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.503215+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15864,7 +15864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.503263+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15897,7 +15897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.503324+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16021,7 +16021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.503402+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16096,7 +16096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.503445+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101334+00:00"
               },
               "deterministic": true
             },
@@ -16109,7 +16109,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.824801+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358595+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16139,7 +16139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.503483+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101351+00:00"
               },
               "deterministic": true
             },
@@ -16152,7 +16152,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.824832+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358611+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16240,7 +16240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.503569+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16326,8 +16326,8 @@
           "description": "Minimum configuration for app_typeFeatureType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeFeatureType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeFeatureType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_feature_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -16418,7 +16418,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.824987+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358692+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16476,7 +16476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.503753+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16520,7 +16520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.503805+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16544,7 +16544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.503856+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16638,7 +16638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:28.503922+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16700,7 +16700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:28.503992+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16712,7 +16712,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825124+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358765+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -16778,7 +16778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.504046+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101580+00:00"
               },
               "deterministic": true
             },
@@ -16791,7 +16791,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825193+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358801+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16820,7 +16820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.504083+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101596+00:00"
               },
               "deterministic": true
             },
@@ -16833,7 +16833,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825222+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358817+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -16872,7 +16872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504148+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16885,7 +16885,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825280+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358848+00:00"
           },
           "uid": {
             "type": "string",
@@ -16902,7 +16902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504182+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16916,7 +16916,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825311+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358864+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_type is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -16968,7 +16968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504238+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17032,7 +17032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504296+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17070,7 +17070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.504333+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101699+00:00"
               },
               "deterministic": true
             },
@@ -17083,7 +17083,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825374+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358897+00:00"
           }
         },
         "x-f5xc-description-short": "Shape of remove to remove override for API endpoints.",
@@ -17125,7 +17125,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825405+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358913+00:00"
           },
           "status_msg": {
             "type": "string",
@@ -17143,7 +17143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504387+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17190,7 +17190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504439+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17228,7 +17228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.504475+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101760+00:00"
               },
               "deterministic": true
             },
@@ -17241,7 +17241,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825455+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358940+00:00"
           },
           "override_info": {
             "$ref": "#/components/schemas/app_typeOverrideInfo"
@@ -17287,7 +17287,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825500+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.358961+00:00"
           },
           "status_msg": {
             "type": "string",
@@ -17305,7 +17305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504531+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17495,8 +17495,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -17508,8 +17508,8 @@
           "description": "Minimum configuration for app_typeReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -17546,7 +17546,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.504693+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17692,7 +17692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504790+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17767,7 +17767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504865+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17794,7 +17794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504913+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17818,7 +17818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.504967+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17868,8 +17868,8 @@
           "description": "Minimum configuration for app_typeSensitiveDataDetectionRuleType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeSensitiveDataDetectionRuleType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeSensitiveDataDetectionRuleType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_sensitive_data_detection_rule_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -17898,8 +17898,8 @@
           "description": "Minimum configuration for app_typeSensitiveDataType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeSensitiveDataType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeSensitiveDataType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_sensitive_data_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -17926,7 +17926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.505024+00:00"
+                "validatedAt": "2026-05-09T01:32:08.101983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17952,7 +17952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.505074+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17978,7 +17978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.505115+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18016,7 +18016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.505156+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102040+00:00"
               },
               "deterministic": true
             },
@@ -18029,7 +18029,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825830+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359134+00:00"
           },
           "service_name": {
             "type": "string",
@@ -18046,7 +18046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.505206+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18105,7 +18105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.505268+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18130,7 +18130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.505318+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18168,7 +18168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.505355+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102126+00:00"
               },
               "deterministic": true
             },
@@ -18181,7 +18181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.825891+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359171+00:00"
           },
           "service_name": {
             "type": "string",
@@ -18198,7 +18198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.505404+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18300,7 +18300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.505492+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18324,7 +18324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.505540+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18373,8 +18373,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18398,8 +18398,8 @@
           "description": "Minimum configuration for schemaHttpSections",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpSections\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpSections\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_sectionses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18427,7 +18427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:28.506092+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18439,7 +18439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.826214+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359341+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -18485,7 +18485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.506130+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102459+00:00"
               },
               "deterministic": true
             },
@@ -18498,7 +18498,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.826252+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359361+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Message Metadata\" MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -18541,7 +18541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.506539+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18554,7 +18554,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.826530+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359508+00:00"
           },
           "name": {
             "type": "string",
@@ -18587,7 +18587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.506574+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102658+00:00"
               },
               "deterministic": true
             },
@@ -18600,7 +18600,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.826559+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359523+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18631,7 +18631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.506625+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102675+00:00"
               },
               "deterministic": true
             },
@@ -18644,7 +18644,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.826600+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359539+00:00"
           },
           "tenant": {
             "type": "string",
@@ -18663,7 +18663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.506668+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18677,7 +18677,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.826631+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359581+00:00"
           },
           "uid": {
             "type": "string",
@@ -18696,7 +18696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.506701+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18711,7 +18711,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.826662+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359599+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -18755,7 +18755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:28.506934+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18795,7 +18795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:28.506971+00:00"
+                "validatedAt": "2026-05-09T01:32:08.102830+00:00"
               },
               "deterministic": true
             },
@@ -18808,7 +18808,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.826827+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.359688+00:00"
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",
@@ -18904,8 +18904,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for endpointCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for endpointCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/endpoints\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19024,7 +19024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.536998+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290325+00:00"
               },
               "deterministic": true
             },
@@ -19037,7 +19037,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.392677+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.918940+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19067,7 +19067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.537051+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290347+00:00"
               },
               "deterministic": true
             },
@@ -19080,7 +19080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.392713+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.918956+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19176,7 +19176,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.537147+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290395+00:00"
               },
               "deterministic": true
             },
@@ -19189,7 +19189,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.392781+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.918995+00:00"
           },
           "refresh_interval": {
             "type": "integer",
@@ -19316,7 +19316,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.392896+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.919055+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19365,7 +19365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.537320+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19389,7 +19389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.537386+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19413,7 +19413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.537449+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19438,7 +19438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.537508+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19462,7 +19462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.537573+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19486,7 +19486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.537663+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19511,7 +19511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.537727+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19658,7 +19658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:11.537814+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19720,7 +19720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:11.537882+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19732,7 +19732,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.393090+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.919163+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -19798,7 +19798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.537936+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290717+00:00"
               },
               "deterministic": true
             },
@@ -19811,7 +19811,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.393162+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.919200+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19840,7 +19840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.537973+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290735+00:00"
               },
               "deterministic": true
             },
@@ -19853,7 +19853,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.393192+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.919216+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -19892,7 +19892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.538041+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19905,7 +19905,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.393251+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.919246+00:00"
           },
           "uid": {
             "type": "string",
@@ -19922,7 +19922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.538074+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19936,7 +19936,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.393283+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.919262+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of endpoint is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19982,8 +19982,8 @@
           "description": "Minimum configuration for endpointOriginSpanStatusType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for endpointOriginSpanStatusType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for endpointOriginSpanStatusType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/endpoint_origin_span_status_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20009,8 +20009,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for endpointReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for endpointReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/endpoint_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20022,8 +20022,8 @@
           "description": "Minimum configuration for endpointReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for endpointReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for endpointReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/endpoint_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20067,7 +20067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.538174+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20244,7 +20244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.538337+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20269,7 +20269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.538376+00:00"
+                "validatedAt": "2026-05-09T01:35:06.290910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20318,8 +20318,8 @@
           "description": "Minimum configuration for schemaDiscoveryType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaDiscoveryType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaDiscoveryType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_discovery_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20385,7 +20385,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.539145+00:00"
+                "validatedAt": "2026-05-09T01:35:06.291251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20439,7 +20439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.539217+00:00"
+                "validatedAt": "2026-05-09T01:35:06.291284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20507,7 +20507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.539281+00:00"
+                "validatedAt": "2026-05-09T01:35:06.291316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20566,7 +20566,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.539336+00:00"
+                "validatedAt": "2026-05-09T01:35:06.291343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20667,7 +20667,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.539977+00:00"
+                "validatedAt": "2026-05-09T01:35:06.291630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20738,7 +20738,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.540820+00:00"
+                "validatedAt": "2026-05-09T01:35:06.291997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20792,8 +20792,8 @@
           "description": "Minimum configuration for schemaVirtualNetworkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_virtual_network_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20841,7 +20841,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541043+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292104+00:00"
               },
               "deterministic": true
             },
@@ -20906,7 +20906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541129+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20946,7 +20946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541171+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292171+00:00"
               },
               "deterministic": true
             },
@@ -20977,7 +20977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.541218+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21061,7 +21061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541304+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292233+00:00"
               },
               "deterministic": true
             },
@@ -21126,7 +21126,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541390+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21166,7 +21166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541430+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292290+00:00"
               },
               "deterministic": true
             },
@@ -21197,7 +21197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.541477+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21281,7 +21281,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541563+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292352+00:00"
               },
               "deterministic": true
             },
@@ -21346,7 +21346,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541666+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21386,7 +21386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541706+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292411+00:00"
               },
               "deterministic": true
             },
@@ -21417,7 +21417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:11.541753+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21509,7 +21509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541836+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292472+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21525,7 +21525,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.395216+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.920303+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21562,7 +21562,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541901+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292505+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21578,7 +21578,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.395247+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.920319+00:00"
           },
           "tenant": {
             "type": "string",
@@ -21607,7 +21607,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.541972+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21621,7 +21621,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.395276+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.920349+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -21678,7 +21678,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:11.542035+00:00"
+                "validatedAt": "2026-05-09T01:35:06.292573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21761,8 +21761,8 @@
           "description": "Minimum configuration for k8s_manifest_paramsDeployStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for k8s_manifest_paramsDeployStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for k8s_manifest_paramsDeployStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/k8s_manifest_params_deploy_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -21788,8 +21788,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nfv_serviceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nfv_serviceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nfv_services\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -21872,7 +21872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.267248+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382248+00:00"
               },
               "deterministic": true
             },
@@ -21885,7 +21885,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.373241+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247235+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21915,7 +21915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.267286+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382300+00:00"
               },
               "deterministic": true
             },
@@ -21928,7 +21928,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.373272+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247250+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22055,7 +22055,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.267427+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22258,7 +22258,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.267577+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22308,7 +22308,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.267671+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22348,7 +22348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.267751+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22441,7 +22441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.267800+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382542+00:00"
               },
               "deterministic": true
             },
@@ -22454,7 +22454,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.373682+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247454+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22479,8 +22479,8 @@
           "description": "Minimum configuration for nfv_serviceForceDeleteNFVServiceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nfv_serviceForceDeleteNFVServiceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nfv_serviceForceDeleteNFVServiceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nfv_service_forces\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -22497,8 +22497,8 @@
           "description": "Minimum configuration for nfv_serviceForwardingServiceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nfv_serviceForwardingServiceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nfv_serviceForwardingServiceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nfv_service_forwarding_service_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -22589,7 +22589,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.373789+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247511+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22657,7 +22657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:32.267943+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22720,7 +22720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:32.268011+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22732,7 +22732,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.373869+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247551+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22798,7 +22798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.268062+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382660+00:00"
               },
               "deterministic": true
             },
@@ -22811,7 +22811,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.373939+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247587+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22840,7 +22840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.268098+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382700+00:00"
               },
               "deterministic": true
             },
@@ -22853,7 +22853,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.373970+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247602+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -22892,7 +22892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.268164+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22905,7 +22905,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.374029+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247633+00:00"
           },
           "uid": {
             "type": "string",
@@ -22922,7 +22922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.268200+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22936,7 +22936,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.374061+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247649+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nfv_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23027,8 +23027,8 @@
           "description": "Minimum configuration for nfv_serviceMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nfv_serviceMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nfv_serviceMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nfv_service_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -23063,7 +23063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.268275+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23108,7 +23108,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.268341+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23135,7 +23135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.268387+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23188,7 +23188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.268442+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382876+00:00"
               },
               "deterministic": true
             },
@@ -23201,7 +23201,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.374168+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247702+00:00"
           },
           "start_time": {
             "type": "string",
@@ -23226,7 +23226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.268494+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23259,7 +23259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.268536+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23336,7 +23336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.268608+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23382,7 +23382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.268663+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23406,7 +23406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.268713+00:00"
+                "validatedAt": "2026-05-09T01:37:03.382990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23467,7 +23467,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.268803+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23533,7 +23533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.268870+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23601,8 +23601,8 @@
           "description": "Minimum configuration for nfv_servicePaloAltoFWAWSInstanceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nfv_servicePaloAltoFWAWSInstanceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nfv_servicePaloAltoFWAWSInstanceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nfv_service_palo_alto_f_w_a_w_s_instance_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -23716,7 +23716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.268987+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23776,7 +23776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.269041+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23788,7 +23788,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.374423+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.247831+00:00"
           }
         },
         "x-f5xc-description-short": "Palo Alto Networks VM-Series next-generation firewall configuration.",
@@ -23850,7 +23850,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269138+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23896,7 +23896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269227+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23958,7 +23958,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269320+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23995,7 +23995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269392+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24027,7 +24027,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269476+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24074,8 +24074,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nfv_serviceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nfv_serviceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nfv_service_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -24087,8 +24087,8 @@
           "description": "Minimum configuration for nfv_serviceReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for nfv_serviceReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for nfv_serviceReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/nfv_service_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -24141,7 +24141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269595+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383439+00:00"
               },
               "deterministic": true
             },
@@ -24207,7 +24207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269679+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24302,7 +24302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269795+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24339,7 +24339,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269855+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24425,7 +24425,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.269963+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24521,7 +24521,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.270084+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24567,7 +24567,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.270169+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24602,7 +24602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.270226+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24675,7 +24675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.270301+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24719,7 +24719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.270377+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24742,7 +24742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.270411+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24798,7 +24798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.270558+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24836,7 +24836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.270648+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24848,7 +24848,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.374956+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.248095+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -24867,7 +24867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.270701+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24918,7 +24918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.270747+00:00"
+                "validatedAt": "2026-05-09T01:37:03.383985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24930,7 +24930,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.374998+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.248116+00:00"
           },
           "url": {
             "type": "string",
@@ -24968,7 +24968,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.270826+00:00"
+                "validatedAt": "2026-05-09T01:37:03.384026+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -25015,8 +25015,8 @@
           "description": "Minimum configuration for schemaHashAlgorithm",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHashAlgorithm\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_hash_algorithms\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25062,7 +25062,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.271221+00:00"
+                "validatedAt": "2026-05-09T01:37:03.384223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25126,7 +25126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.271339+00:00"
+                "validatedAt": "2026-05-09T01:37:03.384278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25138,7 +25138,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.375263+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.248256+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -25195,7 +25195,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.271967+00:00"
+                "validatedAt": "2026-05-09T01:37:03.384584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25233,8 +25233,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25313,7 +25313,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.272856+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25345,7 +25345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:32.272919+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25357,7 +25357,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.376088+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.248667+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -25406,8 +25406,8 @@
           "description": "Minimum configuration for schemaTlsProtocol",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tls_protocols\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25429,8 +25429,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25462,7 +25462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:32.272990+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25474,7 +25474,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.376152+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.248699+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -25492,7 +25492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.273040+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25520,7 +25520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.273087+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25532,7 +25532,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.376201+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.248731+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -25593,8 +25593,8 @@
           "description": "Minimum configuration for schemaUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25620,8 +25620,8 @@
           "description": "Minimum configuration for schemaXfccElement",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaXfccElement\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_xfcc_elements\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25778,8 +25778,8 @@
           "description": "Minimum configuration for schemanfv_serviceMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemanfv_serviceMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemanfv_serviceMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemanfv_service_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -25807,7 +25807,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.376515+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.248893+00:00"
           },
           "value": {
             "type": "array",
@@ -25826,7 +25826,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.376548+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.248910+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -25910,8 +25910,8 @@
           "description": "Minimum configuration for terraform_parametersApplyStageState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersApplyStageState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersApplyStageState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_apply_stage_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25937,7 +25937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.273628+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25965,7 +25965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.273688+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25995,7 +25995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.273750+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26021,7 +26021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.273803+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26047,7 +26047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.273850+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26070,7 +26070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.273897+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26117,8 +26117,8 @@
           "description": "Minimum configuration for terraform_parametersDestroyStageState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersDestroyStageState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersDestroyStageState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_destroy_stage_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -26139,8 +26139,8 @@
           "description": "Minimum configuration for terraform_parametersInfraState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for terraform_parametersInfraState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for terraform_parametersInfraState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/terraform_parameters_infra_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -26207,7 +26207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.273949+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26265,7 +26265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.274053+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26334,7 +26334,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.274121+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26409,7 +26409,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.274197+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26507,7 +26507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:32.274311+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26652,7 +26652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:32.274414+00:00"
+                "validatedAt": "2026-05-09T01:37:03.385755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26733,7 +26733,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:21.177879+00:00"
+                "validatedAt": "2026-05-09T01:39:12.518619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26862,7 +26862,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:21.178922+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26940,7 +26940,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:21.179000+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27018,7 +27018,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:21.179076+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27068,8 +27068,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for site_mesh_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for site_mesh_groupCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_mesh_groups\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -27152,7 +27152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:21.179349+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519364+00:00"
               },
               "deterministic": true
             },
@@ -27165,7 +27165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.879200+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.289358+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27195,7 +27195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:21.179386+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519382+00:00"
               },
               "deterministic": true
             },
@@ -27208,7 +27208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.879229+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.289374+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27339,7 +27339,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.879346+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.289436+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -27435,7 +27435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:25:21.179538+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27498,7 +27498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:25:21.179621+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27510,7 +27510,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.879442+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.289486+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27576,7 +27576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:21.179672+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519544+00:00"
               },
               "deterministic": true
             },
@@ -27589,7 +27589,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.879511+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.289523+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27618,7 +27618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:21.179709+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519563+00:00"
               },
               "deterministic": true
             },
@@ -27631,7 +27631,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.879540+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.289538+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27670,7 +27670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:21.179773+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27683,7 +27683,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.879630+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.289568+00:00"
           },
           "uid": {
             "type": "string",
@@ -27700,7 +27700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:21.179806+00:00"
+                "validatedAt": "2026-05-09T01:39:12.519606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27714,7 +27714,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.879664+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.289584+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of site_mesh_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27764,8 +27764,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for site_mesh_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for site_mesh_groupReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_mesh_group_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -27777,8 +27777,8 @@
           "description": "Minimum configuration for site_mesh_groupReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for site_mesh_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for site_mesh_groupReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_mesh_group_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -28021,7 +28021,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:29.466121+00:00"
+                "validatedAt": "2026-05-09T01:40:11.336998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28106,7 +28106,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.664626+00:00"
+                "validatedAt": "2026-05-09T01:40:33.657947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28131,7 +28131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.664675+00:00"
+                "validatedAt": "2026-05-09T01:40:33.657965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28188,7 +28188,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.664737+00:00"
+                "validatedAt": "2026-05-09T01:40:33.657994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28232,8 +28232,8 @@
           "description": "Minimum configuration for schemaRouteAttrType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaRouteAttrType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaRouteAttrType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_route_attr_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -28304,7 +28304,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.538364+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.979574+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Route Target\" BGP Two-Octet AS Specific Route Target as per RFC 4360.",
@@ -28357,7 +28357,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.538404+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.979595+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Four-Octet AS Specific Route Target\" BGP Four-Octet AS Specific Route Target as per RFC 5668.",
@@ -28394,7 +28394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.665440+00:00"
+                "validatedAt": "2026-05-09T01:40:33.658311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28421,7 +28421,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.538446+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.979617+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"IPv4 Address Specific Route Target\" BGP IPv4 Address Specific Route Target as per RFC 4360.",
@@ -28482,8 +28482,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_networks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -28563,7 +28563,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.666821+00:00"
+                "validatedAt": "2026-05-09T01:40:33.658913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28641,7 +28641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.666866+00:00"
+                "validatedAt": "2026-05-09T01:40:33.658941+00:00"
               },
               "deterministic": true
             },
@@ -28654,7 +28654,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539245+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980029+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28684,7 +28684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.666904+00:00"
+                "validatedAt": "2026-05-09T01:40:33.658960+00:00"
               },
               "deterministic": true
             },
@@ -28697,7 +28697,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980045+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28800,7 +28800,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539371+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980097+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -28873,7 +28873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667069+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28910,7 +28910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667132+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28981,7 +28981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:28:20.667189+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29044,7 +29044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:28:20.667258+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29056,7 +29056,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539504+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980174+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -29122,7 +29122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667312+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659141+00:00"
               },
               "deterministic": true
             },
@@ -29135,7 +29135,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539574+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980211+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29164,7 +29164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667349+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659166+00:00"
               },
               "deterministic": true
             },
@@ -29177,7 +29177,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539626+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980227+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -29216,7 +29216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667417+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29229,7 +29229,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539686+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980257+00:00"
           },
           "uid": {
             "type": "string",
@@ -29246,7 +29246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667452+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29260,7 +29260,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539717+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980273+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_network is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -29310,8 +29310,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_network_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -29323,8 +29323,8 @@
           "description": "Minimum configuration for virtual_networkReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_network_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -29376,7 +29376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667544+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29466,8 +29466,8 @@
           "description": "Minimum configuration for virtual_networkSIDCounterLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkSIDCounterLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkSIDCounterLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_network_s_i_d_counter_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -29502,7 +29502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667637+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29547,7 +29547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667707+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29574,7 +29574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667752+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29627,7 +29627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.667807+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659357+00:00"
               },
               "deterministic": true
             },
@@ -29640,7 +29640,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539893+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980365+00:00"
           },
           "range": {
             "type": "string",
@@ -29665,7 +29665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667852+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29698,7 +29698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667903+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29731,7 +29731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.667946+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29807,7 +29807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:20.668003+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29849,8 +29849,8 @@
           "description": "Minimum configuration for virtual_networkSIDCounterType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_networkSIDCounterType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_networkSIDCounterType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_network_s_i_d_counter_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -29878,7 +29878,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.539979+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980409+00:00"
           },
           "value": {
             "type": "array",
@@ -29897,7 +29897,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.540011+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980426+00:00"
           }
         },
         "x-f5xc-description-short": "SID Counter Type Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -29999,7 +29999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668077+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659475+00:00"
               },
               "deterministic": true
             },
@@ -30012,7 +30012,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:53.540072+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.980456+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Srv6 Network Namespace Parameters\" Configure the how namespace network is connected to srv6 network.",
@@ -30064,7 +30064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668138+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30103,7 +30103,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668220+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659542+00:00"
               },
               "deterministic": true
             },
@@ -30156,7 +30156,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668289+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30222,7 +30222,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668352+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30261,7 +30261,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668431+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659643+00:00"
               },
               "deterministic": true
             },
@@ -30314,7 +30314,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:20.668496+00:00"
+                "validatedAt": "2026-05-09T01:40:33.659673+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/statistics.json
+++ b/docs/specifications/api/statistics.json
@@ -19819,8 +19819,8 @@
           "description": "Minimum configuration for alert_policyAlertName",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_policyAlertName\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_policyAlertName\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_policy_alert_names\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -19846,7 +19846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.219464+00:00"
+                "validatedAt": "2026-05-09T01:32:01.674904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19941,7 +19941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.219622+00:00"
+                "validatedAt": "2026-05-09T01:32:01.674946+00:00"
               },
               "deterministic": true
             },
@@ -19954,7 +19954,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.527658+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.216645+00:00"
           }
         },
         "x-f5xc-description-short": "Request message for GetAlertPolicyMatch RPC, describing alert to match against alert policies.",
@@ -20024,8 +20024,8 @@
           "description": "Minimum configuration for alert_policyAlertPolicyStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_policyAlertPolicyStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_policyAlertPolicyStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_policy_alert_policy_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -20051,8 +20051,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_policyCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_policies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -20121,7 +20121,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.219829+00:00"
+                "validatedAt": "2026-05-09T01:32:01.674999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20158,7 +20158,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.219895+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20221,7 +20221,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.219962+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20354,7 +20354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.220034+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675131+00:00"
               },
               "deterministic": true
             },
@@ -20367,7 +20367,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.527859+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.216748+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20397,7 +20397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.220073+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675150+00:00"
               },
               "deterministic": true
             },
@@ -20410,7 +20410,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.527890+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.216764+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20513,7 +20513,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.527990+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.216817+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -20575,7 +20575,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.220229+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20612,7 +20612,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.220287+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20668,8 +20668,8 @@
           "description": "Minimum configuration for alert_policyGroup",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_policyGroup\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_policyGroup\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_policy_groups\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -20736,7 +20736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.220363+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20765,7 +20765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.220414+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20834,7 +20834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:14.220471+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20897,7 +20897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:14.220539+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20909,7 +20909,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528136+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.216891+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20975,7 +20975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.220616+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675380+00:00"
               },
               "deterministic": true
             },
@@ -20988,7 +20988,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528207+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.216928+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21017,7 +21017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.220657+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675397+00:00"
               },
               "deterministic": true
             },
@@ -21030,7 +21030,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528236+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.216945+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21069,7 +21069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.220726+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21082,7 +21082,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528294+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.216978+00:00"
           },
           "uid": {
             "type": "string",
@@ -21099,7 +21099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.220759+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21113,7 +21113,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528326+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.216994+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of alert_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21183,7 +21183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.220829+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21220,7 +21220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.220880+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21260,7 +21260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.220938+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21315,8 +21315,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_policyReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_policy_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -21328,8 +21328,8 @@
           "description": "Minimum configuration for alert_policyReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_policyReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_policy_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -21370,7 +21370,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.221017+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21407,7 +21407,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.221075+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21460,7 +21460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.221134+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21537,8 +21537,8 @@
           "description": "Minimum configuration for alert_policySeverity",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_policySeverity\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_policySeverity\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_policy_severities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -21646,8 +21646,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21669,7 +21669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.221256+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21692,7 +21692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.221299+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21704,7 +21704,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528670+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217171+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -21750,7 +21750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:09:14.221345+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675689+00:00"
               },
               "deterministic": true
             },
@@ -21776,7 +21776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.221399+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21802,7 +21802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.221443+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21814,7 +21814,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528727+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217199+00:00"
           },
           "service_name": {
             "type": "string",
@@ -21831,7 +21831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.221494+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21864,7 +21864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.221541+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21876,7 +21876,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528768+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217221+00:00"
           },
           "type": {
             "type": "string",
@@ -21901,7 +21901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.221597+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675788+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21955,8 +21955,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21989,7 +21989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.221651+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22051,7 +22051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.221692+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675826+00:00"
               },
               "deterministic": true
             },
@@ -22064,7 +22064,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528842+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217262+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -22182,7 +22182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.221819+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675881+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -22198,7 +22198,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528909+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217299+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -22268,7 +22268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.221870+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675902+00:00"
               },
               "deterministic": true
             },
@@ -22281,7 +22281,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528960+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217330+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22312,7 +22312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.221906+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675918+00:00"
               },
               "deterministic": true
             },
@@ -22325,7 +22325,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.528990+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217348+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -22407,7 +22407,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.222007+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675963+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -22423,7 +22423,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529034+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217371+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -22495,7 +22495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.222056+00:00"
+                "validatedAt": "2026-05-09T01:32:01.675984+00:00"
               },
               "deterministic": true
             },
@@ -22508,7 +22508,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529085+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217398+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22539,7 +22539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.222092+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676000+00:00"
               },
               "deterministic": true
             },
@@ -22552,7 +22552,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529114+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217414+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -22597,7 +22597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222131+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22610,7 +22610,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529146+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217431+00:00"
           },
           "name": {
             "type": "string",
@@ -22643,7 +22643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.222167+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676032+00:00"
               },
               "deterministic": true
             },
@@ -22656,7 +22656,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529174+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217447+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22687,7 +22687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.222205+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676050+00:00"
               },
               "deterministic": true
             },
@@ -22700,7 +22700,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529203+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217462+00:00"
           },
           "tenant": {
             "type": "string",
@@ -22719,7 +22719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222249+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22733,7 +22733,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529232+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217478+00:00"
           },
           "uid": {
             "type": "string",
@@ -22752,7 +22752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222282+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22767,7 +22767,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529263+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217494+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -22849,7 +22849,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.222387+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676126+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -22865,7 +22865,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529306+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217517+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -22935,7 +22935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.222436+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676146+00:00"
               },
               "deterministic": true
             },
@@ -22948,7 +22948,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529356+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217543+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22979,7 +22979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.222473+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676168+00:00"
               },
               "deterministic": true
             },
@@ -22992,7 +22992,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529385+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217559+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -23037,7 +23037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222528+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23065,7 +23065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222578+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23093,7 +23093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222642+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23122,7 +23122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222693+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23149,7 +23149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222726+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23163,7 +23163,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529469+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217601+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -23179,7 +23179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222769+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23242,8 +23242,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -23288,7 +23288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222835+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23300,7 +23300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529531+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217634+00:00"
           },
           "status": {
             "type": "string",
@@ -23318,7 +23318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222878+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23330,7 +23330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529560+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217649+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -23372,7 +23372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222933+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23399,7 +23399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.222983+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23426,7 +23426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.223030+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23454,7 +23454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.223083+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23519,7 +23519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.223164+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23568,7 +23568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.223226+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23581,7 +23581,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529705+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217719+00:00"
           },
           "uid": {
             "type": "string",
@@ -23600,7 +23600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.223260+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23614,7 +23614,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529735+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217735+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -23664,7 +23664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.223300+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23676,7 +23676,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529767+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217751+00:00"
           },
           "name": {
             "type": "string",
@@ -23709,7 +23709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.223336+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676525+00:00"
               },
               "deterministic": true
             },
@@ -23722,7 +23722,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529796+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217767+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23753,7 +23753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:14.223373+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676542+00:00"
               },
               "deterministic": true
             },
@@ -23766,7 +23766,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529825+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217782+00:00"
           },
           "uid": {
             "type": "string",
@@ -23783,7 +23783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:14.223407+00:00"
+                "validatedAt": "2026-05-09T01:32:01.676557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23797,7 +23797,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.529855+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.217798+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -23869,7 +23869,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.615108+00:00"
+                "validatedAt": "2026-05-09T01:32:02.752695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23922,7 +23922,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.615190+00:00"
+                "validatedAt": "2026-05-09T01:32:02.752729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23981,7 +23981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.615240+00:00"
+                "validatedAt": "2026-05-09T01:32:02.752753+00:00"
               },
               "deterministic": true
             },
@@ -23994,7 +23994,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.578655+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.241651+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24031,7 +24031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.615286+00:00"
+                "validatedAt": "2026-05-09T01:32:02.752776+00:00"
               },
               "deterministic": true
             },
@@ -24044,7 +24044,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.578688+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.241668+00:00"
           },
           "verification_code": {
             "type": "string",
@@ -24067,7 +24067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:16.615349+00:00"
+                "validatedAt": "2026-05-09T01:32:02.752800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24104,8 +24104,8 @@
           "description": "Minimum configuration for alert_receiverConfirmAlertReceiverResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_receiverConfirmAlertReceiverResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_receiverConfirmAlertReceiverResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_receiver_confirm_alert_receiver_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -24131,8 +24131,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_receiverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_receiverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_receivers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -24259,7 +24259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.615440+00:00"
+                "validatedAt": "2026-05-09T01:32:02.752837+00:00"
               },
               "deterministic": true
             },
@@ -24272,7 +24272,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.578851+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.241754+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24302,7 +24302,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.615478+00:00"
+                "validatedAt": "2026-05-09T01:32:02.752854+00:00"
               },
               "deterministic": true
             },
@@ -24315,7 +24315,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.578881+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.241770+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24368,7 +24368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.615556+00:00"
+                "validatedAt": "2026-05-09T01:32:02.752892+00:00"
               },
               "deterministic": true
             },
@@ -24478,7 +24478,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.578991+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.241829+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -24663,7 +24663,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.615805+00:00"
+                "validatedAt": "2026-05-09T01:32:02.752983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24730,7 +24730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:16.615865+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24793,7 +24793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:16.615937+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24805,7 +24805,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579223+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.241953+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -24871,7 +24871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.615988+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753061+00:00"
               },
               "deterministic": true
             },
@@ -24884,7 +24884,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579292+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.241990+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24913,7 +24913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.616025+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753078+00:00"
               },
               "deterministic": true
             },
@@ -24926,7 +24926,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579322+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.242006+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -24965,7 +24965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:16.616092+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24978,7 +24978,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579379+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.242037+00:00"
           },
           "uid": {
             "type": "string",
@@ -24995,7 +24995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:16.616125+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25009,7 +25009,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579409+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.242053+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of alert_receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -25081,7 +25081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.616201+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753163+00:00"
               },
               "deterministic": true
             },
@@ -25150,7 +25150,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.616273+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753197+00:00"
               },
               "deterministic": true
             },
@@ -25197,8 +25197,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_receiverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_receiverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_receiver_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -25210,8 +25210,8 @@
           "description": "Minimum configuration for alert_receiverReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_receiverReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_receiverReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_receiver_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -25290,7 +25290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:16.616362+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25347,7 +25347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.616455+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25474,7 +25474,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.616575+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25548,7 +25548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.616640+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753349+00:00"
               },
               "deterministic": true
             },
@@ -25561,7 +25561,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579699+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.242206+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25598,7 +25598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.616682+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753367+00:00"
               },
               "deterministic": true
             },
@@ -25611,7 +25611,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579729+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.242223+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25639,8 +25639,8 @@
           "description": "Minimum configuration for alert_receiverTestAlertReceiverResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_receiverTestAlertReceiverResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_receiverTestAlertReceiverResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_receiver_test_alert_receiver_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -25704,7 +25704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.616725+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753386+00:00"
               },
               "deterministic": true
             },
@@ -25717,7 +25717,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579774+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.242246+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25754,7 +25754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.616765+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753404+00:00"
               },
               "deterministic": true
             },
@@ -25767,7 +25767,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579803+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.242262+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25795,8 +25795,8 @@
           "description": "Minimum configuration for alert_receiverVerifyAlertReceiverResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alert_receiverVerifyAlertReceiverResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alert_receiverVerifyAlertReceiverResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_receiver_verify_alert_receiver_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -25854,7 +25854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:16.616926+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25892,7 +25892,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.617000+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25904,7 +25904,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579910+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.242319+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -25923,7 +25923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:16.617053+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25974,7 +25974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:16.617100+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25986,7 +25986,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.579952+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.242341+00:00"
           },
           "url": {
             "type": "string",
@@ -26024,7 +26024,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:16.617176+00:00"
+                "validatedAt": "2026-05-09T01:32:02.753584+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -26068,8 +26068,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -26123,8 +26123,8 @@
           "description": "Minimum configuration for schemaTlsProtocol",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTlsProtocol\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tls_protocols\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -26173,7 +26173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736051+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26199,7 +26199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736147+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26238,7 +26238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:18.736224+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705097+00:00"
               },
               "deterministic": true
             },
@@ -26251,7 +26251,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.631793+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267127+00:00"
           },
           "start_time": {
             "type": "string",
@@ -26276,7 +26276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736311+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26343,7 +26343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736374+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26410,7 +26410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736446+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26439,7 +26439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736496+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26499,7 +26499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:18.736541+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705220+00:00"
               },
               "deterministic": true
             },
@@ -26512,7 +26512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.631895+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267186+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -26530,7 +26530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736612+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26600,7 +26600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736664+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26695,8 +26695,8 @@
           "description": "Minimum configuration for alertKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for alertKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for alertKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/alert_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -26788,7 +26788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736766+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26886,7 +26886,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632071+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267279+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -26922,7 +26922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736847+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26971,7 +26971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.736894+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27010,7 +27010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:09:18.736951+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705379+00:00"
               },
               "deterministic": true
             },
@@ -27077,7 +27077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737013+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27122,7 +27122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737056+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27145,7 +27145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737090+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27157,7 +27157,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632203+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267348+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -27250,7 +27250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737165+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27274,7 +27274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737198+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27286,7 +27286,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632289+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267394+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -27328,7 +27328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737245+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27352,7 +27352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737278+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27364,7 +27364,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632341+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267421+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -27402,7 +27402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737321+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27459,7 +27459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737368+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27483,7 +27483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737401+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27495,7 +27495,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632407+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267456+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -27545,7 +27545,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632449+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267479+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -27602,7 +27602,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632492+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267501+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -27638,7 +27638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737483+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27749,7 +27749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737556+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27815,7 +27815,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632622+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267565+00:00"
           },
           "value": {
             "type": "number",
@@ -27831,7 +27831,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632651+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267583+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -27868,7 +27868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737645+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27924,8 +27924,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -27953,7 +27953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:18.737727+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27965,7 +27965,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632707+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267612+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -27980,7 +27980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737779+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28006,7 +28006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:18.737826+00:00"
+                "validatedAt": "2026-05-09T01:32:03.705745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28018,7 +28018,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.632757+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.267639+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -28062,7 +28062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:28.142486+00:00"
+                "validatedAt": "2026-05-09T01:33:00.846748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28092,7 +28092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:28.142629+00:00"
+                "validatedAt": "2026-05-09T01:33:00.846782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28228,8 +28228,8 @@
           "description": "Minimum configuration for schemaAddonServiceAccess",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceAccess\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceAccess\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_accesses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28255,8 +28255,8 @@
           "description": "Minimum configuration for schemaAddonServiceGroupStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceGroupStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceGroupStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_group_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28278,8 +28278,8 @@
           "description": "Minimum configuration for schemaAddonServiceState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28302,8 +28302,8 @@
           "description": "Minimum configuration for schemaAddonServiceTierType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceTierType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceTierType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_tier_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28325,8 +28325,8 @@
           "description": "Minimum configuration for schemaFeatureTag",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaFeatureTag\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaFeatureTag\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_feature_tags\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28435,8 +28435,8 @@
           "description": "Minimum configuration for connectivityEdgeMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityEdgeMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityEdgeMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_edge_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28474,7 +28474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478405+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28515,7 +28515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.478478+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689488+00:00"
               },
               "deterministic": true
             },
@@ -28528,7 +28528,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103207+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.833746+00:00"
           },
           "range": {
             "type": "string",
@@ -28553,7 +28553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478530+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28589,7 +28589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478605+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28622,7 +28622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478651+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28687,7 +28687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478702+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28764,7 +28764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478753+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28809,8 +28809,8 @@
           "description": "Minimum configuration for connectivityIdField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityIdField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityIdField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_id_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28843,7 +28843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478814+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28855,7 +28855,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103366+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.833828+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the connectivity graph are tagged with labels listed in the enum Label.",
@@ -29006,7 +29006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478914+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29104,8 +29104,8 @@
           "description": "Minimum configuration for connectivityNodeInstanceMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityNodeInstanceMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityNodeInstanceMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_node_instance_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -29134,7 +29134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478978+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29175,7 +29175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479042+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29201,7 +29201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479092+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29282,8 +29282,8 @@
           "description": "Minimum configuration for connectivityNodeInterfaceMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityNodeInterfaceMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityNodeInterfaceMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_node_interface_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -29316,8 +29316,8 @@
           "description": "Minimum configuration for connectivityNodeMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityNodeMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityNodeMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_node_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -29352,7 +29352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479156+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29413,7 +29413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.479222+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689798+00:00"
               },
               "deterministic": true
             },
@@ -29426,7 +29426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103653+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.833977+00:00"
           },
           "range": {
             "type": "string",
@@ -29451,7 +29451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479267+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29484,7 +29484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479317+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29517,7 +29517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479359+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29582,7 +29582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479407+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29638,7 +29638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479457+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29712,7 +29712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.479530+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689932+00:00"
               },
               "deterministic": true
             },
@@ -29725,7 +29725,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103776+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834042+00:00"
           },
           "start_time": {
             "type": "string",
@@ -29750,7 +29750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479580+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29931,8 +29931,8 @@
           "description": "Minimum configuration for graphHealthscoreType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for graphHealthscoreType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for graphHealthscoreType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/graph_healthscore_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -29960,7 +29960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479705+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29972,7 +29972,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103863+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834088+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/graphHealthscoreType"
@@ -29994,7 +29994,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103904+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834109+00:00"
           }
         },
         "x-f5xc-description-short": "HealthScoreTypeData contains healthscore type and the corresponding value.",
@@ -30150,8 +30150,8 @@
           "description": "Minimum configuration for graphQueryOp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for graphQueryOp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for graphQueryOp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/graph_query_ops\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -30235,7 +30235,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.479907+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30280,8 +30280,8 @@
           "description": "Minimum configuration for graphconnectivityLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for graphconnectivityLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for graphconnectivityLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/graphconnectivity_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -30364,7 +30364,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.479997+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30397,7 +30397,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.480053+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30430,7 +30430,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.480109+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30498,8 +30498,8 @@
           "description": "Minimum configuration for schemaUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -30544,7 +30544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.480338+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30556,7 +30556,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.104223+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834291+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -30593,8 +30593,8 @@
           "description": "Minimum configuration for siteSiteType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteSiteType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteSiteType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_site_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -30619,8 +30619,8 @@
           "description": "Minimum configuration for timeseriesTimeseriesFeature",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for timeseriesTimeseriesFeature\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for timeseriesTimeseriesFeature\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/timeseries_timeseries_features\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -30659,7 +30659,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222309+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30693,7 +30693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222415+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30726,7 +30726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.222533+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30842,7 +30842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222639+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166666+00:00"
               },
               "deterministic": true
             },
@@ -30855,7 +30855,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.203937+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829244+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30892,7 +30892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222684+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166685+00:00"
               },
               "deterministic": true
             },
@@ -30905,7 +30905,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.203970+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829261+00:00"
           },
           "tcp_lb_request": {
             "$ref": "#/components/schemas/discovered_serviceTCPLBRequest"
@@ -30992,7 +30992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222738+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166709+00:00"
               },
               "deterministic": true
             },
@@ -31005,7 +31005,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204026+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829296+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31042,7 +31042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222778+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166726+00:00"
               },
               "deterministic": true
             },
@@ -31055,7 +31055,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204056+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829312+00:00"
           }
         },
         "x-f5xc-description-short": "Disable visibility on the discovered service.",
@@ -31083,8 +31083,8 @@
           "description": "Minimum configuration for discovered_serviceDisableVisibilityResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discovered_serviceDisableVisibilityResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discovered_serviceDisableVisibilityResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovered_service_disable_visibility_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -31114,7 +31114,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204090+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829330+00:00"
           },
           "virtual_server_pool_members_health": {
             "$ref": "#/components/schemas/discovered_serviceVirtualServerPoolMemberHealth"
@@ -31178,7 +31178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222840+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166753+00:00"
               },
               "deterministic": true
             },
@@ -31191,7 +31191,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204134+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829352+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31228,7 +31228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222879+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166771+00:00"
               },
               "deterministic": true
             },
@@ -31241,7 +31241,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204163+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829368+00:00"
           }
         },
         "x-f5xc-description-short": "Enable visibility of the discovered service in all workspaces like WAAP, App Connect, etc.",
@@ -31401,7 +31401,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223031+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31414,7 +31414,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204271+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829424+00:00"
           },
           "http": {
             "$ref": "#/components/schemas/discovered_serviceProxyTypeHttp"
@@ -31463,7 +31463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223086+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166859+00:00"
               },
               "deterministic": true
             },
@@ -31476,7 +31476,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204330+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829456+00:00"
           },
           "skip_server_verification": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -31537,7 +31537,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223157+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31571,7 +31571,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223212+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31604,7 +31604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223268+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31672,7 +31672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:02.223324+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31735,7 +31735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:02.223394+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31747,7 +31747,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204458+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829526+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -31813,7 +31813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223447+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167016+00:00"
               },
               "deterministic": true
             },
@@ -31826,7 +31826,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204529+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829564+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31855,7 +31855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223486+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167033+00:00"
               },
               "deterministic": true
             },
@@ -31868,7 +31868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204558+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829579+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -31891,7 +31891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223538+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31904,7 +31904,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204623+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829605+00:00"
           },
           "uid": {
             "type": "string",
@@ -31922,7 +31922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223571+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31936,7 +31936,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204655+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829621+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -32006,7 +32006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:02.223643+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32070,7 +32070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:02.223710+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32082,7 +32082,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204722+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829656+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -32148,7 +32148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223761+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167149+00:00"
               },
               "deterministic": true
             },
@@ -32161,7 +32161,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204792+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829693+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32190,7 +32190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223798+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167176+00:00"
               },
               "deterministic": true
             },
@@ -32203,7 +32203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204822+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829708+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -32242,7 +32242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223866+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32255,7 +32255,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204880+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829739+00:00"
           },
           "uid": {
             "type": "string",
@@ -32273,7 +32273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223903+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32287,7 +32287,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204910+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829755+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered services is returned in 'List'.",
@@ -32349,7 +32349,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223979+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167258+00:00"
               },
               "deterministic": true
             },
@@ -32391,7 +32391,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224068+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32417,7 +32417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.224126+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32461,7 +32461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224175+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167344+00:00"
               },
               "deterministic": true
             },
@@ -32502,7 +32502,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224259+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32599,7 +32599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224339+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32702,7 +32702,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224447+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32736,7 +32736,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224530+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32774,7 +32774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224568+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167522+00:00"
               },
               "deterministic": true
             },
@@ -32787,7 +32787,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205118+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829863+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -32851,7 +32851,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224669+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32864,7 +32864,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205178+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829895+00:00"
           },
           "listen_port": {
             "type": "integer",
@@ -32929,7 +32929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224734+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167589+00:00"
               },
               "deterministic": true
             },
@@ -32942,7 +32942,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205218+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829916+00:00"
           },
           "no_sni": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -32979,7 +32979,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224823+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33071,7 +33071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224917+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33105,7 +33105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224997+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33149,7 +33149,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225080+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167746+00:00"
               },
               "deterministic": true
             },
@@ -33184,7 +33184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225159+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33222,7 +33222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225197+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167799+00:00"
               },
               "deterministic": true
             },
@@ -33254,7 +33254,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225278+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33288,7 +33288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225361+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33338,8 +33338,8 @@
           "description": "Minimum configuration for discovered_serviceVirtualServerEnabledState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discovered_serviceVirtualServerEnabledState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discovered_serviceVirtualServerEnabledState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovered_service_virtual_server_enabled_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -33381,7 +33381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225400+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167889+00:00"
               },
               "deterministic": true
             },
@@ -33394,7 +33394,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205390+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830007+00:00"
           },
           "status": {
             "type": "array",
@@ -33414,7 +33414,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205419+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830022+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33488,8 +33488,8 @@
           "description": "Minimum configuration for discovered_serviceVirtualServerStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discovered_serviceVirtualServerStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discovered_serviceVirtualServerStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovered_service_virtual_server_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -33516,7 +33516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225471+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33541,7 +33541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225517+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33604,7 +33604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225558+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167955+00:00"
               },
               "deterministic": true
             },
@@ -33638,7 +33638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225620+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33716,7 +33716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225685+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33729,7 +33729,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205519+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830074+00:00"
           },
           "name": {
             "type": "string",
@@ -33762,7 +33762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225722+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168018+00:00"
               },
               "deterministic": true
             },
@@ -33775,7 +33775,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205549+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830090+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33806,7 +33806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225759+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168034+00:00"
               },
               "deterministic": true
             },
@@ -33819,7 +33819,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830106+00:00"
           },
           "tenant": {
             "type": "string",
@@ -33838,7 +33838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225804+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33852,7 +33852,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205620+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830121+00:00"
           },
           "uid": {
             "type": "string",
@@ -33871,7 +33871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225837+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33886,7 +33886,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205651+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830138+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -33947,7 +33947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226382+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33959,7 +33959,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205929+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830290+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -34083,7 +34083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:02.227784+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34132,7 +34132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:02.227845+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34144,7 +34144,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206732+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830741+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -34162,7 +34162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227899+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34224,7 +34224,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.227962+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34282,7 +34282,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228023+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34356,7 +34356,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228098+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169031+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -34372,7 +34372,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206806+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830780+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34409,7 +34409,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228164+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169062+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -34425,7 +34425,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206836+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830796+00:00"
           },
           "tenant": {
             "type": "string",
@@ -34454,7 +34454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228235+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34468,7 +34468,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206866+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830812+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -34519,7 +34519,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228298+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34623,7 +34623,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228382+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34694,8 +34694,8 @@
           "description": "Minimum configuration for viewsSiteNetwork",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_networks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -34717,8 +34717,8 @@
           "description": "Minimum configuration for viewsSiteNetworkSpecifiedVIP",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_network_specified_v_i_ps\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -34763,7 +34763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228432+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169189+00:00"
               },
               "deterministic": true
             },
@@ -34810,7 +34810,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228517+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34933,7 +34933,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228650+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34968,7 +34968,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228731+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35033,7 +35033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228795+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35146,7 +35146,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.492146+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.424645+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -35194,7 +35194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:07.911410+00:00"
+                "validatedAt": "2026-05-09T01:35:31.381181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35264,7 +35264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:17:07.911549+00:00"
+                "validatedAt": "2026-05-09T01:35:31.381219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35327,7 +35327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:17:07.911665+00:00"
+                "validatedAt": "2026-05-09T01:35:31.381262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35339,7 +35339,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.492250+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.424698+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35405,7 +35405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:07.911722+00:00"
+                "validatedAt": "2026-05-09T01:35:31.381286+00:00"
               },
               "deterministic": true
             },
@@ -35418,7 +35418,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.492320+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.424734+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35447,7 +35447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:07.911760+00:00"
+                "validatedAt": "2026-05-09T01:35:31.381304+00:00"
               },
               "deterministic": true
             },
@@ -35460,7 +35460,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.492350+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.424750+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -35499,7 +35499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:07.911831+00:00"
+                "validatedAt": "2026-05-09T01:35:31.381332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35512,7 +35512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.492410+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.424781+00:00"
           },
           "uid": {
             "type": "string",
@@ -35529,7 +35529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:07.911866+00:00"
+                "validatedAt": "2026-05-09T01:35:31.381347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35543,7 +35543,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.492441+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.424797+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of flow_anomaly is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -35683,7 +35683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.926183+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35711,7 +35711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.926298+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35770,7 +35770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.926459+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35830,7 +35830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.926564+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35903,7 +35903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.926682+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36012,7 +36012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.926776+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36083,7 +36083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.926852+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36167,7 +36167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.926923+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36219,7 +36219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.926991+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36263,7 +36263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:13.927038+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077844+00:00"
               },
               "deterministic": true
             },
@@ -36276,7 +36276,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.572517+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.462231+00:00"
           },
           "node": {
             "type": "string",
@@ -36305,7 +36305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:13.927122+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36332,7 +36332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.927158+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36402,7 +36402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.927230+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36427,7 +36427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.927263+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36475,7 +36475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:13.927315+00:00"
+                "validatedAt": "2026-05-09T01:35:34.077967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36566,8 +36566,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -36600,8 +36600,8 @@
           "description": "Minimum configuration for schemaVirtualNetworkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_virtual_network_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -36627,7 +36627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448311+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36654,7 +36654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448393+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36699,7 +36699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448477+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36726,7 +36726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448527+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36767,7 +36767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448602+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36792,7 +36792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448668+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36840,8 +36840,8 @@
           "description": "Minimum configuration for flowAnomalyLevel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowAnomalyLevel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowAnomalyLevel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_anomaly_levels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -36884,7 +36884,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.651115+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.497172+00:00"
           }
         },
         "x-f5xc-description-short": "Field Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -36924,8 +36924,8 @@
           "description": "Minimum configuration for flowFieldSelector",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowFieldSelector\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowFieldSelector\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_field_selectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -37056,8 +37056,8 @@
           "description": "Minimum configuration for flowSortDirection",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowSortDirection\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowSortDirection\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_sort_directions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -37082,8 +37082,8 @@
           "description": "Minimum configuration for flowSortLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowSortLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowSortLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_sort_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -37137,7 +37137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448825+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37165,7 +37165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448879+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37215,7 +37215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448948+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37246,7 +37246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449006+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37305,7 +37305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449067+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37349,7 +37349,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:18.449142+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37383,7 +37383,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:18.449220+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37419,7 +37419,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:18.449280+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37454,7 +37454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:17:18.449332+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37504,7 +37504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449402+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37597,7 +37597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449474+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37641,7 +37641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:18.449543+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37668,7 +37668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449602+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37719,7 +37719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:17:18.449668+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37769,7 +37769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449736+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37869,8 +37869,8 @@
           "description": "Minimum configuration for flowUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -37910,8 +37910,8 @@
           "description": "Minimum configuration for schemaflowLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaflowLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaflowLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaflow_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -37934,8 +37934,8 @@
           "description": "Minimum configuration for schemaflowServiceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaflowServiceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaflowServiceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaflow_service_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -37974,7 +37974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.571406+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38023,7 +38023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.571662+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38067,7 +38067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.571804+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38168,7 +38168,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.571930+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38242,7 +38242,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.572033+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38294,7 +38294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.572128+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522428+00:00"
               },
               "deterministic": true
             },
@@ -38306,7 +38306,7 @@
             },
             "x-original-maxLength": 63,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.035097+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672116+00:00"
           }
         },
         "x-f5xc-description-short": "Azure Event Hubs Configuration for Global Log Receiver.",
@@ -38422,7 +38422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.572244+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38510,8 +38510,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for global_log_receiverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for global_log_receiverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/global_log_receivers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -38680,7 +38680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:17:39.572402+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522540+00:00"
               },
               "deterministic": true
             },
@@ -38719,7 +38719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.572449+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38804,7 +38804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.572502+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522584+00:00"
               },
               "deterministic": true
             },
@@ -38817,7 +38817,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.035536+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672351+00:00"
           },
           "namespace": {
             "type": "string",
@@ -38847,7 +38847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.572539+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522601+00:00"
               },
               "deterministic": true
             },
@@ -38860,7 +38860,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.035569+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672368+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38910,7 +38910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.572661+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38989,7 +38989,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.572771+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39112,7 +39112,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.035774+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672463+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -39317,7 +39317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.573011+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39368,7 +39368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.573094+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39413,7 +39413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.573141+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522853+00:00"
               },
               "deterministic": true
             },
@@ -39426,7 +39426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.036598+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672747+00:00"
           },
           "start_time": {
             "type": "string",
@@ -39451,7 +39451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.573193+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39484,7 +39484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.573237+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39558,7 +39558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.573297+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39636,7 +39636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.573381+00:00"
+                "validatedAt": "2026-05-09T01:35:45.522960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39701,7 +39701,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.573469+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39778,7 +39778,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.573542+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39824,7 +39824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.573662+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39887,7 +39887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.573719+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39899,7 +39899,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.036856+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672879+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the global log receiver are tagged with labels listed in the enum Label.",
@@ -39960,7 +39960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:17:39.573776+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40023,7 +40023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:17:39.573846+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40035,7 +40035,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.036924+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672914+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -40101,7 +40101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.573899+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523196+00:00"
               },
               "deterministic": true
             },
@@ -40114,7 +40114,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.036995+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672951+00:00"
           },
           "namespace": {
             "type": "string",
@@ -40143,7 +40143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.573935+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523213+00:00"
               },
               "deterministic": true
             },
@@ -40156,7 +40156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.037025+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672967+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -40195,7 +40195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.574000+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40208,7 +40208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.037082+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.672997+00:00"
           },
           "uid": {
             "type": "string",
@@ -40226,7 +40226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.574034+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40240,7 +40240,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.037114+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.673013+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of global_log_receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -40305,7 +40305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.574097+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40405,7 +40405,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.574185+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40456,8 +40456,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for global_log_receiverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for global_log_receiverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/global_log_receiver_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -40469,8 +40469,8 @@
           "description": "Minimum configuration for global_log_receiverReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for global_log_receiverReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for global_log_receiverReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/global_log_receiver_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -40608,7 +40608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:39.574318+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40653,7 +40653,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.574419+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40729,7 +40729,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.574506+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523469+00:00"
               },
               "deterministic": true
             },
@@ -40787,8 +40787,8 @@
           "description": "Minimum configuration for global_log_receiverStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for global_log_receiverStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for global_log_receiverStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/global_log_receiver_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -40952,7 +40952,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.574697+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523546+00:00"
               },
               "deterministic": true
             },
@@ -41043,7 +41043,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.574812+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41113,7 +41113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.574851+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523621+00:00"
               },
               "deterministic": true
             },
@@ -41126,7 +41126,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.037733+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.673350+00:00"
           },
           "namespace": {
             "type": "string",
@@ -41163,7 +41163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:39.574891+00:00"
+                "validatedAt": "2026-05-09T01:35:45.523640+00:00"
               },
               "deterministic": true
             },
@@ -41176,7 +41176,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.037764+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.673366+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41204,8 +41204,8 @@
           "description": "Minimum configuration for global_log_receiverTestGlobalLogReceiverResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for global_log_receiverTestGlobalLogReceiverResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for global_log_receiverTestGlobalLogReceiverResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/global_log_receiver_test_global_log_receiver_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -41226,8 +41226,8 @@
           "description": "Minimum configuration for schemaMetricLabelOp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaMetricLabelOp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaMetricLabelOp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_metric_label_ops\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "label"
@@ -41249,8 +41249,8 @@
           "description": "Minimum configuration for schemaglobal_log_receiverLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaglobal_log_receiverLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaglobal_log_receiverLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaglobal_log_receiver_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -41274,8 +41274,8 @@
           "description": "Minimum configuration for global_log_receiverTestConnectionStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for global_log_receiverTestConnectionStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for global_log_receiverTestConnectionStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/global_log_receiver_test_connection_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -41301,8 +41301,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for log_receiverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for log_receiverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/log_receivers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -41414,7 +41414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.629760+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275564+00:00"
               },
               "deterministic": true
             },
@@ -41427,7 +41427,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.472864+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.826857+00:00"
           },
           "namespace": {
             "type": "string",
@@ -41457,7 +41457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.629802+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275582+00:00"
               },
               "deterministic": true
             },
@@ -41470,7 +41470,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.472893+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.826873+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41573,7 +41573,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.472991+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.826926+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -41651,7 +41651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.629942+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275641+00:00"
               },
               "deterministic": true
             },
@@ -41676,7 +41676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:48.629993+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41724,7 +41724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:19:48.630042+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275684+00:00"
               },
               "deterministic": true
             },
@@ -41753,7 +41753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630076+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275701+00:00"
               },
               "deterministic": true
             },
@@ -41821,7 +41821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:19:48.630132+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41884,7 +41884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:48.630200+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41896,7 +41896,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.473132+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.827000+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -41962,7 +41962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630252+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275778+00:00"
               },
               "deterministic": true
             },
@@ -41975,7 +41975,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.473202+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.827038+00:00"
           },
           "namespace": {
             "type": "string",
@@ -42004,7 +42004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630288+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275795+00:00"
               },
               "deterministic": true
             },
@@ -42017,7 +42017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.473232+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.827054+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -42056,7 +42056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:48.630354+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42069,7 +42069,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.473289+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.827084+00:00"
           },
           "uid": {
             "type": "string",
@@ -42086,7 +42086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:48.630387+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42100,7 +42100,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.473320+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.827100+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of log_receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -42150,8 +42150,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for log_receiverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for log_receiverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/log_receiver_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -42163,8 +42163,8 @@
           "description": "Minimum configuration for log_receiverReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for log_receiverReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for log_receiverReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/log_receiver_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -42351,7 +42351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630521+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275902+00:00"
               },
               "deterministic": true
             },
@@ -42390,7 +42390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630623+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42454,7 +42454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630726+00:00"
+                "validatedAt": "2026-05-09T01:36:43.275992+00:00"
               },
               "deterministic": true
             },
@@ -42533,7 +42533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630784+00:00"
+                "validatedAt": "2026-05-09T01:36:43.276018+00:00"
               },
               "deterministic": true
             },
@@ -42578,7 +42578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630866+00:00"
+                "validatedAt": "2026-05-09T01:36:43.276058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42616,7 +42616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630953+00:00"
+                "validatedAt": "2026-05-09T01:36:43.276099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42689,7 +42689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.630995+00:00"
+                "validatedAt": "2026-05-09T01:36:43.276118+00:00"
               },
               "deterministic": true
             },
@@ -42702,7 +42702,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.473602+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.827250+00:00"
           },
           "namespace": {
             "type": "string",
@@ -42739,7 +42739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.631035+00:00"
+                "validatedAt": "2026-05-09T01:36:43.276137+00:00"
               },
               "deterministic": true
             },
@@ -42752,7 +42752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.473634+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.827266+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -42780,8 +42780,8 @@
           "description": "Minimum configuration for log_receiverTestLogReceiverResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for log_receiverTestLogReceiverResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for log_receiverTestLogReceiverResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/log_receiver_test_log_receiver_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -42824,7 +42824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.631078+00:00"
+                "validatedAt": "2026-05-09T01:36:43.276166+00:00"
               },
               "deterministic": true
             },
@@ -42863,7 +42863,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:48.631157+00:00"
+                "validatedAt": "2026-05-09T01:36:43.276203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43024,8 +43024,8 @@
           "description": "Minimum configuration for access_logMultiKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for access_logMultiKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for access_logMultiKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/access_log_multi_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -43045,8 +43045,8 @@
           "description": "Minimum configuration for access_logNumKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for access_logNumKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for access_logNumKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/access_log_num_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -43095,7 +43095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.119899+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43133,7 +43133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.119991+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742654+00:00"
               },
               "deterministic": true
             },
@@ -43146,7 +43146,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589443+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881670+00:00"
           },
           "query": {
             "type": "string",
@@ -43166,7 +43166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120048+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43199,7 +43199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120102+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43271,7 +43271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120163+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43300,7 +43300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120213+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43338,7 +43338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.120252+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742778+00:00"
               },
               "deterministic": true
             },
@@ -43351,7 +43351,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589532+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881717+00:00"
           },
           "query": {
             "type": "string",
@@ -43371,7 +43371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120304+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43424,7 +43424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120362+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43498,7 +43498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120418+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43536,7 +43536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.120455+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742870+00:00"
               },
               "deterministic": true
             },
@@ -43549,7 +43549,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589671+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881767+00:00"
           },
           "query": {
             "type": "string",
@@ -43569,7 +43569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120507+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43602,7 +43602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120557+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43674,7 +43674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120634+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43703,7 +43703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120678+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43740,7 +43740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.120716+00:00"
+                "validatedAt": "2026-05-09T01:36:45.742976+00:00"
               },
               "deterministic": true
             },
@@ -43753,7 +43753,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589759+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881811+00:00"
           },
           "query": {
             "type": "string",
@@ -43773,7 +43773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.120768+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43826,7 +43826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.120829+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43886,7 +43886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121103+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43912,7 +43912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121156+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43950,7 +43950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.121223+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43985,7 +43985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.121272+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44023,7 +44023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.121310+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743257+00:00"
               },
               "deterministic": true
             },
@@ -44036,7 +44036,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.589995+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.881934+00:00"
           },
           "site": {
             "type": "string",
@@ -44053,7 +44053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121349+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44086,7 +44086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121401+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44160,7 +44160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.121867+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44198,7 +44198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.121906+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743528+00:00"
               },
               "deterministic": true
             },
@@ -44211,7 +44211,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590332+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882122+00:00"
           },
           "query": {
             "type": "string",
@@ -44231,7 +44231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.121958+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44264,7 +44264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122010+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44336,7 +44336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122064+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44365,7 +44365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122105+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44403,7 +44403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.122143+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743639+00:00"
               },
               "deterministic": true
             },
@@ -44416,7 +44416,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590417+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882174+00:00"
           },
           "query": {
             "type": "string",
@@ -44436,7 +44436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122194+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44489,7 +44489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122251+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44563,7 +44563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122305+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44601,7 +44601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.122342+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743733+00:00"
               },
               "deterministic": true
             },
@@ -44614,7 +44614,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590512+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882224+00:00"
           },
           "query": {
             "type": "string",
@@ -44634,7 +44634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122393+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44659,7 +44659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122431+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44692,7 +44692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122483+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44765,7 +44765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122537+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44794,7 +44794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122579+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44832,7 +44832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.122631+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743856+00:00"
               },
               "deterministic": true
             },
@@ -44845,7 +44845,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590620+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882273+00:00"
           },
           "query": {
             "type": "string",
@@ -44865,7 +44865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122684+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44907,7 +44907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122727+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44943,7 +44943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122783+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45018,7 +45018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122838+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45056,7 +45056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.122875+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743961+00:00"
               },
               "deterministic": true
             },
@@ -45069,7 +45069,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590722+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882328+00:00"
           },
           "query": {
             "type": "string",
@@ -45089,7 +45089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.122926+00:00"
+                "validatedAt": "2026-05-09T01:36:45.743985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45114,7 +45114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.122963+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45147,7 +45147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123014+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45220,7 +45220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123067+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45249,7 +45249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.123108+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45287,7 +45287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.123146+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744084+00:00"
               },
               "deterministic": true
             },
@@ -45300,7 +45300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590814+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882378+00:00"
           },
           "query": {
             "type": "string",
@@ -45320,7 +45320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.123197+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45362,7 +45362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123239+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45398,7 +45398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123293+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45467,7 +45467,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.123376+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45479,7 +45479,7 @@
             "x-original-maxLength": 256,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.590913+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882432+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter is used to filter th that match the logs specified label key/value and the operator.",
@@ -45536,7 +45536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123434+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45618,7 +45618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123500+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45647,7 +45647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123548+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45709,7 +45709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.123599+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744289+00:00"
               },
               "deterministic": true
             },
@@ -45722,7 +45722,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591013+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882485+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -45740,7 +45740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123649+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45811,7 +45811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.123888+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45849,7 +45849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.123926+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744428+00:00"
               },
               "deterministic": true
             },
@@ -45862,7 +45862,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591300+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882651+00:00"
           },
           "query": {
             "type": "string",
@@ -45882,7 +45882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.123978+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45915,7 +45915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124029+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45987,7 +45987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124083+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46031,7 +46031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124127+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46068,7 +46068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.124162+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744534+00:00"
               },
               "deterministic": true
             },
@@ -46081,7 +46081,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591393+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882703+00:00"
           },
           "query": {
             "type": "string",
@@ -46101,7 +46101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124212+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46154,7 +46154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124268+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46229,7 +46229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124382+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46267,7 +46267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.124418+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744652+00:00"
               },
               "deterministic": true
             },
@@ -46280,7 +46280,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591506+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882764+00:00"
           },
           "query": {
             "type": "string",
@@ -46300,7 +46300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124469+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46333,7 +46333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124519+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46405,7 +46405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124572+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46434,7 +46434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124647+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46472,7 +46472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.124688+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744757+00:00"
               },
               "deterministic": true
             },
@@ -46485,7 +46485,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591600+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882813+00:00"
           },
           "query": {
             "type": "string",
@@ -46505,7 +46505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124741+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46558,7 +46558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124801+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46633,7 +46633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124857+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46671,7 +46671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.124893+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744845+00:00"
               },
               "deterministic": true
             },
@@ -46684,7 +46684,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591694+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882863+00:00"
           },
           "query": {
             "type": "string",
@@ -46704,7 +46704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.124944+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46737,7 +46737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.124994+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46809,7 +46809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125049+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46838,7 +46838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.125089+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46876,7 +46876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:54.125124+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744948+00:00"
               },
               "deterministic": true
             },
@@ -46889,7 +46889,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.591776+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.882908+00:00"
           },
           "query": {
             "type": "string",
@@ -46909,7 +46909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:19:54.125174+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46962,7 +46962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125231+00:00"
+                "validatedAt": "2026-05-09T01:36:45.744996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47035,7 +47035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125276+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47167,8 +47167,8 @@
           "description": "Minimum configuration for logaccess_logKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logaccess_logKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logaccess_logKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logaccess_log_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -47193,7 +47193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125342+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47281,8 +47281,8 @@
           "description": "Minimum configuration for logaudit_logKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logaudit_logKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logaudit_logKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logaudit_log_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -47330,7 +47330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125403+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47424,8 +47424,8 @@
           "description": "Minimum configuration for logfirewall_logKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logfirewall_logKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logfirewall_logKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logfirewall_log_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -47450,7 +47450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125465+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47494,7 +47494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125506+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47574,8 +47574,8 @@
           "description": "Minimum configuration for logk8s_eventsKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logk8s_eventsKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logk8s_eventsKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logk8s_events_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -47600,7 +47600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125562+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47676,8 +47676,8 @@
           "description": "Minimum configuration for logplatform_eventKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logplatform_eventKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logplatform_eventKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logplatform_event_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -47702,7 +47702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125635+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47746,7 +47746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:54.125674+00:00"
+                "validatedAt": "2026-05-09T01:36:45.745189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47827,8 +47827,8 @@
           "description": "Minimum configuration for logvk8s_eventsKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for logvk8s_eventsKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for logvk8s_eventsKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/logvk8s_events_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -47849,8 +47849,8 @@
           "description": "Minimum configuration for schemaSortOrder",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_sort_orders\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -47873,8 +47873,8 @@
           "description": "Minimum configuration for schemalogLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemalogLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemalogLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemalog_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -47902,7 +47902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:18.042879+00:00"
+                "validatedAt": "2026-05-09T01:36:56.698816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47966,7 +47966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.183957+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47991,7 +47991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184007+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48017,7 +48017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184059+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48042,7 +48042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184107+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48122,7 +48122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184190+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48190,8 +48190,8 @@
           "description": "Minimum configuration for reportAttackImpactKey",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for reportAttackImpactKey\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for reportAttackImpactKey\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_attack_impact_keies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -48249,7 +48249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184268+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48317,8 +48317,8 @@
           "description": "Minimum configuration for reportAttackSourcesKey",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for reportAttackSourcesKey\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for reportAttackSourcesKey\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_attack_sources_keies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -48366,7 +48366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184346+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48397,7 +48397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184397+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48441,8 +48441,8 @@
           "description": "Minimum configuration for reportFieldValueType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for reportFieldValueType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for reportFieldValueType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_field_value_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -48569,7 +48569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184534+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48595,7 +48595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184603+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48631,7 +48631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184660+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48698,7 +48698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184724+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48732,7 +48732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184780+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48773,8 +48773,8 @@
           "description": "Minimum configuration for reportReportCreatorMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for reportReportCreatorMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for reportReportCreatorMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_report_creator_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -48808,7 +48808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184832+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48899,8 +48899,8 @@
           "description": "Minimum configuration for reportReportDeliveryState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for reportReportDeliveryState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for reportReportDeliveryState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_report_delivery_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -48929,7 +48929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184915+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48956,7 +48956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184948+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49002,8 +49002,8 @@
           "description": "Minimum configuration for reportReportFrequency",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for reportReportFrequency\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for reportReportFrequency\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_report_frequencies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -49032,7 +49032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.184988+00:00"
+                "validatedAt": "2026-05-09T01:38:10.522989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49062,7 +49062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185043+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49117,7 +49117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185094+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49149,7 +49149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185148+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49194,7 +49194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:01.185197+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523078+00:00"
               },
               "deterministic": true
             },
@@ -49207,7 +49207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.198599+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.539350+00:00"
           },
           "report_frequency": {
             "$ref": "#/components/schemas/reportReportFrequency"
@@ -49234,7 +49234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185260+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49266,7 +49266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185318+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49299,7 +49299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185372+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49331,7 +49331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185425+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49382,8 +49382,8 @@
           "description": "Minimum configuration for reportReportStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for reportReportStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for reportReportStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_report_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -49442,7 +49442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185493+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49521,8 +49521,8 @@
           "description": "Minimum configuration for reportSecurityEventsKey",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for reportSecurityEventsKey\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for reportSecurityEventsKey\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_security_events_keies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -49580,7 +49580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185568+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49659,8 +49659,8 @@
           "description": "Minimum configuration for reportThreatDetailsKey",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for reportThreatDetailsKey\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for reportThreatDetailsKey\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_threat_details_keies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -49709,7 +49709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185680+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49767,7 +49767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:01.185765+00:00"
+                "validatedAt": "2026-05-09T01:38:10.523309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49864,8 +49864,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for report_configCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for report_configCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_configs\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -49965,7 +49965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:06.258457+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49977,7 +49977,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326419+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592453+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -50043,7 +50043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.258512+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777115+00:00"
               },
               "deterministic": true
             },
@@ -50056,7 +50056,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326489+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592497+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50085,7 +50085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.258549+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777132+00:00"
               },
               "deterministic": true
             },
@@ -50098,7 +50098,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326518+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592512+00:00"
           },
           "object": {
             "$ref": "#/components/schemas/schemareportObject"
@@ -50124,7 +50124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.258616+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50137,7 +50137,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326575+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592543+00:00"
           },
           "uid": {
             "type": "string",
@@ -50154,7 +50154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.258651+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50168,7 +50168,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326619+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592559+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of report is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -50247,7 +50247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.258693+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777197+00:00"
               },
               "deterministic": true
             },
@@ -50260,7 +50260,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326662+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592580+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50290,7 +50290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.258732+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777215+00:00"
               },
               "deterministic": true
             },
@@ -50303,7 +50303,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326691+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592596+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -50364,7 +50364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.258774+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777235+00:00"
               },
               "deterministic": true
             },
@@ -50377,7 +50377,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326723+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592612+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50414,7 +50414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.258813+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777253+00:00"
               },
               "deterministic": true
             },
@@ -50427,7 +50427,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326752+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592628+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -50453,8 +50453,8 @@
           "description": "Minimum configuration for report_configGenerateReportResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for report_configGenerateReportResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for report_configGenerateReportResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_config_generate_report_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -50545,7 +50545,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326852+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592681+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -50633,7 +50633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.258947+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777308+00:00"
               },
               "deterministic": true
             },
@@ -50646,7 +50646,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.326902+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592707+00:00"
           },
           "report_config_names": {
             "$ref": "#/components/schemas/report_configReportConfigurationNamesList"
@@ -50692,7 +50692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:06.258994+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50767,8 +50767,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for report_configListReportsHistoryResponseItem\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for report_configListReportsHistoryResponseItem\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_config_list_reports_history_response_items\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -50815,7 +50815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:06.259089+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50878,7 +50878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:06.259153+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50890,7 +50890,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.327030+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592774+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -50956,7 +50956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.259204+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777418+00:00"
               },
               "deterministic": true
             },
@@ -50969,7 +50969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.327099+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592810+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50998,7 +50998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.259242+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777436+00:00"
               },
               "deterministic": true
             },
@@ -51011,7 +51011,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.327128+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592826+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -51050,7 +51050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.259306+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51063,7 +51063,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.327184+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592856+00:00"
           },
           "uid": {
             "type": "string",
@@ -51080,7 +51080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.259339+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51094,7 +51094,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.327214+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.592871+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of report_config is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -51162,7 +51162,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.259408+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51206,8 +51206,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for report_configReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for report_configReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_config_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -51219,8 +51219,8 @@
           "description": "Minimum configuration for report_configReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for report_configReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for report_configReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_config_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -51289,7 +51289,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.259487+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51347,7 +51347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.259610+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51409,7 +51409,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.259717+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51472,7 +51472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.259819+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51540,8 +51540,8 @@
           "description": "Minimum configuration for report_configReportGenerationDate",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for report_configReportGenerationDate\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for report_configReportGenerationDate\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_config_report_generation_dates\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -51568,8 +51568,8 @@
           "description": "Minimum configuration for report_configReportGenerationWeekday",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for report_configReportGenerationWeekday\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for report_configReportGenerationWeekday\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/report_config_report_generation_weekdaies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -51610,7 +51610,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.259882+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51724,7 +51724,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.259977+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51763,7 +51763,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.260039+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51790,7 +51790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.260086+00:00"
+                "validatedAt": "2026-05-09T01:38:12.777822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51880,7 +51880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.260956+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778210+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -51896,7 +51896,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.327951+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.593261+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -51968,7 +51968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.261003+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778231+00:00"
               },
               "deterministic": true
             },
@@ -51981,7 +51981,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.328001+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.593288+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52012,7 +52012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.261038+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778247+00:00"
               },
               "deterministic": true
             },
@@ -52025,7 +52025,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.328029+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.593303+00:00"
           },
           "uid": {
             "type": "string",
@@ -52044,7 +52044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.261071+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52059,7 +52059,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.328060+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.593319+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -52106,7 +52106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262081+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52134,7 +52134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262131+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52163,7 +52163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262181+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52190,7 +52190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262227+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52219,7 +52219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262282+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52244,7 +52244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262333+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52309,7 +52309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262411+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52347,7 +52347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:06.262471+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52359,7 +52359,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.328752+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.593625+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -52400,7 +52400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262535+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52444,7 +52444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262592+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52458,7 +52458,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.328821+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.593661+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -52477,7 +52477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262641+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52504,7 +52504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262672+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52519,7 +52519,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.328862+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.593682+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -52534,7 +52534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.262715+00:00"
+                "validatedAt": "2026-05-09T01:38:12.778968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52633,7 +52633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.263092+00:00"
+                "validatedAt": "2026-05-09T01:38:12.779136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52659,7 +52659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.263142+00:00"
+                "validatedAt": "2026-05-09T01:38:12.779162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52695,7 +52695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.263194+00:00"
+                "validatedAt": "2026-05-09T01:38:12.779185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52772,7 +52772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.263266+00:00"
+                "validatedAt": "2026-05-09T01:38:12.779216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52808,7 +52808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:06.263319+00:00"
+                "validatedAt": "2026-05-09T01:38:12.779239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52946,8 +52946,8 @@
           "description": "Minimum configuration for app_typeAPIEPCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -52993,7 +52993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.970724+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53044,7 +53044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.970806+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53139,7 +53139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.970936+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53181,7 +53181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971002+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53227,7 +53227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971063+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53290,7 +53290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971153+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53331,7 +53331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971208+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53371,7 +53371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971269+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53452,7 +53452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971378+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53604,7 +53604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971507+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53796,8 +53796,8 @@
           "description": "Minimum configuration for app_typeAPIEPPIILevel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPPIILevel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPPIILevel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_p_i_i_levels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -53822,8 +53822,8 @@
           "description": "Minimum configuration for app_typeAPIEPSecurityRisk",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPSecurityRisk\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPSecurityRisk\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_security_risks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -53847,8 +53847,8 @@
           "description": "Minimum configuration for app_typeAPIType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -53872,8 +53872,8 @@
           "description": "Minimum configuration for app_typeAuthenticationLocation",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAuthenticationLocation\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAuthenticationLocation\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_authentication_locations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -53896,8 +53896,8 @@
           "description": "Minimum configuration for app_typeAuthenticationState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAuthenticationState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAuthenticationState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_authentication_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -53927,8 +53927,8 @@
           "description": "Minimum configuration for app_typeAuthenticationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAuthenticationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAuthenticationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_authentication_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -53956,7 +53956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971711+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54158,8 +54158,8 @@
           "description": "Minimum configuration for app_typeSensitiveDataType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeSensitiveDataType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeSensitiveDataType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_sensitive_data_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -54374,7 +54374,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.972129+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54425,7 +54425,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.972201+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54474,8 +54474,8 @@
           "description": "Minimum configuration for graphserviceLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for graphserviceLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for graphserviceLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/graphservice_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -54503,7 +54503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972249+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54528,7 +54528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972294+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54566,7 +54566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.972341+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721838+00:00"
               },
               "deterministic": true
             },
@@ -54579,7 +54579,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.650405+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.220767+00:00"
           },
           "service": {
             "type": "string",
@@ -54597,7 +54597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972389+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54623,7 +54623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972428+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54648,7 +54648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972479+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54699,8 +54699,8 @@
           "description": "Minimum configuration for instanceInstanceIdField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for instanceInstanceIdField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for instanceInstanceIdField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/instance_instance_id_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -54735,7 +54735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972541+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54768,7 +54768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972602+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54801,7 +54801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972651+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54827,7 +54827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972689+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54860,7 +54860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972742+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54936,8 +54936,8 @@
           "description": "Minimum configuration for schemagraphMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemagraphMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemagraphMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemagraph_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -54995,7 +54995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.973027+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722123+00:00"
               },
               "deterministic": true
             },
@@ -55008,7 +55008,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.650676+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.220902+00:00"
           }
         },
         "x-f5xc-description-short": "List of application types for a namespace.",
@@ -55134,7 +55134,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.650758+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.220947+00:00"
           }
         },
         "x-f5xc-description-short": "CdnMetricData contains the metric type and the corresponding metric value(s).",
@@ -55191,8 +55191,8 @@
           "description": "Minimum configuration for serviceEdgeAPIEPSelector",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for serviceEdgeAPIEPSelector\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for serviceEdgeAPIEPSelector\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/service_edge_a_p_i_e_p_selectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -55341,7 +55341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973186+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55382,7 +55382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.973227+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722215+00:00"
               },
               "deterministic": true
             },
@@ -55395,7 +55395,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.650928+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221037+00:00"
           },
           "range": {
             "type": "string",
@@ -55420,7 +55420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973273+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55456,7 +55456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973329+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55489,7 +55489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973370+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55554,7 +55554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973415+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55688,7 +55688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973497+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55714,7 +55714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973547+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55752,7 +55752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.973596+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722371+00:00"
               },
               "deterministic": true
             },
@@ -55765,7 +55765,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651081+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221118+00:00"
           },
           "service": {
             "type": "string",
@@ -55783,7 +55783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973641+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55809,7 +55809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973680+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55834,7 +55834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973723+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55860,7 +55860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973756+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55885,7 +55885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973810+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55940,8 +55940,8 @@
           "description": "Minimum configuration for serviceIdField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for serviceIdField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for serviceIdField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/service_id_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -56004,7 +56004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973871+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56048,7 +56048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.973915+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722505+00:00"
               },
               "deterministic": true
             },
@@ -56061,7 +56061,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651209+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221191+00:00"
           },
           "range": {
             "type": "string",
@@ -56086,7 +56086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973959+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56119,7 +56119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974009+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56152,7 +56152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974049+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56215,7 +56215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974096+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56307,7 +56307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974163+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56382,7 +56382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.974234+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722643+00:00"
               },
               "deterministic": true
             },
@@ -56395,7 +56395,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651341+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221261+00:00"
           },
           "range": {
             "type": "string",
@@ -56420,7 +56420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974278+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56453,7 +56453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974329+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56486,7 +56486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974371+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56550,7 +56550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974418+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56606,7 +56606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974467+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56667,7 +56667,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.974555+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56712,7 +56712,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.974637+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56750,7 +56750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.974677+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722834+00:00"
               },
               "deterministic": true
             },
@@ -56763,7 +56763,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651460+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221324+00:00"
           },
           "start_time": {
             "type": "string",
@@ -56788,7 +56788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974730+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56821,7 +56821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974775+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56897,7 +56897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974832+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56950,7 +56950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974882+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56962,7 +56962,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651550+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221371+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used to render the service graph are tagged with labels listed in the enum Label.",
@@ -57096,7 +57096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974955+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57140,7 +57140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.975000+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722972+00:00"
               },
               "deterministic": true
             },
@@ -57153,7 +57153,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651683+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221436+00:00"
           },
           "range": {
             "type": "string",
@@ -57178,7 +57178,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975044+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57211,7 +57211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975094+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57244,7 +57244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975135+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57308,7 +57308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975181+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57364,7 +57364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975230+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57455,7 +57455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.975304+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723102+00:00"
               },
               "deterministic": true
             },
@@ -57468,7 +57468,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651812+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221504+00:00"
           },
           "range": {
             "type": "string",
@@ -57493,7 +57493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975346+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57526,7 +57526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975396+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57559,7 +57559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975436+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57624,7 +57624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975482+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57673,7 +57673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975528+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57706,7 +57706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975576+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57733,7 +57733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975627+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57758,7 +57758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975660+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57791,7 +57791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975713+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57842,7 +57842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:39.602135+00:00"
+                "validatedAt": "2026-05-09T01:38:54.121539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57882,7 +57882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:39.602172+00:00"
+                "validatedAt": "2026-05-09T01:38:54.121557+00:00"
               },
               "deterministic": true
             },
@@ -57895,7 +57895,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:48.537516+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.647476+00:00"
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",
@@ -58064,7 +58064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.495068+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58143,7 +58143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.495165+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58190,8 +58190,8 @@
           "description": "Minimum configuration for schemasiteLinkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemasiteLinkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemasiteLinkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemasite_link_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -58232,7 +58232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.495432+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729242+00:00"
               },
               "deterministic": true
             },
@@ -58245,7 +58245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.834989+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.196709+00:00"
           },
           "sli_address": {
             "type": "string",
@@ -58260,7 +58260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.495482+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58283,7 +58283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.495533+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58327,8 +58327,8 @@
           "description": "Minimum configuration for schemasiteSiteType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemasiteSiteType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemasiteSiteType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemasite_site_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -58352,8 +58352,8 @@
           "description": "Minimum configuration for schemasite_mesh_groupSiteMeshGroupType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemasite_mesh_groupSiteMeshGroupType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemasite_mesh_groupSiteMeshGroupType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemasite_mesh_group_site_mesh_group_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -58382,8 +58382,8 @@
           "description": "Minimum configuration for schematopologyLinkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schematopologyLinkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schematopologyLinkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schematopology_link_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -58414,8 +58414,8 @@
           "description": "Minimum configuration for schematopologyMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schematopologyMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schematopologyMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schematopology_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -58501,7 +58501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.495614+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58634,7 +58634,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.495754+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58711,7 +58711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:51.495828+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58779,8 +58779,8 @@
           "description": "Minimum configuration for siteActiveState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteActiveState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteActiveState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_active_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -58802,8 +58802,8 @@
           "description": "Minimum configuration for siteAddressMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteAddressMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteAddressMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_address_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -58870,7 +58870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.496174+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729540+00:00"
               },
               "deterministic": true
             },
@@ -58883,7 +58883,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.835417+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.196933+00:00"
           }
         },
         "x-f5xc-description-short": "BondMembersType represents the bond interface members along with the corresponding link state.",
@@ -58982,7 +58982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.496253+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59020,7 +59020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.496293+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729589+00:00"
               },
               "deterministic": true
             },
@@ -59033,7 +59033,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.835544+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197000+00:00"
           },
           "network_name": {
             "type": "string",
@@ -59050,7 +59050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.496344+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59107,8 +59107,8 @@
           "description": "Minimum configuration for siteLinkQuality",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteLinkQuality\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteLinkQuality\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_link_qualities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -59286,7 +59286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.496452+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59310,7 +59310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.496510+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59337,7 +59337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:26:51.496556+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729699+00:00"
               },
               "deterministic": true
             },
@@ -59379,7 +59379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.496624+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59417,7 +59417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.496661+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729736+00:00"
               },
               "deterministic": true
             },
@@ -59430,7 +59430,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.835776+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197113+00:00"
           },
           "resource_id": {
             "type": "string",
@@ -59447,7 +59447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:51.496709+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59472,7 +59472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.496761+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59495,7 +59495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.496811+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59565,7 +59565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.496861+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59590,7 +59590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:51.496912+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59615,7 +59615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.496964+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59638,7 +59638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497015+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59662,7 +59662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497058+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59727,7 +59727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497126+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59771,7 +59771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497171+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59806,7 +59806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:26:51.497215+00:00"
+                "validatedAt": "2026-05-09T01:39:54.729987+00:00"
               },
               "deterministic": true
             },
@@ -59864,7 +59864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497267+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59887,7 +59887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497325+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59932,8 +59932,8 @@
           "description": "Minimum configuration for topologyCloudNetworkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyCloudNetworkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyCloudNetworkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_cloud_network_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -60018,7 +60018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497402+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60082,7 +60082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497465+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60106,7 +60106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497512+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60160,7 +60160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:51.497563+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60209,7 +60209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497632+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60235,7 +60235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:51.497678+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60260,7 +60260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497725+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60328,8 +60328,8 @@
           "description": "Minimum configuration for topologyGCPRouteType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyGCPRouteType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyGCPRouteType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_g_c_p_route_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -60351,8 +60351,8 @@
           "description": "Minimum configuration for topologyGatewayTypeEnum",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyGatewayTypeEnum\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyGatewayTypeEnum\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_gateway_type_enums\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -60377,7 +60377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497799+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60400,7 +60400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497854+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60437,7 +60437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497919+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60460,7 +60460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.497972+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60498,7 +60498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498035+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60521,7 +60521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498089+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60545,7 +60545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498143+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60568,7 +60568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498194+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60592,7 +60592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498247+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60660,8 +60660,8 @@
           "description": "Minimum configuration for topologyInterfaceTypeEnum",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyInterfaceTypeEnum\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyInterfaceTypeEnum\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_interface_type_enums\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -60689,7 +60689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498310+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60730,7 +60730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.498347+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730466+00:00"
               },
               "deterministic": true
             },
@@ -60743,7 +60743,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.836253+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197372+00:00"
           },
           "src_id": {
             "type": "string",
@@ -60761,7 +60761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498390+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60819,7 +60819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:51.498440+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60869,8 +60869,8 @@
           "description": "Minimum configuration for topologyLinkStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyLinkStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyLinkStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_link_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -60938,7 +60938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498499+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60976,7 +60976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.498534+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730549+00:00"
               },
               "deterministic": true
             },
@@ -60989,7 +60989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.836375+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197437+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -61045,7 +61045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498593+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61083,7 +61083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.498632+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730584+00:00"
               },
               "deterministic": true
             },
@@ -61096,7 +61096,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.836428+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197464+00:00"
           },
           "owner_id": {
             "type": "string",
@@ -61111,7 +61111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498677+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61138,7 +61138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498726+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61162,7 +61162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498771+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61174,7 +61174,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.836488+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197495+00:00"
           },
           "tags": {
             "type": "object",
@@ -61286,7 +61286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.498859+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61319,7 +61319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.498911+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61352,7 +61352,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.498965+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61385,7 +61385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.499019+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61418,7 +61418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.499061+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61484,7 +61484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.499105+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730787+00:00"
               },
               "deterministic": true
             },
@@ -61497,7 +61497,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.836636+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197566+00:00"
           },
           "private_addresses": {
             "type": "array",
@@ -61558,7 +61558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.499198+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61570,7 +61570,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.836695+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197598+00:00"
           },
           "subnet": {
             "type": "array",
@@ -61747,7 +61747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.499322+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61809,7 +61809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.499398+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61836,7 +61836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.499431+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61874,7 +61874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.499466+00:00"
+                "validatedAt": "2026-05-09T01:39:54.730939+00:00"
               },
               "deterministic": true
             },
@@ -61887,7 +61887,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.836832+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197669+00:00"
           },
           "network_type": {
             "$ref": "#/components/schemas/topologyCloudNetworkType"
@@ -62101,7 +62101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.499664+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62130,7 +62130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:51.499727+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62142,7 +62142,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.836964+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197738+00:00"
           },
           "level": {
             "type": "integer",
@@ -62189,7 +62189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.499776+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731057+00:00"
               },
               "deterministic": true
             },
@@ -62202,7 +62202,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.837003+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197759+00:00"
           },
           "owner_id": {
             "type": "string",
@@ -62219,7 +62219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.499821+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62247,7 +62247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.499869+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62259,7 +62259,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.837052+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197786+00:00"
           },
           "tags": {
             "type": "object",
@@ -62583,8 +62583,8 @@
           "description": "Minimum configuration for topologyOrchestrationMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyOrchestrationMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyOrchestrationMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_orchestration_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -62615,8 +62615,8 @@
           "description": "Minimum configuration for topologyProviderType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyProviderType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyProviderType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_provider_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -62654,8 +62654,8 @@
           "description": "Minimum configuration for topologyRouteNextHopTypeEnum",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyRouteNextHopTypeEnum\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyRouteNextHopTypeEnum\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_route_next_hop_type_enums\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -62681,8 +62681,8 @@
           "description": "Minimum configuration for topologyRouteSourceTypeEnum",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyRouteSourceTypeEnum\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyRouteSourceTypeEnum\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_route_source_type_enums\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -62710,8 +62710,8 @@
           "description": "Minimum configuration for topologyRouteStateTypeEnum",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyRouteStateTypeEnum\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyRouteStateTypeEnum\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_route_state_type_enums\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -62764,7 +62764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.500057+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62804,7 +62804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.500093+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731193+00:00"
               },
               "deterministic": true
             },
@@ -62817,7 +62817,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.837305+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.197918+00:00"
           },
           "tags": {
             "type": "object",
@@ -62897,8 +62897,8 @@
           "description": "Minimum configuration for topologyRouteTableStateEnum",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyRouteTableStateEnum\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyRouteTableStateEnum\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_route_table_state_enums\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -62975,7 +62975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:51.500205+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63091,8 +63091,8 @@
           "description": "Minimum configuration for topologyRouteTableTypeEnum",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologyRouteTableTypeEnum\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologyRouteTableTypeEnum\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_route_table_type_enums\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -63121,7 +63121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.500326+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63150,7 +63150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.500378+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63180,7 +63180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.500444+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63228,8 +63228,8 @@
           "description": "Minimum configuration for topologySiteAppTypeEnum",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for topologySiteAppTypeEnum\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for topologySiteAppTypeEnum\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/topology_site_app_type_enums\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -63344,7 +63344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.500575+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63551,7 +63551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.500735+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63577,7 +63577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.500778+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63683,7 +63683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.500871+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63722,7 +63722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:51.500911+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731548+00:00"
               },
               "deterministic": true
             },
@@ -63735,7 +63735,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.837782+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.198168+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -63810,7 +63810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.500983+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63871,7 +63871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:51.501062+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64013,7 +64013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:51.501166+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64106,7 +64106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:51.501238+00:00"
+                "validatedAt": "2026-05-09T01:39:54.731695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64272,7 +64272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.241301+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64310,7 +64310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:10.241406+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206144+00:00"
               },
               "deterministic": true
             },
@@ -64323,7 +64323,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.533269+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.441884+00:00"
           },
           "network_id": {
             "type": "string",
@@ -64340,7 +64340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.241494+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64370,7 +64370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.241612+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64478,7 +64478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.241724+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64503,7 +64503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.241786+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64542,7 +64542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:10.241829+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206284+00:00"
               },
               "deterministic": true
             },
@@ -64555,7 +64555,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.533378+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.441940+00:00"
           },
           "sort": {
             "$ref": "#/components/schemas/l3l4MitigationSeriesSort"
@@ -64579,7 +64579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.241882+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64689,7 +64689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.241966+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64727,7 +64727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:10.242007+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206363+00:00"
               },
               "deterministic": true
             },
@@ -64740,7 +64740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.533472+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.441988+00:00"
           },
           "network_id": {
             "type": "string",
@@ -64757,7 +64757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242056+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64787,7 +64787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242104+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64895,7 +64895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242178+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64933,7 +64933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:10.242218+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206455+00:00"
               },
               "deterministic": true
             },
@@ -64946,7 +64946,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.533564+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.442037+00:00"
           },
           "network_id": {
             "type": "string",
@@ -64963,7 +64963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242265+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64996,7 +64996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242316+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65104,7 +65104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242390+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65142,7 +65142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:10.242432+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206549+00:00"
               },
               "deterministic": true
             },
@@ -65155,7 +65155,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.533681+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.442091+00:00"
           },
           "network_id": {
             "type": "string",
@@ -65173,7 +65173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242480+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65203,7 +65203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242529+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65230,7 +65230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242569+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65317,7 +65317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242664+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65342,7 +65342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242711+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65375,7 +65375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:29:10.242766+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206685+00:00"
               },
               "deterministic": true
             },
@@ -65431,7 +65431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:29:10.242821+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206709+00:00"
               },
               "deterministic": true
             },
@@ -65457,7 +65457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242864+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65469,7 +65469,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.533798+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.442157+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -65521,7 +65521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:10.242902+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206744+00:00"
               },
               "deterministic": true
             },
@@ -65534,7 +65534,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.533832+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.442176+00:00"
           },
           "values": {
             "type": "array",
@@ -65584,8 +65584,8 @@
           "description": "Minimum configuration for l3l4MitigationSeriesSort",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for l3l4MitigationSeriesSort\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for l3l4MitigationSeriesSort\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/l3l4_mitigation_series_sorts\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -65608,8 +65608,8 @@
           "description": "Minimum configuration for l3l4RoutedTraffic",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for l3l4RoutedTraffic\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for l3l4RoutedTraffic\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/l3l4_routed_traffics\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "network"
@@ -65633,7 +65633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242949+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65657,7 +65657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.242981+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65682,7 +65682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.243013+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65733,7 +65733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.243060+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65771,7 +65771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:29:10.243099+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206831+00:00"
               },
               "deterministic": true
             },
@@ -65784,7 +65784,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.533918+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.442221+00:00"
           },
           "network_id": {
             "type": "string",
@@ -65801,7 +65801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.243147+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65831,7 +65831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:29:10.243199+00:00"
+                "validatedAt": "2026-05-09T01:40:55.206873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65924,8 +65924,8 @@
           "description": "Minimum configuration for l3l4TrafficType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for l3l4TrafficType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for l3l4TrafficType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/l3l4_traffic_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -65948,8 +65948,8 @@
           "description": "Minimum configuration for l3l4TrafficUnit",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for l3l4TrafficUnit\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for l3l4TrafficUnit\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/l3l4_traffic_units\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"

--- a/docs/specifications/api/support.json
+++ b/docs/specifications/api/support.json
@@ -13176,7 +13176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:23.949753+00:00"
+                "validatedAt": "2026-05-09T01:32:58.989069+00:00"
               },
               "deterministic": true
             },
@@ -13189,7 +13189,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.500038+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:04.632860+00:00",
             "x-f5xc-conflicts-with": [
               "uid"
             ]
@@ -13222,7 +13222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:23.949828+00:00"
+                "validatedAt": "2026-05-09T01:32:58.989096+00:00"
               },
               "deterministic": true
             },
@@ -13235,7 +13235,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.500071+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.632877+00:00"
           },
           "site": {
             "type": "string",
@@ -13253,7 +13253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:23.949902+00:00"
+                "validatedAt": "2026-05-09T01:32:58.989114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13277,7 +13277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:23.949962+00:00"
+                "validatedAt": "2026-05-09T01:32:58.989129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13291,7 +13291,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.500113+00:00",
+            "x-reconciled-at": "2026-05-09T01:41:04.632898+00:00",
             "x-f5xc-conflicts-with": [
               "name"
             ]
@@ -13335,7 +13335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:23.950036+00:00"
+                "validatedAt": "2026-05-09T01:32:58.989149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13347,7 +13347,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.500147+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.632916+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13388,7 +13388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.114519+00:00"
+                "validatedAt": "2026-05-09T01:34:27.569949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13414,7 +13414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.114648+00:00"
+                "validatedAt": "2026-05-09T01:34:27.569985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13440,7 +13440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.114702+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13466,7 +13466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.114746+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13532,7 +13532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.114797+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570048+00:00"
               },
               "deterministic": true
             },
@@ -13545,7 +13545,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483153+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010637+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13575,7 +13575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.114842+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570067+00:00"
               },
               "deterministic": true
             },
@@ -13588,7 +13588,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483186+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010653+00:00"
           }
         },
         "x-f5xc-description-short": "Closes an open existing customer support ticket.",
@@ -13672,7 +13672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:44.114929+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13712,7 +13712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.114966+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570121+00:00"
               },
               "deterministic": true
             },
@@ -13725,7 +13725,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483252+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010687+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13755,7 +13755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.115008+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570137+00:00"
               },
               "deterministic": true
             },
@@ -13768,7 +13768,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483281+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010702+00:00"
           }
         },
         "x-f5xc-description-short": "Adds a new comment to an existing customer support ticket.",
@@ -13868,7 +13868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.115101+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13893,7 +13893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.115150+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13926,7 +13926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:14:44.115206+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570229+00:00"
               },
               "deterministic": true
             },
@@ -13953,7 +13953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.115246+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13978,7 +13978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.115294+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14030,8 +14030,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_supports\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -14101,7 +14101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.115352+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570293+00:00"
               },
               "deterministic": true
             },
@@ -14114,7 +14114,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483446+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010789+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14144,7 +14144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.115390+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570310+00:00"
               },
               "deterministic": true
             },
@@ -14157,7 +14157,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483475+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010805+00:00"
           }
         },
         "x-f5xc-description-short": "Changes priority of an existing customer support ticket.",
@@ -14281,7 +14281,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483576+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010858+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -14348,7 +14348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:44.115532+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14411,7 +14411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:44.115637+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14423,7 +14423,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483667+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010897+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14489,7 +14489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.115694+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570420+00:00"
               },
               "deterministic": true
             },
@@ -14502,7 +14502,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483737+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010936+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14531,7 +14531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.115732+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570436+00:00"
               },
               "deterministic": true
             },
@@ -14544,7 +14544,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483766+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010953+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -14583,7 +14583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.115800+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14596,7 +14596,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483824+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.010984+00:00"
           },
           "uid": {
             "type": "string",
@@ -14614,7 +14614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.115834+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14628,7 +14628,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483854+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011003+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of customer_support is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -14699,7 +14699,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.115910+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14744,7 +14744,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.115973+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14756,7 +14756,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483896+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011030+00:00"
           }
         },
         "x-f5xc-description-short": "Input message of the 'ListCTSupportTickets' RPC. Fields can be used to control scope and filtering of collection.",
@@ -14816,7 +14816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:44.116030+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14878,7 +14878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.116073+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570585+00:00"
               },
               "deterministic": true
             },
@@ -14891,7 +14891,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483949+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011062+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14921,7 +14921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.116111+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570602+00:00"
               },
               "deterministic": true
             },
@@ -14934,7 +14934,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.483978+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011077+00:00"
           },
           "priority": {
             "$ref": "#/components/schemas/customer_supportSupportTicketPriority"
@@ -15019,7 +15019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.116193+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15083,7 +15083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.116238+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570653+00:00"
               },
               "deterministic": true
             },
@@ -15096,7 +15096,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484063+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011121+00:00"
           }
         },
         "x-f5xc-description-short": "Any error that may occurred during tax status verification request.",
@@ -15151,7 +15151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.116278+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570669+00:00"
               },
               "deterministic": true
             },
@@ -15164,7 +15164,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484095+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011138+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15194,7 +15194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.116314+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570685+00:00"
               },
               "deterministic": true
             },
@@ -15207,7 +15207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484124+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011160+00:00"
           }
         },
         "x-f5xc-description-short": "Reopens a closed existing customer support ticket.",
@@ -15347,8 +15347,8 @@
           "description": "Minimum configuration for customer_supportSupportService",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportService\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportService\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_services\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -15372,8 +15372,8 @@
           "description": "Minimum configuration for customer_supportSupportTicketPriority",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportTicketPriority\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportTicketPriority\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_ticket_priorities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -15401,8 +15401,8 @@
           "description": "Minimum configuration for customer_supportSupportTicketStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportTicketStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportTicketStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_ticket_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -15430,8 +15430,8 @@
           "description": "Minimum configuration for customer_supportSupportTicketType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportTicketType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportTicketType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_ticket_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -15476,8 +15476,8 @@
           "description": "Minimum configuration for customer_supportSupportTopic",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportTopic\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportTopic\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_topics\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -15506,8 +15506,8 @@
           "description": "Minimum configuration for ioschemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -15529,7 +15529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.116405+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15552,7 +15552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.116449+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15564,7 +15564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484216+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011209+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -15610,7 +15610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:14:44.116496+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570761+00:00"
               },
               "deterministic": true
             },
@@ -15636,7 +15636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.116549+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15663,7 +15663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.116607+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15675,7 +15675,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484268+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011236+00:00"
           },
           "service_name": {
             "type": "string",
@@ -15692,7 +15692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.116660+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15725,7 +15725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.116714+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15737,7 +15737,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484307+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011257+00:00"
           },
           "type": {
             "type": "string",
@@ -15762,7 +15762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.116755+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15820,7 +15820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.116808+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15882,7 +15882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.116847+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570902+00:00"
               },
               "deterministic": true
             },
@@ -15895,7 +15895,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484378+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011296+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -16013,7 +16013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.116977+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570958+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16029,7 +16029,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484443+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011333+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16099,7 +16099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.117029+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570979+00:00"
               },
               "deterministic": true
             },
@@ -16112,7 +16112,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484493+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011363+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16143,7 +16143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.117066+00:00"
+                "validatedAt": "2026-05-09T01:34:27.570995+00:00"
               },
               "deterministic": true
             },
@@ -16156,7 +16156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484523+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011383+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -16238,7 +16238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.117169+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571040+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16254,7 +16254,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484565+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011407+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16326,7 +16326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.117218+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571061+00:00"
               },
               "deterministic": true
             },
@@ -16339,7 +16339,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484629+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011434+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16370,7 +16370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.117255+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571077+00:00"
               },
               "deterministic": true
             },
@@ -16383,7 +16383,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484659+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011450+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -16428,7 +16428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117297+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16441,7 +16441,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484690+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011466+00:00"
           },
           "name": {
             "type": "string",
@@ -16474,7 +16474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.117333+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571110+00:00"
               },
               "deterministic": true
             },
@@ -16487,7 +16487,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484719+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011482+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16518,7 +16518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.117370+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571126+00:00"
               },
               "deterministic": true
             },
@@ -16531,7 +16531,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484748+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011497+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16550,7 +16550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117413+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16564,7 +16564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484777+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011512+00:00"
           },
           "uid": {
             "type": "string",
@@ -16583,7 +16583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117447+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16598,7 +16598,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484806+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011528+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -16643,7 +16643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117503+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16671,7 +16671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117556+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16699,7 +16699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117618+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16728,7 +16728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117669+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16755,7 +16755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117703+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16769,7 +16769,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484887+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011570+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -16785,7 +16785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117748+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16848,8 +16848,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -16894,7 +16894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117813+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16906,7 +16906,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484949+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011603+00:00"
           },
           "status": {
             "type": "string",
@@ -16924,7 +16924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117854+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16936,7 +16936,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.484978+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011618+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -16978,7 +16978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117911+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17005,7 +17005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.117962+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17032,7 +17032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118009+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17060,7 +17060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118064+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17125,7 +17125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118144+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17174,7 +17174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118210+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17187,7 +17187,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.485106+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011686+00:00"
           },
           "uid": {
             "type": "string",
@@ -17206,7 +17206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118244+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17220,7 +17220,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.485137+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011702+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -17270,7 +17270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118285+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17282,7 +17282,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.485168+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011719+00:00"
           },
           "name": {
             "type": "string",
@@ -17315,7 +17315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.118323+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571518+00:00"
               },
               "deterministic": true
             },
@@ -17328,7 +17328,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.485197+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011734+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17359,7 +17359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:44.118361+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571534+00:00"
               },
               "deterministic": true
             },
@@ -17372,7 +17372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.485226+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011749+00:00"
           },
           "uid": {
             "type": "string",
@@ -17389,7 +17389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118393+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17403,7 +17403,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.485256+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011764+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -17447,7 +17447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118439+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17493,7 +17493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:44.118516+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17505,7 +17505,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.485306+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011791+00:00"
           },
           "ongoing": {
             "type": "boolean",
@@ -17538,7 +17538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118577+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17583,7 +17583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118658+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17608,7 +17608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118703+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17636,7 +17636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118747+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17698,8 +17698,8 @@
           "description": "Minimum configuration for schemacustomer_supportErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemacustomer_supportErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemacustomer_supportErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemacustomer_support_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -17725,7 +17725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118805+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17753,7 +17753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.118849+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17802,7 +17802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:14:44.118922+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571813+00:00"
               },
               "deterministic": true
             },
@@ -17851,7 +17851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:44.118997+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17863,7 +17863,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.485489+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.011890+00:00"
           },
           "escalated": {
             "type": "boolean",
@@ -17926,7 +17926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.119074+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17971,7 +17971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.119139+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18000,7 +18000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:14:44.119176+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571923+00:00"
               },
               "deterministic": true
             },
@@ -18026,7 +18026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.119222+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18054,7 +18054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.119268+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18084,7 +18084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:44.119318+00:00"
+                "validatedAt": "2026-05-09T01:34:27.571981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18177,7 +18177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:13.232448+00:00"
+                "validatedAt": "2026-05-09T01:34:40.460097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18202,7 +18202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:13.232535+00:00"
+                "validatedAt": "2026-05-09T01:34:40.460128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18266,7 +18266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825177+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18297,7 +18297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825225+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18322,7 +18322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825264+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18353,7 +18353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825310+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18404,7 +18404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825371+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18444,7 +18444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825425+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18470,7 +18470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825471+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18584,7 +18584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825539+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18646,7 +18646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825624+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18684,7 +18684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.825668+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115522+00:00"
               },
               "deterministic": true
             },
@@ -18697,7 +18697,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.991936+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728346+00:00"
           },
           "node": {
             "type": "string",
@@ -18714,7 +18714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825709+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18739,7 +18739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825749+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18789,7 +18789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825795+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18854,7 +18854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:50.825860+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115607+00:00"
               },
               "deterministic": true
             },
@@ -18885,7 +18885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:50.825901+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115627+00:00"
               },
               "deterministic": true
             },
@@ -18939,7 +18939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.825963+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18963,7 +18963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826011+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19001,7 +19001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826077+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19028,7 +19028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826126+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19040,7 +19040,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992110+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728435+00:00"
           },
           "wifi_support": {
             "type": "boolean",
@@ -19103,7 +19103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:15:50.826183+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19129,7 +19129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826223+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19157,7 +19157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:15:50.826263+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115791+00:00"
               },
               "deterministic": true
             },
@@ -19211,7 +19211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.826316+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115815+00:00"
               },
               "deterministic": true
             },
@@ -19224,7 +19224,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992192+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728477+00:00"
           },
           "node": {
             "type": "string",
@@ -19241,7 +19241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826357+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19266,7 +19266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826397+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19317,7 +19317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826444+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19343,7 +19343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826488+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19383,7 +19383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826545+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19408,7 +19408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826603+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19465,7 +19465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826683+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19551,7 +19551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826736+00:00"
+                "validatedAt": "2026-05-09T01:34:57.115995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19609,7 +19609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.826782+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116018+00:00"
               },
               "deterministic": true
             },
@@ -19622,7 +19622,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992350+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728558+00:00"
           },
           "node": {
             "type": "string",
@@ -19639,7 +19639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826820+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19664,7 +19664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826859+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19700,8 +19700,8 @@
           "description": "Minimum configuration for debugRebootResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for debugRebootResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for debugRebootResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/debug_reboot_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -19742,7 +19742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.826898+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116072+00:00"
               },
               "deterministic": true
             },
@@ -19755,7 +19755,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992404+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728585+00:00"
           },
           "node": {
             "type": "string",
@@ -19772,7 +19772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826936+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19797,7 +19797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.826977+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19809,7 +19809,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992443+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728606+00:00"
           }
         },
         "x-f5xc-description-short": "Name and formal displayed name of the service.",
@@ -19862,7 +19862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.827017+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116128+00:00"
               },
               "deterministic": true
             },
@@ -19875,7 +19875,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992475+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728622+00:00"
           },
           "node": {
             "type": "string",
@@ -19892,7 +19892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827056+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19917,7 +19917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827102+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19942,7 +19942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827141+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19979,8 +19979,8 @@
           "description": "Minimum configuration for debugSoftRestartResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for debugSoftRestartResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for debugSoftRestartResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/debug_soft_restart_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20007,7 +20007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827187+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20046,7 +20046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.827222+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116241+00:00"
               },
               "deterministic": true
             },
@@ -20059,7 +20059,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992549+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728659+00:00"
           },
           "node": {
             "type": "string",
@@ -20076,7 +20076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827260+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20101,7 +20101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827303+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20113,7 +20113,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992606+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728680+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20156,7 +20156,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992641+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728696+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20192,8 +20192,8 @@
           "description": "Minimum configuration for debugVpmState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for debugVpmState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for debugVpmState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/debug_vpm_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20223,7 +20223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827466+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20261,7 +20261,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.827549+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20273,7 +20273,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992729+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728741+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -20292,7 +20292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827616+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20343,7 +20343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827662+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20355,7 +20355,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992771+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728764+00:00"
           },
           "url": {
             "type": "string",
@@ -20393,7 +20393,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.827746+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116492+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -20437,8 +20437,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -20502,7 +20502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:50.827805+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116519+00:00"
               },
               "deterministic": true
             },
@@ -20529,7 +20529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827849+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20555,7 +20555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827893+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20567,7 +20567,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992857+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728808+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20607,7 +20607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.827942+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20647,7 +20647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.827979+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116602+00:00"
               },
               "deterministic": true
             },
@@ -20660,7 +20660,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992899+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728830+00:00"
           },
           "serial": {
             "type": "string",
@@ -20678,7 +20678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828022+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20704,7 +20704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828065+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20730,7 +20730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828108+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20742,7 +20742,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.992947+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728856+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20784,7 +20784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828158+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20810,7 +20810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828200+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20852,7 +20852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828256+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20878,7 +20878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828303+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20890,7 +20890,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.993018+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728892+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20976,7 +20976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828382+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21031,7 +21031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828451+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21082,7 +21082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828503+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21107,7 +21107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828555+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21170,7 +21170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828620+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21195,7 +21195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828668+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21220,7 +21220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828718+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21267,7 +21267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828769+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21292,7 +21292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828814+00:00"
+                "validatedAt": "2026-05-09T01:34:57.116993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21317,7 +21317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828857+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21329,7 +21329,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.993201+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.728988+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21365,8 +21365,8 @@
           "description": "Minimum configuration for siteLinkQuality",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteLinkQuality\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteLinkQuality\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_link_qualities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21393,8 +21393,8 @@
           "description": "Minimum configuration for siteLinkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteLinkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteLinkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_link_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -21451,7 +21451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828925+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21498,7 +21498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.828972+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21550,7 +21550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:50.829044+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117100+00:00"
               },
               "deterministic": true
             },
@@ -21590,7 +21590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.829082+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117118+00:00"
               },
               "deterministic": true
             },
@@ -21603,7 +21603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.993315+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.729047+00:00"
           },
           "port": {
             "type": "string",
@@ -21622,7 +21622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829119+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21689,7 +21689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829185+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21728,7 +21728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.829222+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117189+00:00"
               },
               "deterministic": true
             },
@@ -21741,7 +21741,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.993375+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.729078+00:00"
           },
           "release": {
             "type": "string",
@@ -21758,7 +21758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829265+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21783,7 +21783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829308+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21808,7 +21808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829352+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21820,7 +21820,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.993424+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.729104+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21885,7 +21885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:50.829421+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21918,7 +21918,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.829486+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22026,7 +22026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.829560+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117353+00:00"
               },
               "deterministic": true
             },
@@ -22039,7 +22039,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.993580+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.729197+00:00"
           },
           "serial": {
             "type": "string",
@@ -22058,7 +22058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829618+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22083,7 +22083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829662+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22109,7 +22109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829707+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22121,7 +22121,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.993642+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.729223+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22161,7 +22161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829753+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22186,7 +22186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829795+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22225,7 +22225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.829831+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117468+00:00"
               },
               "deterministic": true
             },
@@ -22238,7 +22238,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.993695+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.729250+00:00"
           },
           "serial": {
             "type": "string",
@@ -22255,7 +22255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829873+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22295,7 +22295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829931+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22361,7 +22361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.829998+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22387,7 +22387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830052+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22413,7 +22413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830106+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22453,7 +22453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830171+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22478,7 +22478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830216+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22523,7 +22523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:50.830287+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22535,7 +22535,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:37.993833+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.729321+00:00"
           },
           "i_manufacturer": {
             "type": "string",
@@ -22552,7 +22552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830338+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22577,7 +22577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830385+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22603,7 +22603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830430+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22629,7 +22629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830478+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22654,7 +22654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830525+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22684,7 +22684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:15:50.830563+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117796+00:00"
               },
               "deterministic": true
             },
@@ -22711,7 +22711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830630+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22737,7 +22737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830673+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22766,7 +22766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:50.830726+00:00"
+                "validatedAt": "2026-05-09T01:34:57.117864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22826,8 +22826,8 @@
           "description": "Minimum configuration for siteUsbType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteUsbType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteUsbType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_usb_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -22853,7 +22853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765000+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22865,7 +22865,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.049370+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.756701+00:00"
           },
           "value": {
             "type": "string",
@@ -22880,7 +22880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765091+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22892,7 +22892,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.049406+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.756718+00:00"
           }
         },
         "x-f5xc-description-short": "DHCP Option information as a (key, value) pair.",
@@ -22931,7 +22931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765192+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22959,7 +22959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:15:52.765303+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22971,7 +22971,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.049451+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.756742+00:00"
           },
           "expiry": {
             "type": "string",
@@ -22988,7 +22988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765384+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23018,7 +23018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:15:52.765440+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983313+00:00"
               },
               "deterministic": true
             },
@@ -23043,7 +23043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765488+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23068,7 +23068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765520+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23093,7 +23093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765567+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23118,7 +23118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765621+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23157,7 +23157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765683+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23291,7 +23291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765804+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23315,7 +23315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:15:52.765846+00:00"
+                "validatedAt": "2026-05-09T01:34:57.983474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23419,7 +23419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:16.629987+00:00"
+                "validatedAt": "2026-05-09T01:35:08.573380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23457,8 +23457,8 @@
           "description": "Minimum configuration for debugAllowF5SSHResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for debugAllowF5SSHResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for debugAllowF5SSHResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/debug_allow_f5_s_s_h_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -23502,7 +23502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.009407+00:00"
+                "validatedAt": "2026-05-09T01:36:41.188877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23527,7 +23527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.009523+00:00"
+                "validatedAt": "2026-05-09T01:36:41.188913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23604,7 +23604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.009660+00:00"
+                "validatedAt": "2026-05-09T01:36:41.188942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23629,7 +23629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.009748+00:00"
+                "validatedAt": "2026-05-09T01:36:41.188962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23654,7 +23654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.009786+00:00"
+                "validatedAt": "2026-05-09T01:36:41.188978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23701,7 +23701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.009842+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23763,7 +23763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:44.009886+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189023+00:00"
               },
               "deterministic": true
             },
@@ -23776,7 +23776,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.405895+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.794611+00:00"
           },
           "node": {
             "type": "string",
@@ -23793,7 +23793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.009927+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23818,7 +23818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.009967+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23853,8 +23853,8 @@
           "description": "Minimum configuration for lteLteDisconnectResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for lteLteDisconnectResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for lteLteDisconnectResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/lte_lte_disconnect_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -23944,7 +23944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:44.010023+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189084+00:00"
               },
               "deterministic": true
             },
@@ -23957,7 +23957,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.405986+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.794657+00:00"
           },
           "node": {
             "type": "string",
@@ -23974,7 +23974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.010062+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23999,7 +23999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.010101+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24035,8 +24035,8 @@
           "description": "Minimum configuration for lteLteUpdateConfigResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for lteLteUpdateConfigResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for lteLteUpdateConfigResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/lte_ltes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -24146,8 +24146,8 @@
           "description": "Minimum configuration for lteSignalStrength",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for lteSignalStrength\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for lteSignalStrength\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/lte_signal_strengths\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -24172,7 +24172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.010194+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24198,7 +24198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.010234+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24222,7 +24222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:44.010272+00:00"
+                "validatedAt": "2026-05-09T01:36:41.189204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24295,7 +24295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:21:59.628353+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24334,7 +24334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:21:59.628447+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771362+00:00"
               },
               "deterministic": true
             },
@@ -24376,7 +24376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:59.628526+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771384+00:00"
               },
               "deterministic": true
             },
@@ -24389,7 +24389,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.062956+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.018780+00:00"
           },
           "node": {
             "type": "string",
@@ -24421,7 +24421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:59.628693+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24470,7 +24470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:59.628768+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24523,7 +24523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:59.628818+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24548,7 +24548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:59.628856+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24588,7 +24588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:59.628913+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24613,7 +24613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:59.628958+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24668,7 +24668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:59.629036+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24708,8 +24708,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -24752,7 +24752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:59.629118+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771609+00:00"
               },
               "deterministic": true
             },
@@ -24790,7 +24790,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:59.629180+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24856,7 +24856,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:59.629261+00:00"
+                "validatedAt": "2026-05-09T01:37:42.771675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24908,8 +24908,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -24949,7 +24949,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.100403+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24991,7 +24991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.100474+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25033,7 +25033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.100541+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25095,8 +25095,8 @@
           "description": "Minimum configuration for schemaVirtualNetworkType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaVirtualNetworkType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_virtual_network_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25140,7 +25140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.100618+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503272+00:00"
               },
               "deterministic": true
             },
@@ -25153,7 +25153,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.162737+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.884098+00:00"
           },
           "node": {
             "type": "string",
@@ -25185,7 +25185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.100698+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25211,7 +25211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:17.100738+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25263,7 +25263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:17.100800+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25328,7 +25328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.100846+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503374+00:00"
               },
               "deterministic": true
             },
@@ -25341,7 +25341,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.162826+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.884142+00:00"
           },
           "node": {
             "type": "string",
@@ -25373,7 +25373,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.100918+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25399,7 +25399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:17.100958+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25473,8 +25473,8 @@
           "description": "Minimum configuration for tcpdumpStopResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tcpdumpStopResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tcpdumpStopResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tcpdump_stop_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25511,7 +25511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:17.101034+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25575,7 +25575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.101100+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503487+00:00"
               },
               "deterministic": true
             },
@@ -25588,7 +25588,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.162922+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.884199+00:00"
           },
           "node": {
             "type": "string",
@@ -25620,7 +25620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.101174+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25658,7 +25658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:17.101251+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25684,7 +25684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:17.101291+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25740,7 +25740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:17.101337+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25786,7 +25786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:17.101406+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25812,7 +25812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:17.101445+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25837,7 +25837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:17.101490+00:00"
+                "validatedAt": "2026-05-09T01:39:39.503662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25849,7 +25849,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.163035+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.884260+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25888,8 +25888,8 @@
           "description": "Minimum configuration for tcpdumpTcpdumpStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tcpdumpTcpdumpStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tcpdumpTcpdumpStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tcpdump_tcpdump_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -25955,7 +25955,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.837075+00:00"
+                "validatedAt": "2026-05-09T01:39:51.344727+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -25971,7 +25971,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.655733+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.113899+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -26041,7 +26041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.837124+00:00"
+                "validatedAt": "2026-05-09T01:39:51.344748+00:00"
               },
               "deterministic": true
             },
@@ -26054,7 +26054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.655784+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.113926+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26085,7 +26085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.837159+00:00"
+                "validatedAt": "2026-05-09T01:39:51.344764+00:00"
               },
               "deterministic": true
             },
@@ -26098,7 +26098,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.655814+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.113942+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -26139,7 +26139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.837705+00:00"
+                "validatedAt": "2026-05-09T01:39:51.344990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26151,7 +26151,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656083+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114082+00:00"
           },
           "location": {
             "type": "string",
@@ -26167,7 +26167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.837752+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26179,7 +26179,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656114+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114098+00:00"
           },
           "provider": {
             "type": "string",
@@ -26196,7 +26196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.837796+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26208,7 +26208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656143+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114113+00:00"
           },
           "secret_encoding": {
             "$ref": "#/components/schemas/schemaSecretEncodingType"
@@ -26230,7 +26230,7 @@
             "maxLength": 1,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656183+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114134+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Vault Secret\" VaultSecretInfoType specifies information about the Secret managed by Hashicorp Vault.",
@@ -26284,7 +26284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.837998+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345118+00:00"
               },
               "deterministic": true
             },
@@ -26297,7 +26297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656338+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114222+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Wingman Secret\" WingmanSecretInfoType specifies the handle to the wingman secret.",
@@ -26335,7 +26335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.838047+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26362,7 +26362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.838094+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26389,7 +26389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.838125+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26429,7 +26429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.838161+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345196+00:00"
               },
               "deterministic": true
             },
@@ -26442,7 +26442,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656400+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114254+00:00"
           }
         },
         "x-f5xc-description-short": "Issue (ticket) type information that's specific to Jira - modeled after the JIRA REST API response format.",
@@ -26486,7 +26486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.838194+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26527,7 +26527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.838244+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26539,7 +26539,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656451+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114281+00:00"
           },
           "name": {
             "type": "string",
@@ -26571,7 +26571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.838280+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345249+00:00"
               },
               "deterministic": true
             },
@@ -26584,7 +26584,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656481+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114296+00:00"
           }
         },
         "x-f5xc-description-short": "Contains fields and information that are specific to Jira projects - modeled after the JIRA REST API response format.",
@@ -26625,8 +26625,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ticket_tracking_systemCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ticket_tracking_systemCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ticket_tracking_systems\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -26733,7 +26733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.838346+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345277+00:00"
               },
               "deterministic": true
             },
@@ -26746,7 +26746,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656600+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114351+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26776,7 +26776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.838382+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345293+00:00"
               },
               "deterministic": true
             },
@@ -26789,7 +26789,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656638+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114367+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26958,7 +26958,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.838551+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26993,7 +26993,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.838648+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27034,7 +27034,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.838738+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27104,7 +27104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.838803+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27163,7 +27163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.838878+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27229,7 +27229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:43.838934+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27292,7 +27292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:43.839001+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27304,7 +27304,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656878+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114489+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27371,7 +27371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.839054+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345601+00:00"
               },
               "deterministic": true
             },
@@ -27384,7 +27384,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656947+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114525+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27413,7 +27413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:43.839091+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345618+00:00"
               },
               "deterministic": true
             },
@@ -27426,7 +27426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.656976+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114540+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27449,7 +27449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.839141+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27462,7 +27462,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.657024+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114566+00:00"
           },
           "uid": {
             "type": "string",
@@ -27480,7 +27480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:43.839174+00:00"
+                "validatedAt": "2026-05-09T01:39:51.345654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27494,7 +27494,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.657055+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.114582+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ticket_tracking_system is returned in 'List'.",
@@ -27543,8 +27543,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ticket_tracking_systemReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ticket_tracking_systemReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ticket_tracking_system_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -27556,8 +27556,8 @@
           "description": "Minimum configuration for ticket_tracking_systemReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ticket_tracking_systemReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ticket_tracking_systemReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ticket_tracking_system_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -27687,7 +27687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:09.418955+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600453+00:00"
               },
               "deterministic": true
             },
@@ -27700,7 +27700,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.202568+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.363346+00:00"
           },
           "node": {
             "type": "string",
@@ -27717,7 +27717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.418996+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27745,7 +27745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:09.419047+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27770,7 +27770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419086+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27821,7 +27821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:09.419129+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27914,7 +27914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:09.419177+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600547+00:00"
               },
               "deterministic": true
             },
@@ -27927,7 +27927,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.202673+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.363391+00:00"
           },
           "node": {
             "type": "string",
@@ -27944,7 +27944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419217+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27972,7 +27972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:09.419257+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27997,7 +27997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419297+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28048,7 +28048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:09.419339+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600615+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28130,7 +28130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:09.419388+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600636+00:00"
               },
               "deterministic": true
             },
@@ -28143,7 +28143,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.202759+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.363435+00:00"
           },
           "node": {
             "type": "string",
@@ -28160,7 +28160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419427+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28185,7 +28185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419466+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28251,7 +28251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:09.419520+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28312,7 +28312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:09.419564+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600712+00:00"
               },
               "deterministic": true
             },
@@ -28325,7 +28325,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.202843+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.363478+00:00"
           },
           "node": {
             "type": "string",
@@ -28342,7 +28342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419617+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28367,7 +28367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419660+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28403,8 +28403,8 @@
           "description": "Minimum configuration for usbUsbUpdateConfigResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for usbUsbUpdateConfigResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for usbUsbUpdateConfigResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/usb_usbs\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"
@@ -28431,7 +28431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419715+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28457,7 +28457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419771+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28483,7 +28483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419827+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28509,7 +28509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419873+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28535,7 +28535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419923+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28560,7 +28560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:09.419970+00:00"
+                "validatedAt": "2026-05-09T01:40:02.600875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28608,8 +28608,8 @@
           "description": "Minimum configuration for wifiSignalStrength",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for wifiSignalStrength\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for wifiSignalStrength\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/wifi_signal_strengths\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -28638,7 +28638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:47.118442+00:00"
+                "validatedAt": "2026-05-09T01:40:45.145846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28730,7 +28730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:47.118660+00:00"
+                "validatedAt": "2026-05-09T01:40:45.145903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28803,7 +28803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:47.118792+00:00"
+                "validatedAt": "2026-05-09T01:40:45.145933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28866,7 +28866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:47.118871+00:00"
+                "validatedAt": "2026-05-09T01:40:45.145969+00:00"
               },
               "deterministic": true
             },
@@ -28879,7 +28879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.125503+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.251937+00:00"
           },
           "node": {
             "type": "string",
@@ -28896,7 +28896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:47.118914+00:00"
+                "validatedAt": "2026-05-09T01:40:45.145989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28921,7 +28921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:47.118958+00:00"
+                "validatedAt": "2026-05-09T01:40:45.146011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28956,8 +28956,8 @@
           "description": "Minimum configuration for wifiWifiDisconnectResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for wifiWifiDisconnectResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for wifiWifiDisconnectResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/wifi_wifi_disconnect_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -29035,7 +29035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:47.119014+00:00"
+                "validatedAt": "2026-05-09T01:40:45.146037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29114,8 +29114,8 @@
           "description": "Minimum configuration for wifiWifiSecurity",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for wifiWifiSecurity\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for wifiWifiSecurity\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/wifi_wifi_securities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -29130,8 +29130,8 @@
           "description": "Minimum configuration for wifiWifiSecurityNone",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for wifiWifiSecurityNone\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for wifiWifiSecurityNone\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/wifi_wifi_security_nones\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -29158,7 +29158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:47.119084+00:00"
+                "validatedAt": "2026-05-09T01:40:45.146067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29219,7 +29219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:28:47.119130+00:00"
+                "validatedAt": "2026-05-09T01:40:45.146087+00:00"
               },
               "deterministic": true
             },
@@ -29232,7 +29232,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:54.125660+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:15.252006+00:00"
           },
           "node": {
             "type": "string",
@@ -29249,7 +29249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:47.119172+00:00"
+                "validatedAt": "2026-05-09T01:40:45.146106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29274,7 +29274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:47.119212+00:00"
+                "validatedAt": "2026-05-09T01:40:45.146124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29310,8 +29310,8 @@
           "description": "Minimum configuration for wifiWifiUpdateConfigResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for wifiWifiUpdateConfigResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for wifiWifiUpdateConfigResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/wifi_wifis\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "certificates"

--- a/docs/specifications/api/telemetry_and_insights.json
+++ b/docs/specifications/api/telemetry_and_insights.json
@@ -6140,8 +6140,8 @@
           "description": "Minimum configuration for connectivityEdgeMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityEdgeMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityEdgeMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_edge_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6179,7 +6179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478405+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6220,7 +6220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.478478+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689488+00:00"
               },
               "deterministic": true
             },
@@ -6233,7 +6233,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103207+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.833746+00:00"
           },
           "range": {
             "type": "string",
@@ -6258,7 +6258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478530+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6294,7 +6294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478605+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6327,7 +6327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478651+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6392,7 +6392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478702+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6469,7 +6469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478753+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6514,8 +6514,8 @@
           "description": "Minimum configuration for connectivityIdField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityIdField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityIdField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_id_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6548,7 +6548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478814+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6560,7 +6560,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103366+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.833828+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the connectivity graph are tagged with labels listed in the enum Label.",
@@ -6711,7 +6711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478914+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6809,8 +6809,8 @@
           "description": "Minimum configuration for connectivityNodeInstanceMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityNodeInstanceMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityNodeInstanceMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_node_instance_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6839,7 +6839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.478978+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6880,7 +6880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479042+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6906,7 +6906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479092+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6987,8 +6987,8 @@
           "description": "Minimum configuration for connectivityNodeInterfaceMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityNodeInterfaceMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityNodeInterfaceMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_node_interface_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7021,8 +7021,8 @@
           "description": "Minimum configuration for connectivityNodeMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for connectivityNodeMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for connectivityNodeMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/connectivity_node_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -7057,7 +7057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479156+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7118,7 +7118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.479222+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689798+00:00"
               },
               "deterministic": true
             },
@@ -7131,7 +7131,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103653+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.833977+00:00"
           },
           "range": {
             "type": "string",
@@ -7156,7 +7156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479267+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7189,7 +7189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479317+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7222,7 +7222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479359+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7287,7 +7287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479407+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7343,7 +7343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479457+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7417,7 +7417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.479530+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689932+00:00"
               },
               "deterministic": true
             },
@@ -7430,7 +7430,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103776+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834042+00:00"
           },
           "start_time": {
             "type": "string",
@@ -7455,7 +7455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479580+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7636,8 +7636,8 @@
           "description": "Minimum configuration for graphHealthscoreType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for graphHealthscoreType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for graphHealthscoreType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/graph_healthscore_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -7665,7 +7665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.479705+00:00"
+                "validatedAt": "2026-05-09T01:34:20.689996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7677,7 +7677,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103863+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834088+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/graphHealthscoreType"
@@ -7699,7 +7699,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.103904+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834109+00:00"
           }
         },
         "x-f5xc-description-short": "HealthScoreTypeData contains healthscore type and the corresponding value.",
@@ -7855,8 +7855,8 @@
           "description": "Minimum configuration for graphQueryOp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for graphQueryOp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for graphQueryOp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/graph_query_ops\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -7940,7 +7940,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.479907+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7985,8 +7985,8 @@
           "description": "Minimum configuration for graphconnectivityLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for graphconnectivityLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for graphconnectivityLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/graphconnectivity_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -8069,7 +8069,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.479997+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8102,7 +8102,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.480053+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8135,7 +8135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:28.480109+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8179,8 +8179,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -8212,7 +8212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:28.480175+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8224,7 +8224,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.104121+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834238+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -8242,7 +8242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.480229+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8270,7 +8270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.480273+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8282,7 +8282,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.104172+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834264+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -8343,8 +8343,8 @@
           "description": "Minimum configuration for schemaUnitType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaUnitType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_unit_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -8389,7 +8389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:28.480338+00:00"
+                "validatedAt": "2026-05-09T01:34:20.690279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8401,7 +8401,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.104223+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.834291+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -8438,8 +8438,8 @@
           "description": "Minimum configuration for siteSiteType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for siteSiteType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for siteSiteType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/site_site_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -8464,8 +8464,8 @@
           "description": "Minimum configuration for timeseriesTimeseriesFeature",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for timeseriesTimeseriesFeature\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for timeseriesTimeseriesFeature\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/timeseries_timeseries_features\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -8504,7 +8504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222309+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8538,7 +8538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222415+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8571,7 +8571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.222533+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8687,7 +8687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222639+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166666+00:00"
               },
               "deterministic": true
             },
@@ -8700,7 +8700,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.203937+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829244+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8737,7 +8737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222684+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166685+00:00"
               },
               "deterministic": true
             },
@@ -8750,7 +8750,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.203970+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829261+00:00"
           },
           "tcp_lb_request": {
             "$ref": "#/components/schemas/discovered_serviceTCPLBRequest"
@@ -8837,7 +8837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222738+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166709+00:00"
               },
               "deterministic": true
             },
@@ -8850,7 +8850,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204026+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829296+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8887,7 +8887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222778+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166726+00:00"
               },
               "deterministic": true
             },
@@ -8900,7 +8900,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204056+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829312+00:00"
           }
         },
         "x-f5xc-description-short": "Disable visibility on the discovered service.",
@@ -8928,8 +8928,8 @@
           "description": "Minimum configuration for discovered_serviceDisableVisibilityResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discovered_serviceDisableVisibilityResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discovered_serviceDisableVisibilityResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovered_service_disable_visibility_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -8959,7 +8959,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204090+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829330+00:00"
           },
           "virtual_server_pool_members_health": {
             "$ref": "#/components/schemas/discovered_serviceVirtualServerPoolMemberHealth"
@@ -9023,7 +9023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222840+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166753+00:00"
               },
               "deterministic": true
             },
@@ -9036,7 +9036,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204134+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829352+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9073,7 +9073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.222879+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166771+00:00"
               },
               "deterministic": true
             },
@@ -9086,7 +9086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204163+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829368+00:00"
           }
         },
         "x-f5xc-description-short": "Enable visibility of the discovered service in all workspaces like WAAP, App Connect, etc.",
@@ -9246,7 +9246,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223031+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9259,7 +9259,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204271+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829424+00:00"
           },
           "http": {
             "$ref": "#/components/schemas/discovered_serviceProxyTypeHttp"
@@ -9308,7 +9308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223086+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166859+00:00"
               },
               "deterministic": true
             },
@@ -9321,7 +9321,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204330+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829456+00:00"
           },
           "skip_server_verification": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -9382,7 +9382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223157+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9416,7 +9416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223212+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9449,7 +9449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223268+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9517,7 +9517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:02.223324+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9580,7 +9580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:02.223394+00:00"
+                "validatedAt": "2026-05-09T01:35:02.166994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9592,7 +9592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204458+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829526+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9658,7 +9658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223447+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167016+00:00"
               },
               "deterministic": true
             },
@@ -9671,7 +9671,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204529+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829564+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9700,7 +9700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223486+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167033+00:00"
               },
               "deterministic": true
             },
@@ -9713,7 +9713,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204558+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829579+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9736,7 +9736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223538+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9749,7 +9749,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204623+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829605+00:00"
           },
           "uid": {
             "type": "string",
@@ -9767,7 +9767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223571+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9781,7 +9781,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204655+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829621+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9851,7 +9851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:02.223643+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9915,7 +9915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:02.223710+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9927,7 +9927,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204722+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829656+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9993,7 +9993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223761+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167149+00:00"
               },
               "deterministic": true
             },
@@ -10006,7 +10006,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204792+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829693+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10035,7 +10035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223798+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167176+00:00"
               },
               "deterministic": true
             },
@@ -10048,7 +10048,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204822+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829708+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10087,7 +10087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223866+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10100,7 +10100,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204880+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829739+00:00"
           },
           "uid": {
             "type": "string",
@@ -10118,7 +10118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.223903+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10132,7 +10132,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.204910+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829755+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered services is returned in 'List'.",
@@ -10194,7 +10194,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.223979+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167258+00:00"
               },
               "deterministic": true
             },
@@ -10236,7 +10236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224068+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10262,7 +10262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.224126+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10306,7 +10306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224175+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167344+00:00"
               },
               "deterministic": true
             },
@@ -10347,7 +10347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224259+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10444,7 +10444,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224339+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10547,7 +10547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224447+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10581,7 +10581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224530+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10619,7 +10619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224568+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167522+00:00"
               },
               "deterministic": true
             },
@@ -10632,7 +10632,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205118+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829863+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -10696,7 +10696,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224669+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10709,7 +10709,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205178+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829895+00:00"
           },
           "listen_port": {
             "type": "integer",
@@ -10774,7 +10774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224734+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167589+00:00"
               },
               "deterministic": true
             },
@@ -10787,7 +10787,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205218+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.829916+00:00"
           },
           "no_sni": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -10824,7 +10824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224823+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10916,7 +10916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224917+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10950,7 +10950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.224997+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10994,7 +10994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225080+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167746+00:00"
               },
               "deterministic": true
             },
@@ -11029,7 +11029,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225159+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11067,7 +11067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225197+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167799+00:00"
               },
               "deterministic": true
             },
@@ -11099,7 +11099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225278+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11133,7 +11133,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225361+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11183,8 +11183,8 @@
           "description": "Minimum configuration for discovered_serviceVirtualServerEnabledState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discovered_serviceVirtualServerEnabledState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discovered_serviceVirtualServerEnabledState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovered_service_virtual_server_enabled_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -11226,7 +11226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225400+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167889+00:00"
               },
               "deterministic": true
             },
@@ -11239,7 +11239,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205390+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830007+00:00"
           },
           "status": {
             "type": "array",
@@ -11259,7 +11259,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205419+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830022+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -11333,8 +11333,8 @@
           "description": "Minimum configuration for discovered_serviceVirtualServerStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for discovered_serviceVirtualServerStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for discovered_serviceVirtualServerStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/discovered_service_virtual_server_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -11361,7 +11361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225471+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11386,7 +11386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225517+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11449,7 +11449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225558+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167955+00:00"
               },
               "deterministic": true
             },
@@ -11483,7 +11483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225620+00:00"
+                "validatedAt": "2026-05-09T01:35:02.167975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11547,8 +11547,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11577,7 +11577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225685+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11590,7 +11590,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205519+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830074+00:00"
           },
           "name": {
             "type": "string",
@@ -11623,7 +11623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225722+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168018+00:00"
               },
               "deterministic": true
             },
@@ -11636,7 +11636,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205549+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830090+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11667,7 +11667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.225759+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168034+00:00"
               },
               "deterministic": true
             },
@@ -11680,7 +11680,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830106+00:00"
           },
           "tenant": {
             "type": "string",
@@ -11699,7 +11699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225804+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11713,7 +11713,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205620+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830121+00:00"
           },
           "uid": {
             "type": "string",
@@ -11732,7 +11732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225837+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11747,7 +11747,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205651+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830138+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11785,7 +11785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225885+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11808,7 +11808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.225928+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11820,7 +11820,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205694+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830165+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -11866,7 +11866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:16:02.225970+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168127+00:00"
               },
               "deterministic": true
             },
@@ -11892,7 +11892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226024+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11919,7 +11919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226068+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11931,7 +11931,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205745+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830193+00:00"
           },
           "service_name": {
             "type": "string",
@@ -11948,7 +11948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226119+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11981,7 +11981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226166+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11993,7 +11993,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205784+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830213+00:00"
           },
           "type": {
             "type": "string",
@@ -12018,7 +12018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226207+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12072,8 +12072,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12106,7 +12106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226261+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12168,7 +12168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.226299+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168275+00:00"
               },
               "deterministic": true
             },
@@ -12181,7 +12181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205857+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830252+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -12279,7 +12279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226382+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12291,7 +12291,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205929+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830290+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -12370,7 +12370,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.226484+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168356+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12386,7 +12386,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.205973+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830313+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12458,7 +12458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.226533+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168376+00:00"
               },
               "deterministic": true
             },
@@ -12471,7 +12471,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206023+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830340+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12502,7 +12502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.226568+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168392+00:00"
               },
               "deterministic": true
             },
@@ -12515,7 +12515,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206053+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830356+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -12560,7 +12560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226643+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12588,7 +12588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226696+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12616,7 +12616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226745+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12645,7 +12645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226796+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12672,7 +12672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226829+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12686,7 +12686,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206133+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830422+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -12702,7 +12702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226873+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12765,8 +12765,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12811,7 +12811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226935+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12823,7 +12823,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206195+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830461+00:00"
           },
           "status": {
             "type": "string",
@@ -12841,7 +12841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.226978+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12853,7 +12853,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206224+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830477+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -12895,7 +12895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227036+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12922,7 +12922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227087+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12949,7 +12949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227135+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12977,7 +12977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227189+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13042,7 +13042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227271+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13091,7 +13091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227334+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13104,7 +13104,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206353+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830547+00:00"
           },
           "uid": {
             "type": "string",
@@ -13123,7 +13123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227367+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13137,7 +13137,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206384+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830564+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -13187,7 +13187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227562+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13199,7 +13199,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206498+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830624+00:00"
           },
           "name": {
             "type": "string",
@@ -13232,7 +13232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.227612+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168817+00:00"
               },
               "deterministic": true
             },
@@ -13245,7 +13245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206528+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830639+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13276,7 +13276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.227649+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168833+00:00"
               },
               "deterministic": true
             },
@@ -13289,7 +13289,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206557+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830655+00:00"
           },
           "uid": {
             "type": "string",
@@ -13306,7 +13306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227681+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13320,7 +13320,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206598+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830671+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -13445,7 +13445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:16:02.227784+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13494,7 +13494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:16:02.227845+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13506,7 +13506,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206732+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830741+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -13524,7 +13524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:16:02.227899+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13586,7 +13586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.227962+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13644,7 +13644,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228023+00:00"
+                "validatedAt": "2026-05-09T01:35:02.168994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13718,7 +13718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228098+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169031+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13734,7 +13734,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206806+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830780+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13771,7 +13771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228164+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169062+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13787,7 +13787,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206836+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830796+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13816,7 +13816,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228235+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13830,7 +13830,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:38.206866+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:07.830812+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -13881,7 +13881,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228298+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13985,7 +13985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228382+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14056,8 +14056,8 @@
           "description": "Minimum configuration for viewsSiteNetwork",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetwork\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_networks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14079,8 +14079,8 @@
           "description": "Minimum configuration for viewsSiteNetworkSpecifiedVIP",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for viewsSiteNetworkSpecifiedVIP\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/views_site_network_specified_v_i_ps\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -14125,7 +14125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228432+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169189+00:00"
               },
               "deterministic": true
             },
@@ -14172,7 +14172,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228517+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14295,7 +14295,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228650+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14330,7 +14330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228731+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14395,7 +14395,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:16:02.228795+00:00"
+                "validatedAt": "2026-05-09T01:35:02.169342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14449,7 +14449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448311+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14476,7 +14476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448393+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14521,7 +14521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448477+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14548,7 +14548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448527+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14589,7 +14589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448602+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14614,7 +14614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448668+00:00"
+                "validatedAt": "2026-05-09T01:35:36.088984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14662,8 +14662,8 @@
           "description": "Minimum configuration for flowAnomalyLevel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowAnomalyLevel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowAnomalyLevel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_anomaly_levels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -14706,7 +14706,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:39.651115+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:08.497172+00:00"
           }
         },
         "x-f5xc-description-short": "Field Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -14746,8 +14746,8 @@
           "description": "Minimum configuration for flowFieldSelector",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowFieldSelector\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowFieldSelector\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_field_selectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -14878,8 +14878,8 @@
           "description": "Minimum configuration for flowSortDirection",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowSortDirection\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowSortDirection\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_sort_directions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -14904,8 +14904,8 @@
           "description": "Minimum configuration for flowSortLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowSortLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowSortLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_sort_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -14959,7 +14959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448825+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14987,7 +14987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448879+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15037,7 +15037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.448948+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15068,7 +15068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449006+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15127,7 +15127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449067+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15171,7 +15171,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:18.449142+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15205,7 +15205,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:18.449220+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15241,7 +15241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:18.449280+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15276,7 +15276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:17:18.449332+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15326,7 +15326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449402+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15419,7 +15419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449474+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15463,7 +15463,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:17:18.449543+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15490,7 +15490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449602+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15541,7 +15541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:17:18.449668+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15591,7 +15591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:17:18.449736+00:00"
+                "validatedAt": "2026-05-09T01:35:36.089470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15691,8 +15691,8 @@
           "description": "Minimum configuration for flowUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for flowUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for flowUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/flow_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -15716,8 +15716,8 @@
           "description": "Minimum configuration for schemaAddonServiceState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -15757,8 +15757,8 @@
           "description": "Minimum configuration for schemaflowLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaflowLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaflowLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaflow_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -15781,8 +15781,8 @@
           "description": "Minimum configuration for schemaflowServiceType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaflowServiceType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaflowServiceType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaflow_service_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -15808,8 +15808,8 @@
           "description": "Minimum configuration for app_typeAPIEPCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -15855,7 +15855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.970724+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15906,7 +15906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.970806+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16001,7 +16001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.970936+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16043,7 +16043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971002+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16089,7 +16089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971063+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16152,7 +16152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971153+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16193,7 +16193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971208+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16233,7 +16233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971269+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16314,7 +16314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971378+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16466,7 +16466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971507+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16658,8 +16658,8 @@
           "description": "Minimum configuration for app_typeAPIEPPIILevel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPPIILevel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPPIILevel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_p_i_i_levels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -16684,8 +16684,8 @@
           "description": "Minimum configuration for app_typeAPIEPSecurityRisk",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIEPSecurityRisk\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIEPSecurityRisk\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_e_p_security_risks\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -16709,8 +16709,8 @@
           "description": "Minimum configuration for app_typeAPIType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAPIType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAPIType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_a_p_i_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -16734,8 +16734,8 @@
           "description": "Minimum configuration for app_typeAuthenticationLocation",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAuthenticationLocation\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAuthenticationLocation\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_authentication_locations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -16758,8 +16758,8 @@
           "description": "Minimum configuration for app_typeAuthenticationState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAuthenticationState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAuthenticationState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_authentication_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -16789,8 +16789,8 @@
           "description": "Minimum configuration for app_typeAuthenticationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeAuthenticationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeAuthenticationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_authentication_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -16818,7 +16818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.971711+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17020,8 +17020,8 @@
           "description": "Minimum configuration for app_typeSensitiveDataType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_typeSensitiveDataType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_typeSensitiveDataType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_type_sensitive_data_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "service_mesh"
@@ -17236,7 +17236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.972129+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17287,7 +17287,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.972201+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17336,8 +17336,8 @@
           "description": "Minimum configuration for graphserviceLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for graphserviceLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for graphserviceLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/graphservice_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -17365,7 +17365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972249+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17390,7 +17390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972294+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17428,7 +17428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.972341+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721838+00:00"
               },
               "deterministic": true
             },
@@ -17441,7 +17441,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.650405+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.220767+00:00"
           },
           "service": {
             "type": "string",
@@ -17459,7 +17459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972389+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17485,7 +17485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972428+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17510,7 +17510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972479+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17561,8 +17561,8 @@
           "description": "Minimum configuration for instanceInstanceIdField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for instanceInstanceIdField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for instanceInstanceIdField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/instance_instance_id_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -17597,7 +17597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972541+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17630,7 +17630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972602+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17663,7 +17663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972651+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17689,7 +17689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972689+00:00"
+                "validatedAt": "2026-05-09T01:38:39.721979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17722,7 +17722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.972742+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17798,8 +17798,8 @@
           "description": "Minimum configuration for schemagraphMetricType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemagraphMetricType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemagraphMetricType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemagraph_metric_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -17857,7 +17857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.973027+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722123+00:00"
               },
               "deterministic": true
             },
@@ -17870,7 +17870,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.650676+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.220902+00:00"
           }
         },
         "x-f5xc-description-short": "List of application types for a namespace.",
@@ -17996,7 +17996,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.650758+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.220947+00:00"
           }
         },
         "x-f5xc-description-short": "CdnMetricData contains the metric type and the corresponding metric value(s).",
@@ -18053,8 +18053,8 @@
           "description": "Minimum configuration for serviceEdgeAPIEPSelector",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for serviceEdgeAPIEPSelector\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for serviceEdgeAPIEPSelector\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/service_edge_a_p_i_e_p_selectors\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18203,7 +18203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973186+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18244,7 +18244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.973227+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722215+00:00"
               },
               "deterministic": true
             },
@@ -18257,7 +18257,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.650928+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221037+00:00"
           },
           "range": {
             "type": "string",
@@ -18282,7 +18282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973273+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18318,7 +18318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973329+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18351,7 +18351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973370+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18416,7 +18416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973415+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18550,7 +18550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973497+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18576,7 +18576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973547+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18614,7 +18614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.973596+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722371+00:00"
               },
               "deterministic": true
             },
@@ -18627,7 +18627,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651081+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221118+00:00"
           },
           "service": {
             "type": "string",
@@ -18645,7 +18645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973641+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18671,7 +18671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973680+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18696,7 +18696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973723+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18722,7 +18722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973756+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18747,7 +18747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973810+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18802,8 +18802,8 @@
           "description": "Minimum configuration for serviceIdField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for serviceIdField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for serviceIdField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/service_id_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -18866,7 +18866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973871+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18910,7 +18910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.973915+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722505+00:00"
               },
               "deterministic": true
             },
@@ -18923,7 +18923,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651209+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221191+00:00"
           },
           "range": {
             "type": "string",
@@ -18948,7 +18948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.973959+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18981,7 +18981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974009+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19014,7 +19014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974049+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19077,7 +19077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974096+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19169,7 +19169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974163+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19244,7 +19244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.974234+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722643+00:00"
               },
               "deterministic": true
             },
@@ -19257,7 +19257,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651341+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221261+00:00"
           },
           "range": {
             "type": "string",
@@ -19282,7 +19282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974278+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19315,7 +19315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974329+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19348,7 +19348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974371+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19412,7 +19412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974418+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19468,7 +19468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974467+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19529,7 +19529,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.974555+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19574,7 +19574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.974637+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19612,7 +19612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.974677+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722834+00:00"
               },
               "deterministic": true
             },
@@ -19625,7 +19625,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651460+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221324+00:00"
           },
           "start_time": {
             "type": "string",
@@ -19650,7 +19650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974730+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19683,7 +19683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974775+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19759,7 +19759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974832+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19812,7 +19812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974882+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19824,7 +19824,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651550+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221371+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used to render the service graph are tagged with labels listed in the enum Label.",
@@ -19958,7 +19958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.974955+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20002,7 +20002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.975000+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722972+00:00"
               },
               "deterministic": true
             },
@@ -20015,7 +20015,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651683+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221436+00:00"
           },
           "range": {
             "type": "string",
@@ -20040,7 +20040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975044+00:00"
+                "validatedAt": "2026-05-09T01:38:39.722990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20073,7 +20073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975094+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20106,7 +20106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975135+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20170,7 +20170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975181+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20226,7 +20226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975230+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20317,7 +20317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:06.975304+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723102+00:00"
               },
               "deterministic": true
             },
@@ -20330,7 +20330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:47.651812+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.221504+00:00"
           },
           "range": {
             "type": "string",
@@ -20355,7 +20355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975346+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20388,7 +20388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975396+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20421,7 +20421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975436+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20486,7 +20486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975482+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20535,7 +20535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975528+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20568,7 +20568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975576+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20595,7 +20595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975627+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20620,7 +20620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975660+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20653,7 +20653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:06.975713+00:00"
+                "validatedAt": "2026-05-09T01:38:39.723276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20704,7 +20704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:24:39.602135+00:00"
+                "validatedAt": "2026-05-09T01:38:54.121539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20744,7 +20744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:24:39.602172+00:00"
+                "validatedAt": "2026-05-09T01:38:54.121557+00:00"
               },
               "deterministic": true
             },
@@ -20757,7 +20757,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:48.537516+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.647476+00:00"
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",

--- a/docs/specifications/api/tenant_and_identity.json
+++ b/docs/specifications/api/tenant_and_identity.json
@@ -48993,7 +48993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.027540+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729118+00:00"
               },
               "deterministic": true
             },
@@ -49006,7 +49006,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.667991+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284309+00:00"
           },
           "namespace": {
             "type": "string",
@@ -49036,7 +49036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.027632+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729142+00:00"
               },
               "deterministic": true
             },
@@ -49049,7 +49049,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668025+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284326+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -49137,7 +49137,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.027719+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49182,8 +49182,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for allowed_tenantReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for allowed_tenantReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/allowed_tenant_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -49195,8 +49195,8 @@
           "description": "Minimum configuration for allowed_tenantReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for allowed_tenantReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for allowed_tenantReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/allowed_tenant_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -49236,7 +49236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.027797+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49271,7 +49271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.027887+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49356,8 +49356,8 @@
           "description": "Minimum configuration for ioschemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -49386,7 +49386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.027945+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49399,7 +49399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668154+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284392+00:00"
           },
           "name": {
             "type": "string",
@@ -49432,7 +49432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.027985+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729309+00:00"
               },
               "deterministic": true
             },
@@ -49445,7 +49445,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668184+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284408+00:00"
           },
           "namespace": {
             "type": "string",
@@ -49476,7 +49476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.028025+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729326+00:00"
               },
               "deterministic": true
             },
@@ -49489,7 +49489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668213+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284424+00:00"
           },
           "tenant": {
             "type": "string",
@@ -49508,7 +49508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028069+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49522,7 +49522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668242+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284439+00:00"
           },
           "uid": {
             "type": "string",
@@ -49541,7 +49541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028106+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49556,7 +49556,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668273+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284456+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -49594,7 +49594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028155+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49617,7 +49617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028198+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49629,7 +49629,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668316+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284479+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -49675,7 +49675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:09:21.028243+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729420+00:00"
               },
               "deterministic": true
             },
@@ -49701,7 +49701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028296+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49727,7 +49727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028341+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49739,7 +49739,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668367+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284506+00:00"
           },
           "service_name": {
             "type": "string",
@@ -49756,7 +49756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028392+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49789,7 +49789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028441+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49801,7 +49801,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668406+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284527+00:00"
           },
           "type": {
             "type": "string",
@@ -49826,7 +49826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028485+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49880,8 +49880,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -49914,7 +49914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.028538+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49976,7 +49976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.028577+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729561+00:00"
               },
               "deterministic": true
             },
@@ -49989,7 +49989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668480+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284565+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -50107,7 +50107,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.028722+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729618+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -50123,7 +50123,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668545+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284600+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -50193,7 +50193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.028773+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729639+00:00"
               },
               "deterministic": true
             },
@@ -50206,7 +50206,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668611+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284627+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50237,7 +50237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.028810+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729656+00:00"
               },
               "deterministic": true
             },
@@ -50250,7 +50250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668642+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284643+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -50332,7 +50332,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.028911+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729701+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -50348,7 +50348,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668684+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284666+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -50420,7 +50420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.028959+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729722+00:00"
               },
               "deterministic": true
             },
@@ -50433,7 +50433,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668735+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284693+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50464,7 +50464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.028997+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729739+00:00"
               },
               "deterministic": true
             },
@@ -50477,7 +50477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668764+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284708+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -50559,7 +50559,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.029096+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729783+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -50575,7 +50575,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668807+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284731+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -50645,7 +50645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.029144+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729805+00:00"
               },
               "deterministic": true
             },
@@ -50658,7 +50658,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668857+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284758+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50689,7 +50689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.029180+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729822+00:00"
               },
               "deterministic": true
             },
@@ -50702,7 +50702,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668886+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284773+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -50747,7 +50747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029237+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50775,7 +50775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029289+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50803,7 +50803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029338+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50832,7 +50832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029388+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50859,7 +50859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029423+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50873,7 +50873,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.668968+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284816+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -50889,7 +50889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029467+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50952,8 +50952,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -50998,7 +50998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029531+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51010,7 +51010,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669030+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284849+00:00"
           },
           "status": {
             "type": "string",
@@ -51028,7 +51028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029574+00:00"
+                "validatedAt": "2026-05-09T01:32:04.729986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51040,7 +51040,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669059+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284864+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -51082,7 +51082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029645+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51109,7 +51109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029697+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51136,7 +51136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029744+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51164,7 +51164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029798+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51229,7 +51229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029880+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51278,7 +51278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029944+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51291,7 +51291,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669189+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284932+00:00"
           },
           "uid": {
             "type": "string",
@@ -51310,7 +51310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.029978+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51324,7 +51324,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669218+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284948+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -51374,7 +51374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.030018+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51386,7 +51386,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669250+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284965+00:00"
           },
           "name": {
             "type": "string",
@@ -51419,7 +51419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030055+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730188+00:00"
               },
               "deterministic": true
             },
@@ -51432,7 +51432,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669279+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284981+00:00"
           },
           "namespace": {
             "type": "string",
@@ -51463,7 +51463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030091+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730205+00:00"
               },
               "deterministic": true
             },
@@ -51476,7 +51476,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669308+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.284997+00:00"
           },
           "uid": {
             "type": "string",
@@ -51493,7 +51493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.030124+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51507,7 +51507,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669338+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285012+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -51576,7 +51576,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030199+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730255+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -51592,7 +51592,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669369+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285029+00:00"
           },
           "namespace": {
             "type": "string",
@@ -51629,7 +51629,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030266+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730286+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -51645,7 +51645,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669398+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285045+00:00"
           },
           "tenant": {
             "type": "string",
@@ -51674,7 +51674,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030338+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51688,7 +51688,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669428+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285061+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -51728,8 +51728,8 @@
           "description": "Minimum configuration for tenant_managementStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_management_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -51755,8 +51755,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementallowed_tenantCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementallowed_tenantCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_managementallowed_tenants\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -51824,7 +51824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030426+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51859,7 +51859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030508+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51972,7 +51972,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669611+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285151+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -52034,7 +52034,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030681+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52072,7 +52072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030765+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52141,7 +52141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:21.030822+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52204,7 +52204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:21.030890+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52216,7 +52216,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669717+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285211+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -52282,7 +52282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030943+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730577+00:00"
               },
               "deterministic": true
             },
@@ -52295,7 +52295,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669785+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285248+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52324,7 +52324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:21.030979+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730595+00:00"
               },
               "deterministic": true
             },
@@ -52337,7 +52337,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669814+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285263+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -52376,7 +52376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.031046+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52389,7 +52389,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669871+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285293+00:00"
           },
           "uid": {
             "type": "string",
@@ -52406,7 +52406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:21.031080+00:00"
+                "validatedAt": "2026-05-09T01:32:04.730637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52420,7 +52420,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:28.669901+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.285309+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of allowed_tenant is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -52627,8 +52627,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for authenticationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for authenticationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/authentications\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -52738,7 +52738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.384442+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849732+00:00"
               },
               "deterministic": true
             },
@@ -52751,7 +52751,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.448687+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660499+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52781,7 +52781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.384490+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849753+00:00"
               },
               "deterministic": true
             },
@@ -52794,7 +52794,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.448721+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660520+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -52897,7 +52897,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.448821+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660573+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -52983,7 +52983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:48.384687+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53020,7 +53020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:48.384751+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53058,8 +53058,8 @@
           "description": "Minimum configuration for authenticationKMSKeyRefType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for authenticationKMSKeyRefType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for authenticationKMSKeyRefType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/authentication_k_m_s_key_ref_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -53106,7 +53106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:48.384810+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53169,7 +53169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:48.384882+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53181,7 +53181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.448962+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660646+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -53247,7 +53247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.384936+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849930+00:00"
               },
               "deterministic": true
             },
@@ -53260,7 +53260,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.449032+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660684+00:00"
           },
           "namespace": {
             "type": "string",
@@ -53289,7 +53289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.384974+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849948+00:00"
               },
               "deterministic": true
             },
@@ -53302,7 +53302,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.449061+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660700+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -53341,7 +53341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:48.385041+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53354,7 +53354,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.449119+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660731+00:00"
           },
           "uid": {
             "type": "string",
@@ -53371,7 +53371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:48.385076+00:00"
+                "validatedAt": "2026-05-09T01:32:16.849993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53385,7 +53385,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.449149+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660747+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of authentication is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -53453,7 +53453,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.385172+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53496,7 +53496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.385265+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53539,7 +53539,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.385352+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53607,7 +53607,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.385444+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53649,7 +53649,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.385537+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53699,8 +53699,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for authenticationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for authenticationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/authentication_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -53712,8 +53712,8 @@
           "description": "Minimum configuration for authenticationReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for authenticationReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for authenticationReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/authentication_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -53827,7 +53827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:48.385950+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53865,7 +53865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.386031+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53877,7 +53877,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.449532+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660952+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -53896,7 +53896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:48.386083+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53947,7 +53947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:48.386131+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53959,7 +53959,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.449574+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.660974+00:00"
           },
           "url": {
             "type": "string",
@@ -53997,7 +53997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:48.386206+00:00"
+                "validatedAt": "2026-05-09T01:32:16.850504+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -54041,8 +54041,8 @@
           "description": "Minimum configuration for schemaSecretEncodingType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSecretEncodingType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_secret_encoding_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -54097,8 +54097,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for authorization_serverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for authorization_serverCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/authorization_servers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -54165,7 +54165,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.515318+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54239,7 +54239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.515388+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690524+00:00"
               },
               "deterministic": true
             },
@@ -54252,7 +54252,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.504754+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.686816+00:00"
           },
           "namespace": {
             "type": "string",
@@ -54282,7 +54282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.515429+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690544+00:00"
               },
               "deterministic": true
             },
@@ -54295,7 +54295,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.504787+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.686833+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -54398,7 +54398,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.504890+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.686886+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -54458,7 +54458,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.515633+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54488,7 +54488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:52.515701+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54556,7 +54556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:09:52.515763+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54619,7 +54619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:52.515833+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54631,7 +54631,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.504999+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.686942+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -54697,7 +54697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.515886+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690736+00:00"
               },
               "deterministic": true
             },
@@ -54710,7 +54710,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505070+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.686979+00:00"
           },
           "namespace": {
             "type": "string",
@@ -54739,7 +54739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.515924+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690756+00:00"
               },
               "deterministic": true
             },
@@ -54752,7 +54752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505100+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.686994+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -54791,7 +54791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:52.515993+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54804,7 +54804,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505158+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.687025+00:00"
           },
           "uid": {
             "type": "string",
@@ -54822,7 +54822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:52.516028+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54836,7 +54836,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505189+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.687041+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of authorization_server is returned in 'List'.",
@@ -54886,8 +54886,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for authorization_serverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for authorization_serverReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/authorization_server_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -54899,8 +54899,8 @@
           "description": "Minimum configuration for authorization_serverReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for authorization_serverReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for authorization_serverReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/authorization_server_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -54939,7 +54939,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.516121+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54983,8 +54983,8 @@
           "description": "Minimum configuration for authorization_serverStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for authorization_serverStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for authorization_serverStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/authorization_server_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -55082,7 +55082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.516199+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690876+00:00"
               },
               "deterministic": true
             },
@@ -55095,7 +55095,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505290+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.687092+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55124,7 +55124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.516236+00:00"
+                "validatedAt": "2026-05-09T01:32:18.690892+00:00"
               },
               "deterministic": true
             },
@@ -55137,7 +55137,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505319+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.687108+00:00"
           }
         },
         "x-f5xc-description-short": "Request message for UpdateAuthorizationServer API.",
@@ -55165,8 +55165,8 @@
           "description": "Minimum configuration for authorization_serverUpdateAuthorizationServerResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for authorization_serverUpdateAuthorizationServerResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for authorization_serverUpdateAuthorizationServerResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/authorization_servers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -55195,7 +55195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:52.517158+00:00"
+                "validatedAt": "2026-05-09T01:32:18.691302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55208,7 +55208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505856+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.687388+00:00"
           },
           "name": {
             "type": "string",
@@ -55241,7 +55241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.517194+00:00"
+                "validatedAt": "2026-05-09T01:32:18.691318+00:00"
               },
               "deterministic": true
             },
@@ -55254,7 +55254,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505885+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.687403+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55285,7 +55285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:52.517230+00:00"
+                "validatedAt": "2026-05-09T01:32:18.691334+00:00"
               },
               "deterministic": true
             },
@@ -55298,7 +55298,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505914+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.687418+00:00"
           },
           "tenant": {
             "type": "string",
@@ -55317,7 +55317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:52.517273+00:00"
+                "validatedAt": "2026-05-09T01:32:18.691353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55331,7 +55331,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505943+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.687434+00:00"
           },
           "uid": {
             "type": "string",
@@ -55350,7 +55350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:52.517306+00:00"
+                "validatedAt": "2026-05-09T01:32:18.691367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55365,7 +55365,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.505974+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.687450+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -55416,7 +55416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.589576+00:00"
+                "validatedAt": "2026-05-09T01:33:10.753852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55456,7 +55456,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.589694+00:00"
+                "validatedAt": "2026-05-09T01:33:10.753897+00:00"
               },
               "deterministic": true
             },
@@ -55489,7 +55489,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.589776+00:00"
+                "validatedAt": "2026-05-09T01:33:10.753934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55521,7 +55521,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.589853+00:00"
+                "validatedAt": "2026-05-09T01:33:10.753973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55598,7 +55598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.589899+00:00"
+                "validatedAt": "2026-05-09T01:33:10.753994+00:00"
               },
               "deterministic": true
             },
@@ -55611,7 +55611,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.905646+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.822678+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55641,7 +55641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.589939+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754014+00:00"
               },
               "deterministic": true
             },
@@ -55654,7 +55654,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.905679+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.822694+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -55709,7 +55709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590007+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55810,7 +55810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590108+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55903,8 +55903,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for child_tenantReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for child_tenantReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/child_tenant_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -55916,8 +55916,8 @@
           "description": "Minimum configuration for child_tenantReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for child_tenantReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for child_tenantReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/child_tenant_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -55940,8 +55940,8 @@
           "description": "Minimum configuration for contactContactType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for contactContactType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for contactContactType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/contact_contact_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -55972,7 +55972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590218+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55998,7 +55998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590271+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56024,7 +56024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590315+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56050,7 +56050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590357+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56184,7 +56184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590449+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56209,7 +56209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590497+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56242,7 +56242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:11:50.590551+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754297+00:00"
               },
               "deterministic": true
             },
@@ -56269,7 +56269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590605+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56294,7 +56294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.590654+00:00"
+                "validatedAt": "2026-05-09T01:33:10.754334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56440,8 +56440,8 @@
           "description": "Minimum configuration for customer_supportSupportService",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportService\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportService\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_services\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -56465,8 +56465,8 @@
           "description": "Minimum configuration for customer_supportSupportTicketPriority",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportTicketPriority\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportTicketPriority\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_ticket_priorities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -56494,8 +56494,8 @@
           "description": "Minimum configuration for customer_supportSupportTicketStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportTicketStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportTicketStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_ticket_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -56523,8 +56523,8 @@
           "description": "Minimum configuration for customer_supportSupportTicketType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportTicketType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportTicketType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_ticket_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -56569,8 +56569,8 @@
           "description": "Minimum configuration for customer_supportSupportTopic",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for customer_supportSupportTopic\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for customer_supportSupportTopic\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/customer_support_support_topics\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -56599,8 +56599,8 @@
           "description": "Minimum configuration for ioschemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for ioschemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for ioschemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/ioschema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -56615,8 +56615,8 @@
           "description": "Minimum configuration for schemaCRMInfo",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaCRMInfo\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaCRMInfo\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_c_r_m_infos\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -56643,7 +56643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.592866+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56668,7 +56668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.592909+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56693,7 +56693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.592946+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56721,7 +56721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.592992+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56746,7 +56746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593035+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56772,7 +56772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593085+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56797,7 +56797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593125+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56822,7 +56822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593172+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56847,7 +56847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593215+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56902,8 +56902,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemacustomer_supportCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemacustomer_supportCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemacustomer_supports\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -56961,7 +56961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593280+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57007,7 +57007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:50.593353+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57019,7 +57019,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.907395+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.823591+00:00"
           },
           "ongoing": {
             "type": "boolean",
@@ -57052,7 +57052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593409+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57097,7 +57097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593474+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57122,7 +57122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593517+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57150,7 +57150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593560+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57212,8 +57212,8 @@
           "description": "Minimum configuration for schemacustomer_supportErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemacustomer_supportErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemacustomer_supportErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemacustomer_support_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "support"
@@ -57239,7 +57239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593627+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57267,7 +57267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593671+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57316,7 +57316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:11:50.593742+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755703+00:00"
               },
               "deterministic": true
             },
@@ -57365,7 +57365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:50.593814+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57377,7 +57377,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.907577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.823689+00:00"
           },
           "escalated": {
             "type": "boolean",
@@ -57440,7 +57440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593890+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57485,7 +57485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.593955+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57514,7 +57514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:11:50.593991+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755813+00:00"
               },
               "deterministic": true
             },
@@ -57540,7 +57540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.594035+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57568,7 +57568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.594078+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57598,7 +57598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.594127+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57714,7 +57714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:50.594207+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57726,7 +57726,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.907793+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.823798+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -57792,7 +57792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.594259+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755931+00:00"
               },
               "deterministic": true
             },
@@ -57805,7 +57805,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.907862+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.823834+00:00"
           },
           "namespace": {
             "type": "string",
@@ -57834,7 +57834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.594295+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755948+00:00"
               },
               "deterministic": true
             },
@@ -57847,7 +57847,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.907891+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.823850+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -57886,7 +57886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.594359+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57899,7 +57899,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.907947+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.823880+00:00"
           },
           "uid": {
             "type": "string",
@@ -57917,7 +57917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.594392+00:00"
+                "validatedAt": "2026-05-09T01:33:10.755990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57931,7 +57931,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.907978+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.823896+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of customer_support is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -58059,7 +58059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:50.594498+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58085,7 +58085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.594538+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58138,7 +58138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.594595+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58221,7 +58221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.594867+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756207+00:00"
               },
               "deterministic": true
             },
@@ -58234,7 +58234,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.908201+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824013+00:00"
           },
           "support_request_count": {
             "$ref": "#/components/schemas/tenant_managementSupportTicketInfo"
@@ -58320,7 +58320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.594953+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58364,7 +58364,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.595016+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58498,7 +58498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.595116+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58565,7 +58565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:50.595169+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58638,7 +58638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.595220+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58682,8 +58682,8 @@
           "description": "Minimum configuration for tenant_managementTenantStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementTenantStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementTenantStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_management_tenant_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -58709,8 +58709,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementchild_tenantCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementchild_tenantCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_managementchild_tenants\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -58774,7 +58774,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.595327+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58824,7 +58824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.595410+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58835,7 +58835,7 @@
             },
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.908491+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824170+00:00"
           },
           "tenant_profile": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -58884,8 +58884,8 @@
           "description": "Minimum configuration for tenant_managementchild_tenantFSMState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementchild_tenantFSMState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementchild_tenantFSMState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_managementchild_tenant_f_s_m_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -58976,7 +58976,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.908611+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824227+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -59033,7 +59033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.595596+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59086,7 +59086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.595683+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59097,7 +59097,7 @@
             },
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.908699+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824272+00:00"
           },
           "status": {
             "$ref": "#/components/schemas/tenant_managementchild_tenantFSMState"
@@ -59168,7 +59168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:50.595744+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59231,7 +59231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:50.595809+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59243,7 +59243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.908784+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824316+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -59309,7 +59309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.595860+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756644+00:00"
               },
               "deterministic": true
             },
@@ -59322,7 +59322,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.908852+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824353+00:00"
           },
           "namespace": {
             "type": "string",
@@ -59351,7 +59351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.595900+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756661+00:00"
               },
               "deterministic": true
             },
@@ -59364,7 +59364,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.908881+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824368+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -59403,7 +59403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.595976+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59416,7 +59416,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.908938+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824398+00:00"
           },
           "uid": {
             "type": "string",
@@ -59433,7 +59433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:50.596012+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59447,7 +59447,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.908968+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824414+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of child_tenant is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -59504,7 +59504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.596101+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59625,7 +59625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.596224+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59674,7 +59674,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:50.596297+00:00"
+                "validatedAt": "2026-05-09T01:33:10.756851+00:00"
               },
               "deterministic": true
             },
@@ -59686,7 +59686,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:31.909070+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.824468+00:00"
           }
         },
         "x-f5xc-description-short": "LinkRefType This message defines a reference to hyperlink that can be accessed via web.",
@@ -59723,7 +59723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.351302+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59749,7 +59749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.351359+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59787,7 +59787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.351411+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59799,7 +59799,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.055003+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.890311+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -59859,7 +59859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.351486+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59926,7 +59926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:55.351562+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59938,7 +59938,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.055076+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.890347+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -60004,7 +60004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.351637+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862814+00:00"
               },
               "deterministic": true
             },
@@ -60017,7 +60017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.055147+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.890384+00:00"
           },
           "namespace": {
             "type": "string",
@@ -60046,7 +60046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.351675+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862830+00:00"
               },
               "deterministic": true
             },
@@ -60059,7 +60059,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.055177+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.890400+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -60098,7 +60098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.351743+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60111,7 +60111,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.055235+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.890431+00:00"
           },
           "uid": {
             "type": "string",
@@ -60128,7 +60128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.351777+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60142,7 +60142,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.055266+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.890447+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -60219,7 +60219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.351821+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862891+00:00"
               },
               "deterministic": true
             },
@@ -60232,7 +60232,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.055308+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.890469+00:00"
           },
           "namespace": {
             "type": "string",
@@ -60262,7 +60262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.351856+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862907+00:00"
               },
               "deterministic": true
             },
@@ -60275,7 +60275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.055337+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.890484+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -60334,7 +60334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:55.351912+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60407,7 +60407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.351959+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862951+00:00"
               },
               "deterministic": true
             },
@@ -60420,7 +60420,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.055401+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.890517+00:00"
           }
         },
         "x-f5xc-description-short": "Request to migrate child tenants to a specified child tenant manager.",
@@ -60458,7 +60458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.352019+00:00"
+                "validatedAt": "2026-05-09T01:33:12.862975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60551,8 +60551,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for child_tenant_managerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for child_tenant_managerReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/child_tenant_manager_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -60564,8 +60564,8 @@
           "description": "Minimum configuration for child_tenant_managerReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for child_tenant_managerReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for child_tenant_managerReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/child_tenant_manager_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -60599,7 +60599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.352715+00:00"
+                "validatedAt": "2026-05-09T01:33:12.863267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60631,7 +60631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.352767+00:00"
+                "validatedAt": "2026-05-09T01:33:12.863288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60677,8 +60677,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementchild_tenant_managerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementchild_tenant_managerCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_managementchild_tenant_managers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -60746,7 +60746,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.355462+00:00"
+                "validatedAt": "2026-05-09T01:33:12.864437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60903,7 +60903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.355625+00:00"
+                "validatedAt": "2026-05-09T01:33:12.864497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60974,7 +60974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:11:55.355688+00:00"
+                "validatedAt": "2026-05-09T01:33:12.864524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61037,7 +61037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:11:55.355758+00:00"
+                "validatedAt": "2026-05-09T01:33:12.864551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61049,7 +61049,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.057326+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.891534+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -61115,7 +61115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.355811+00:00"
+                "validatedAt": "2026-05-09T01:33:12.864573+00:00"
               },
               "deterministic": true
             },
@@ -61128,7 +61128,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.057395+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.891571+00:00"
           },
           "namespace": {
             "type": "string",
@@ -61157,7 +61157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.355846+00:00"
+                "validatedAt": "2026-05-09T01:33:12.864589+00:00"
               },
               "deterministic": true
             },
@@ -61170,7 +61170,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.057424+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.891586+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -61193,7 +61193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.355898+00:00"
+                "validatedAt": "2026-05-09T01:33:12.864610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61206,7 +61206,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.057471+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.891611+00:00"
           },
           "uid": {
             "type": "string",
@@ -61224,7 +61224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:11:55.355931+00:00"
+                "validatedAt": "2026-05-09T01:33:12.864624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61238,7 +61238,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:32.057502+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:04.891627+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of child_tenant_manager is returned in 'List'.",
@@ -61304,7 +61304,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:11:55.356000+00:00"
+                "validatedAt": "2026-05-09T01:33:12.864655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61349,7 +61349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:05.478020+00:00"
+                "validatedAt": "2026-05-09T01:33:17.318898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61374,7 +61374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:05.478087+00:00"
+                "validatedAt": "2026-05-09T01:33:17.318925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61444,7 +61444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:12:54.519087+00:00"
+                "validatedAt": "2026-05-09T01:33:39.113083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61480,8 +61480,8 @@
           "description": "Minimum configuration for cloud_user_accountDiscoverCloudNetworksResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for cloud_user_accountDiscoverCloudNetworksResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for cloud_user_accountDiscoverCloudNetworksResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/cloud_user_account_discover_cloud_networks_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -61507,8 +61507,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for contactCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for contactCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/contacts\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -61562,7 +61562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.058553+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61586,7 +61586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.058677+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61610,7 +61610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.058755+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61637,7 +61637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.058839+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61661,7 +61661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.058896+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61686,7 +61686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.058949+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61710,7 +61710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.058992+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61734,7 +61734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059040+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61758,7 +61758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059084+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61841,7 +61841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:33.059138+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718495+00:00"
               },
               "deterministic": true
             },
@@ -61854,7 +61854,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.178838+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.869567+00:00"
           },
           "namespace": {
             "type": "string",
@@ -61884,7 +61884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:33.059179+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718514+00:00"
               },
               "deterministic": true
             },
@@ -61897,7 +61897,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.178871+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.869584+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -62000,7 +62000,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.178972+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.869638+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -62047,7 +62047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059315+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62071,7 +62071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059360+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62095,7 +62095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059399+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62122,7 +62122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059445+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62146,7 +62146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059489+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62171,7 +62171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059540+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62195,7 +62195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059608+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62219,7 +62219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059664+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62243,7 +62243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059709+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62318,7 +62318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:14:33.059768+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62380,7 +62380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:14:33.059838+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62392,7 +62392,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.179148+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.869741+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -62458,7 +62458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:33.059893+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718808+00:00"
               },
               "deterministic": true
             },
@@ -62471,7 +62471,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.179219+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.869778+00:00"
           },
           "namespace": {
             "type": "string",
@@ -62500,7 +62500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:14:33.059929+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718825+00:00"
               },
               "deterministic": true
             },
@@ -62513,7 +62513,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.179248+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.869794+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -62552,7 +62552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.059994+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62565,7 +62565,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.179307+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.869828+00:00"
           },
           "uid": {
             "type": "string",
@@ -62582,7 +62582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060029+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62596,7 +62596,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:36.179338+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:06.869844+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of contact is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -62646,8 +62646,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for contactReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for contactReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/contact_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -62659,8 +62659,8 @@
           "description": "Minimum configuration for contactReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for contactReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for contactReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/contact_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -62686,7 +62686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060084+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62710,7 +62710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060128+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62734,7 +62734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060166+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62761,7 +62761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060213+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62785,7 +62785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060256+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62810,7 +62810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060306+00:00"
+                "validatedAt": "2026-05-09T01:34:22.718987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62834,7 +62834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060346+00:00"
+                "validatedAt": "2026-05-09T01:34:22.719006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62858,7 +62858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060394+00:00"
+                "validatedAt": "2026-05-09T01:34:22.719027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62882,7 +62882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:14:33.060438+00:00"
+                "validatedAt": "2026-05-09T01:34:22.719053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63021,7 +63021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.961073+00:00"
+                "validatedAt": "2026-05-09T01:36:49.773137+00:00"
               },
               "deterministic": true
             },
@@ -63034,7 +63034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.805228+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.980499+00:00"
           },
           "namespace": {
             "type": "string",
@@ -63064,7 +63064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.961109+00:00"
+                "validatedAt": "2026-05-09T01:36:49.773162+00:00"
               },
               "deterministic": true
             },
@@ -63077,7 +63077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.805258+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.980515+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -63132,7 +63132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:02.961176+00:00"
+                "validatedAt": "2026-05-09T01:36:49.773194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63228,7 +63228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:02.961275+00:00"
+                "validatedAt": "2026-05-09T01:36:49.773239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63253,7 +63253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:02.961323+00:00"
+                "validatedAt": "2026-05-09T01:36:49.773259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63380,7 +63380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.961418+00:00"
+                "validatedAt": "2026-05-09T01:36:49.773302+00:00"
               },
               "deterministic": true
             },
@@ -63393,7 +63393,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.805411+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.980598+00:00"
           },
           "tenant_status": {
             "$ref": "#/components/schemas/tenant_managementTenantStatus"
@@ -63436,8 +63436,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for managed_tenantReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for managed_tenantReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/managed_tenant_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -63449,8 +63449,8 @@
           "description": "Minimum configuration for managed_tenantReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for managed_tenantReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for managed_tenantReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/managed_tenant_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -63476,8 +63476,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementmanaged_tenantCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementmanaged_tenantCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_managementmanaged_tenants\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -63547,7 +63547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.965451+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63580,7 +63580,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.965532+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63693,7 +63693,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.807770+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.981899+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -63756,7 +63756,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.965695+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63792,7 +63792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.965777+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63861,7 +63861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:02.965833+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63924,7 +63924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:02.965899+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63936,7 +63936,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.807876+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.981956+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -64002,7 +64002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.965949+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775342+00:00"
               },
               "deterministic": true
             },
@@ -64015,7 +64015,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.807945+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.981993+00:00"
           },
           "namespace": {
             "type": "string",
@@ -64044,7 +64044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.965985+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775359+00:00"
               },
               "deterministic": true
             },
@@ -64057,7 +64057,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.807975+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.982008+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -64096,7 +64096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:02.966051+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64109,7 +64109,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.808032+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.982039+00:00"
           },
           "uid": {
             "type": "string",
@@ -64126,7 +64126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:02.966083+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64140,7 +64140,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.808062+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.982055+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of managed_tenant is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -64205,7 +64205,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:02.966143+00:00"
+                "validatedAt": "2026-05-09T01:36:49.775431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64312,7 +64312,7 @@
             "maxLength": 43,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.774404+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427107+00:00"
           },
           "status": {
             "type": "string",
@@ -64334,7 +64334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.822544+00:00"
+                "validatedAt": "2026-05-09T01:37:14.858787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64346,7 +64346,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.774438+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427124+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -64418,8 +64418,8 @@
           "description": "Minimum configuration for app_firewallAppFirewallViolationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_firewallAppFirewallViolationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_firewallAppFirewallViolationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_firewall_app_firewall_violation_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -64456,7 +64456,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.822989+00:00"
+                "validatedAt": "2026-05-09T01:37:14.858938+00:00"
               },
               "deterministic": true
             },
@@ -64482,7 +64482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.823036+00:00"
+                "validatedAt": "2026-05-09T01:37:14.858957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64532,7 +64532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:57.823076+00:00"
+                "validatedAt": "2026-05-09T01:37:14.858976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64557,7 +64557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.823124+00:00"
+                "validatedAt": "2026-05-09T01:37:14.858996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64621,7 +64621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.823175+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64648,7 +64648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:57.823228+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64698,7 +64698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.823278+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64728,7 +64728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:57.823332+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64786,8 +64786,8 @@
           "description": "Minimum configuration for namespaceAccessControlType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceAccessControlType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceAccessControlType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_access_control_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -65009,7 +65009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.823487+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859163+00:00"
               },
               "deterministic": true
             },
@@ -65022,7 +65022,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.774909+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427373+00:00"
           }
         },
         "x-f5xc-description-short": "Request shape for GET API Endpoints Stats All Namespaces.",
@@ -65073,7 +65073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.823525+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859181+00:00"
               },
               "deterministic": true
             },
@@ -65086,7 +65086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.774941+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427392+00:00"
           },
           "vhosts_filter": {
             "type": "array",
@@ -65134,7 +65134,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.823624+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65298,7 +65298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.823761+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859280+00:00"
               },
               "deterministic": true
             },
@@ -65311,7 +65311,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.775075+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427460+00:00"
           },
           "nginx_one_server_filter": {
             "$ref": "#/components/schemas/namespaceNGINXOneServerInventoryFilterType"
@@ -65578,7 +65578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:57.823978+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65590,7 +65590,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.775308+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427580+00:00"
           },
           "host_name": {
             "type": "string",
@@ -65606,7 +65606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.824028+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65644,7 +65644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.824063+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859411+00:00"
               },
               "deterministic": true
             },
@@ -65657,7 +65657,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.775349+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427601+00:00"
           },
           "server_name": {
             "type": "string",
@@ -65673,7 +65673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.824112+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65697,7 +65697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.824157+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65709,7 +65709,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.775390+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427623+00:00"
           },
           "waf_enforcement_mode": {
             "type": "string",
@@ -65724,7 +65724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.824212+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65748,7 +65748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.824266+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65802,7 +65802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.824321+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65828,7 +65828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.824370+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65854,7 +65854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.824419+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65880,7 +65880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.824467+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65944,7 +65944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.824504+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859610+00:00"
               },
               "deterministic": true
             },
@@ -65957,7 +65957,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.775484+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427672+00:00"
           }
         },
         "x-f5xc-description-short": "CascadeDeleteRequest contains the name of the namespace that has to be deleted along with the objects configured under the namespace.",
@@ -65999,7 +65999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:57.824544+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66045,8 +66045,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespaces\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -66112,7 +66112,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.824646+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66150,7 +66150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.824684+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859688+00:00"
               },
               "deterministic": true
             },
@@ -66163,7 +66163,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.775617+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427732+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -66247,7 +66247,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.824770+00:00"
+                "validatedAt": "2026-05-09T01:37:14.859729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66561,7 +66561,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.775815+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.427831+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -67410,7 +67410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.825444+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67433,7 +67433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.825501+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67500,7 +67500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.825616+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67527,7 +67527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.825657+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67556,7 +67556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.825722+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67596,7 +67596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.825801+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67646,7 +67646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.825852+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860191+00:00"
               },
               "deterministic": true
             },
@@ -67659,7 +67659,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.776618+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428292+00:00"
           },
           "namespace": {
             "type": "string",
@@ -67687,7 +67687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.825889+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860209+00:00"
               },
               "deterministic": true
             },
@@ -67700,7 +67700,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.776650+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428311+00:00"
           },
           "namespace_service_policy_enabled": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -67739,7 +67739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.825970+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67768,7 +67768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.826023+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67794,7 +67794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.826081+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67831,7 +67831,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.826148+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67936,7 +67936,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.826187+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860344+00:00"
               },
               "deterministic": true
             },
@@ -67949,7 +67949,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.776833+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428408+00:00"
           },
           "namespace": {
             "type": "string",
@@ -67977,7 +67977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.826222+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860361+00:00"
               },
               "deterministic": true
             },
@@ -67990,7 +67990,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.776864+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428425+00:00"
           }
         },
         "x-f5xc-description-short": "HTTP Loadbalancer WAF Filter Inventory Results.",
@@ -68049,7 +68049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:57.826276+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68111,7 +68111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:57.826342+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68123,7 +68123,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.776933+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428460+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -68189,7 +68189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.826395+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860438+00:00"
               },
               "deterministic": true
             },
@@ -68202,7 +68202,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777003+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428497+00:00"
           },
           "namespace": {
             "type": "string",
@@ -68231,7 +68231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.826429+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860455+00:00"
               },
               "deterministic": true
             },
@@ -68244,7 +68244,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777034+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428513+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -68283,7 +68283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.826495+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68296,7 +68296,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777093+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428544+00:00"
           },
           "uid": {
             "type": "string",
@@ -68313,7 +68313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.826529+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68327,7 +68327,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777124+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428560+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of namespace is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -68391,7 +68391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.826567+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860517+00:00"
               },
               "deterministic": true
             },
@@ -68404,7 +68404,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777157+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428577+00:00"
           }
         },
         "x-f5xc-description-short": "Request body of LookupUserRoles request.",
@@ -68595,7 +68595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.826708+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68634,7 +68634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.826745+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860587+00:00"
               },
               "deterministic": true
             },
@@ -68647,7 +68647,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777275+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428638+00:00"
           },
           "nginx_one_object_id": {
             "type": "string",
@@ -68662,7 +68662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.826800+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68688,7 +68688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.826858+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68713,7 +68713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.826914+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68750,7 +68750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.826985+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68774,7 +68774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.827041+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68805,7 +68805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.827107+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68829,7 +68829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.827160+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68924,7 +68924,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827248+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68962,7 +68962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827288+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860827+00:00"
               },
               "deterministic": true
             },
@@ -68975,7 +68975,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777413+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428711+00:00"
           }
         },
         "x-f5xc-description-short": "NamespaceAPIListReq holds the namespace and its associated APIs.",
@@ -69042,7 +69042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827343+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860851+00:00"
               },
               "deterministic": true
             },
@@ -69055,7 +69055,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777456+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428733+00:00"
           }
         },
         "x-f5xc-description-short": "NamespaceAPIListResp holds the namespace and its associated APIs.",
@@ -69083,8 +69083,8 @@
           "description": "Minimum configuration for namespaceNetworkingInventoryRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceNetworkingInventoryRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceNetworkingInventoryRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_networking_inventory_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -69213,8 +69213,8 @@
           "description": "Minimum configuration for namespacePublicAdvertiseChoice",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespacePublicAdvertiseChoice\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespacePublicAdvertiseChoice\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_public_advertise_choices\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -69240,8 +69240,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -69253,8 +69253,8 @@
           "description": "Minimum configuration for namespaceReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -69290,7 +69290,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827513+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69327,7 +69327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827550+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860942+00:00"
               },
               "deterministic": true
             },
@@ -69340,7 +69340,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777595+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428800+00:00"
           }
         },
         "x-f5xc-description-short": "SetActiveAlertPoliciesRequest is the shape of the request for SetActiveAlertPolicies.",
@@ -69368,8 +69368,8 @@
           "description": "Minimum configuration for namespaceSetActiveAlertPoliciesResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceSetActiveAlertPoliciesResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceSetActiveAlertPoliciesResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_set_active_alert_policies_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -69408,7 +69408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827602+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860961+00:00"
               },
               "deterministic": true
             },
@@ -69421,7 +69421,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777631+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428817+00:00"
           },
           "network_policies": {
             "type": "array",
@@ -69447,7 +69447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827665+00:00"
+                "validatedAt": "2026-05-09T01:37:14.860989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69483,8 +69483,8 @@
           "description": "Minimum configuration for namespaceSetActiveNetworkPoliciesResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceSetActiveNetworkPoliciesResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceSetActiveNetworkPoliciesResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_set_active_network_policies_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -69523,7 +69523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827706+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861007+00:00"
               },
               "deterministic": true
             },
@@ -69536,7 +69536,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777675+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428839+00:00"
           },
           "service_policies": {
             "type": "array",
@@ -69563,7 +69563,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827768+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69599,8 +69599,8 @@
           "description": "Minimum configuration for namespaceSetActiveServicePoliciesResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceSetActiveServicePoliciesResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceSetActiveServicePoliciesResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_set_active_service_policies_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -69637,7 +69637,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827834+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69674,7 +69674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827882+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861085+00:00"
               },
               "deterministic": true
             },
@@ -69687,7 +69687,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777729+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428867+00:00"
           }
         },
         "x-f5xc-description-short": "SetFastACLsForInternetVIPsRequest contains list of FastACLs refs that should be applied to the Internet VIPs.",
@@ -69716,8 +69716,8 @@
           "description": "Minimum configuration for namespaceSetFastACLsForInternetVIPsResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceSetFastACLsForInternetVIPsResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceSetFastACLsForInternetVIPsResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_set_fast_a_c_ls_for_internet_v_i_ps_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -69740,8 +69740,8 @@
           "description": "Minimum configuration for namespaceSeverity",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for namespaceSeverity\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for namespaceSeverity\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/namespace_severities\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -69776,7 +69776,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.827967+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69810,7 +69810,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.828049+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69848,7 +69848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.828088+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861191+00:00"
               },
               "deterministic": true
             },
@@ -69861,7 +69861,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777784+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428896+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -70123,7 +70123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.828263+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861266+00:00"
               },
               "deterministic": true
             },
@@ -70136,7 +70136,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777937+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428976+00:00"
           },
           "namespace": {
             "type": "string",
@@ -70164,7 +70164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.828299+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861283+00:00"
               },
               "deterministic": true
             },
@@ -70177,7 +70177,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.777967+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.428995+00:00"
           },
           "namespace_service_policy": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -70340,7 +70340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.828409+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861330+00:00"
               },
               "deterministic": true
             },
@@ -70353,7 +70353,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.778098+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.429065+00:00"
           }
         },
         "x-f5xc-description-short": "Third Party Application Inventory Results.",
@@ -70519,7 +70519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.828512+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861374+00:00"
               },
               "deterministic": true
             },
@@ -70532,7 +70532,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.778185+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.429109+00:00"
           },
           "namespace": {
             "type": "string",
@@ -70560,7 +70560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.828548+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861390+00:00"
               },
               "deterministic": true
             },
@@ -70573,7 +70573,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.778219+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.429126+00:00"
           },
           "private_advertisement": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -70635,7 +70635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.828611+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861414+00:00"
               },
               "deterministic": true
             },
@@ -70648,7 +70648,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.778280+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.429170+00:00"
           }
         },
         "x-f5xc-description-short": "Request body of UpdateAllowAdvertiseOnPublic request.",
@@ -70734,7 +70734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:20:57.828656+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861434+00:00"
               },
               "deterministic": true
             },
@@ -70747,7 +70747,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.778325+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.429194+00:00"
           },
           "validator_evaluation": {
             "type": "object",
@@ -70779,7 +70779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.828703+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70791,7 +70791,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.778367+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.429216+00:00"
           }
         },
         "x-f5xc-description-short": "Request body of ValidateRulesReq request.",
@@ -70830,7 +70830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.828746+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70905,7 +70905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.828815+00:00"
+                "validatedAt": "2026-05-09T01:37:14.861503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70943,8 +70943,8 @@
           "description": "Minimum configuration for schemanamespaceCreateSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemanamespaceCreateSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemanamespaceCreateSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemanamespaces\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -70960,8 +70960,8 @@
           "description": "Minimum configuration for schemanamespaceGetSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemanamespaceGetSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemanamespaceGetSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemanamespaces\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -70977,8 +70977,8 @@
           "description": "Minimum configuration for schemanamespaceReplaceSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemanamespaceReplaceSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemanamespaceReplaceSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemanamespace_replace_spec_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -71065,7 +71065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:20:57.830879+00:00"
+                "validatedAt": "2026-05-09T01:37:14.862408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71114,7 +71114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:20:57.830939+00:00"
+                "validatedAt": "2026-05-09T01:37:14.862434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71126,7 +71126,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.779606+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.429844+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -71144,7 +71144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.830989+00:00"
+                "validatedAt": "2026-05-09T01:37:14.862457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71173,7 +71173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.831042+00:00"
+                "validatedAt": "2026-05-09T01:37:14.862481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71185,7 +71185,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.779655+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.429870+00:00"
           },
           "value": {
             "type": "string",
@@ -71201,7 +71201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:20:57.831088+00:00"
+                "validatedAt": "2026-05-09T01:37:14.862500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71213,7 +71213,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.779687+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.429886+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -71256,8 +71256,8 @@
           "description": "Minimum configuration for virtual_hostVirtualHostType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for virtual_hostVirtualHostType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for virtual_hostVirtualHostType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/virtual_host_virtual_host_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -71342,7 +71342,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.953641+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.512659+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -71407,7 +71407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:02.827044+00:00"
+                "validatedAt": "2026-05-09T01:37:17.119649+00:00"
               },
               "deterministic": true
             },
@@ -71420,7 +71420,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.953689+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.512682+00:00"
           },
           "role": {
             "type": "array",
@@ -71451,7 +71451,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:02.827172+00:00"
+                "validatedAt": "2026-05-09T01:37:17.119689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71489,7 +71489,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:02.827250+00:00"
+                "validatedAt": "2026-05-09T01:37:17.119722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71557,7 +71557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:21:02.827307+00:00"
+                "validatedAt": "2026-05-09T01:37:17.119748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71620,7 +71620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:21:02.827379+00:00"
+                "validatedAt": "2026-05-09T01:37:17.119781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71632,7 +71632,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.953779+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.512728+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -71698,7 +71698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:02.827433+00:00"
+                "validatedAt": "2026-05-09T01:37:17.119807+00:00"
               },
               "deterministic": true
             },
@@ -71711,7 +71711,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.953850+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.512764+00:00"
           },
           "namespace": {
             "type": "string",
@@ -71740,7 +71740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:02.827471+00:00"
+                "validatedAt": "2026-05-09T01:37:17.119824+00:00"
               },
               "deterministic": true
             },
@@ -71753,7 +71753,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.953880+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.512780+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -71792,7 +71792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:02.827538+00:00"
+                "validatedAt": "2026-05-09T01:37:17.119852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71805,7 +71805,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.953939+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.512811+00:00"
           },
           "uid": {
             "type": "string",
@@ -71822,7 +71822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:02.827572+00:00"
+                "validatedAt": "2026-05-09T01:37:17.119867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71836,7 +71836,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:43.953970+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.512827+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of namespace_role is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -71965,7 +71965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:25.895551+00:00"
+                "validatedAt": "2026-05-09T01:37:27.573473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72001,7 +72001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:25.895606+00:00"
+                "validatedAt": "2026-05-09T01:37:27.573493+00:00"
               },
               "deterministic": true
             },
@@ -72014,7 +72014,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.363569+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.692198+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -72092,7 +72092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:25.899890+00:00"
+                "validatedAt": "2026-05-09T01:37:27.575417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72129,7 +72129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:25.899927+00:00"
+                "validatedAt": "2026-05-09T01:37:27.575434+00:00"
               },
               "deterministic": true
             },
@@ -72142,7 +72142,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.366651+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.693771+00:00"
           },
           "namespace": {
             "type": "string",
@@ -72169,7 +72169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:21:25.899966+00:00"
+                "validatedAt": "2026-05-09T01:37:27.575453+00:00"
               },
               "deterministic": true
             },
@@ -72182,7 +72182,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:44.366683+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:10.693786+00:00"
           },
           "vip_type": {
             "type": "string",
@@ -72196,7 +72196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:21:25.900011+00:00"
+                "validatedAt": "2026-05-09T01:37:27.575472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72303,7 +72303,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.782028+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.346298+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -72369,7 +72369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:22:41.622810+00:00"
+                "validatedAt": "2026-05-09T01:38:01.753866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72432,7 +72432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:22:41.622880+00:00"
+                "validatedAt": "2026-05-09T01:38:01.753897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72444,7 +72444,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.782105+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.346338+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -72510,7 +72510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:41.622935+00:00"
+                "validatedAt": "2026-05-09T01:38:01.753921+00:00"
               },
               "deterministic": true
             },
@@ -72523,7 +72523,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.782176+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.346375+00:00"
           },
           "namespace": {
             "type": "string",
@@ -72552,7 +72552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:41.622971+00:00"
+                "validatedAt": "2026-05-09T01:38:01.753938+00:00"
               },
               "deterministic": true
             },
@@ -72565,7 +72565,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.782205+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.346391+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -72604,7 +72604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:41.623037+00:00"
+                "validatedAt": "2026-05-09T01:38:01.753966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72617,7 +72617,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.782263+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.346422+00:00"
           },
           "uid": {
             "type": "string",
@@ -72634,7 +72634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:41.623071+00:00"
+                "validatedAt": "2026-05-09T01:38:01.753981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72648,7 +72648,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:45.782293+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.346438+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of rbac_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -72695,7 +72695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:22:41.623120+00:00"
+                "validatedAt": "2026-05-09T01:38:01.754010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72809,7 +72809,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:22:41.624758+00:00"
+                "validatedAt": "2026-05-09T01:38:01.754738+00:00"
               },
               "deterministic": true
             },
@@ -72855,8 +72855,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for roleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for roleCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/roles\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -72899,8 +72899,8 @@
           "description": "Minimum configuration for roleCreateSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for roleCreateSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for roleCreateSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/roles\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -72941,7 +72941,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.865983+00:00"
+                "validatedAt": "2026-05-09T01:38:14.821762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72981,7 +72981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866033+00:00"
+                "validatedAt": "2026-05-09T01:38:14.821785+00:00"
               },
               "deterministic": true
             },
@@ -72994,7 +72994,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427019+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.640740+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/roleCreateSpecType"
@@ -73085,7 +73085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:10.866103+00:00"
+                "validatedAt": "2026-05-09T01:38:14.821816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73144,7 +73144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866173+00:00"
+                "validatedAt": "2026-05-09T01:38:14.821848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73183,7 +73183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866211+00:00"
+                "validatedAt": "2026-05-09T01:38:14.821866+00:00"
               },
               "deterministic": true
             },
@@ -73196,7 +73196,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427105+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.640784+00:00"
           },
           "namespace": {
             "type": "string",
@@ -73225,7 +73225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866248+00:00"
+                "validatedAt": "2026-05-09T01:38:14.821884+00:00"
               },
               "deterministic": true
             },
@@ -73238,7 +73238,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427135+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.640800+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/roleReplaceSpecType"
@@ -73309,7 +73309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866294+00:00"
+                "validatedAt": "2026-05-09T01:38:14.821905+00:00"
               },
               "deterministic": true
             },
@@ -73322,7 +73322,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427186+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.640827+00:00"
           },
           "namespace": {
             "type": "string",
@@ -73352,7 +73352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866332+00:00"
+                "validatedAt": "2026-05-09T01:38:14.821922+00:00"
               },
               "deterministic": true
             },
@@ -73365,7 +73365,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427216+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.640842+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -73468,7 +73468,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427314+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.640895+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -73529,7 +73529,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866484+00:00"
+                "validatedAt": "2026-05-09T01:38:14.821992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73587,7 +73587,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866544+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73654,7 +73654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:10.866613+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73716,7 +73716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:10.866682+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73728,7 +73728,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427415+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.640948+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -73793,7 +73793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866735+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822098+00:00"
               },
               "deterministic": true
             },
@@ -73806,7 +73806,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427485+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.640985+00:00"
           },
           "namespace": {
             "type": "string",
@@ -73835,7 +73835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866770+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822114+00:00"
               },
               "deterministic": true
             },
@@ -73848,7 +73848,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427515+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641011+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -73887,7 +73887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.866837+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73900,7 +73900,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427573+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641042+00:00"
           },
           "uid": {
             "type": "string",
@@ -73917,7 +73917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.866872+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73931,7 +73931,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427619+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641058+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of role is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -74012,8 +74012,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for roleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for roleReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/role_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -74025,8 +74025,8 @@
           "description": "Minimum configuration for roleReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for roleReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for roleReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/role_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -74041,8 +74041,8 @@
           "description": "Minimum configuration for roleReplaceSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for roleReplaceSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for roleReplaceSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/role_replace_spec_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -74118,7 +74118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866952+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822199+00:00"
               },
               "deterministic": true
             },
@@ -74131,7 +74131,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427734+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641118+00:00"
           },
           "namespace": {
             "type": "string",
@@ -74160,7 +74160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.866988+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822215+00:00"
               },
               "deterministic": true
             },
@@ -74173,7 +74173,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427764+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641133+00:00"
           },
           "tenant": {
             "type": "string",
@@ -74190,7 +74190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.867030+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74203,7 +74203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427793+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641149+00:00"
           },
           "uid": {
             "type": "string",
@@ -74220,7 +74220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.867062+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74234,7 +74234,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.427823+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641170+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -74395,7 +74395,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.867979+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822645+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -74411,7 +74411,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.428342+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641452+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -74483,7 +74483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.868025+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822666+00:00"
               },
               "deterministic": true
             },
@@ -74496,7 +74496,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.428392+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641478+00:00"
           },
           "namespace": {
             "type": "string",
@@ -74527,7 +74527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.868059+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822682+00:00"
               },
               "deterministic": true
             },
@@ -74540,7 +74540,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.428421+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641493+00:00"
           },
           "uid": {
             "type": "string",
@@ -74559,7 +74559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.868091+00:00"
+                "validatedAt": "2026-05-09T01:38:14.822695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74574,7 +74574,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.428451+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641509+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -74621,7 +74621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869294+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74649,7 +74649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869344+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74678,7 +74678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869397+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74705,7 +74705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869443+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74734,7 +74734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869496+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74759,7 +74759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869548+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74824,7 +74824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869641+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74862,7 +74862,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:10.869703+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74874,7 +74874,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.429196+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641898+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -74915,7 +74915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869768+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74959,7 +74959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869816+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74973,7 +74973,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.429263+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641933+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -74992,7 +74992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869864+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75019,7 +75019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869896+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75034,7 +75034,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.429302+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.641954+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -75049,7 +75049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:10.869939+00:00"
+                "validatedAt": "2026-05-09T01:38:14.823488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75167,7 +75167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.828509+00:00"
+                "validatedAt": "2026-05-09T01:38:24.616959+00:00"
               },
               "deterministic": true
             },
@@ -75180,7 +75180,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.897079+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.863844+00:00"
           }
         },
         "x-f5xc-description-short": "RecreateScimTokenRequest is the request format for generating SCIM API credential.",
@@ -75228,7 +75228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.828652+00:00"
+                "validatedAt": "2026-05-09T01:38:24.616991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75275,7 +75275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.828762+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75309,7 +75309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.828841+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75348,7 +75348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.828935+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75375,7 +75375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.828983+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75401,7 +75401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829028+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75427,7 +75427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829076+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75463,7 +75463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829130+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75489,7 +75489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829183+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75578,7 +75578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829241+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75612,7 +75612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829296+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75639,7 +75639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829346+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75698,7 +75698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:23:32.829397+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617292+00:00"
               },
               "deterministic": true
             },
@@ -75751,7 +75751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829453+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75784,7 +75784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829513+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75831,7 +75831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829566+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75865,7 +75865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829654+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75904,7 +75904,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.829745+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75947,7 +75947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:23:32.829792+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75974,7 +75974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829851+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76001,7 +76001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829894+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76027,7 +76027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829940+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76053,7 +76053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.829986+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76116,7 +76116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830048+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76142,7 +76142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830101+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76228,7 +76228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830162+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76275,7 +76275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830216+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76309,7 +76309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830269+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76348,7 +76348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.830353+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76375,7 +76375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830396+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76401,7 +76401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830440+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76427,7 +76427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830487+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76463,7 +76463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830543+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76489,7 +76489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830609+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76543,8 +76543,8 @@
           "description": "Minimum configuration for oidc_providerPromptType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for oidc_providerPromptType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for oidc_providerPromptType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/oidc_provider_prompt_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -76568,8 +76568,8 @@
           "description": "Minimum configuration for oidc_providerProviderType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for oidc_providerProviderType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for oidc_providerProviderType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/oidc_provider_provider_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -76610,7 +76610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.830653+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617822+00:00"
               },
               "deterministic": true
             },
@@ -76623,7 +76623,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.897578+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864127+00:00"
           },
           "namespace": {
             "type": "string",
@@ -76652,7 +76652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.830691+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617839+00:00"
               },
               "deterministic": true
             },
@@ -76665,7 +76665,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.897624+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864146+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/schemaoidc_providerCustomCreateSpecType"
@@ -76731,7 +76731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.830753+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76806,7 +76806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.830796+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617884+00:00"
               },
               "deterministic": true
             },
@@ -76819,7 +76819,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.897702+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864192+00:00"
           },
           "namespace": {
             "type": "string",
@@ -76849,7 +76849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.830833+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617901+00:00"
               },
               "deterministic": true
             },
@@ -76862,7 +76862,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.897733+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864208+00:00"
           },
           "oidc_mappers": {
             "$ref": "#/components/schemas/oidc_providerOIDCMappers"
@@ -76920,7 +76920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.830875+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617920+00:00"
               },
               "deterministic": true
             },
@@ -76933,7 +76933,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.897775+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864230+00:00"
           },
           "namespace": {
             "type": "string",
@@ -76962,7 +76962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.830913+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617938+00:00"
               },
               "deterministic": true
             },
@@ -76975,7 +76975,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.897805+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864246+00:00"
           },
           "scim_enabled": {
             "type": "boolean",
@@ -77065,7 +77065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:23:32.830973+00:00"
+                "validatedAt": "2026-05-09T01:38:24.617963+00:00"
               },
               "deterministic": true
             },
@@ -77130,7 +77130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.832615+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77154,7 +77154,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.832671+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77190,7 +77190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.832712+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618730+00:00"
               },
               "deterministic": true
             },
@@ -77203,7 +77203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.898836+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864787+00:00"
           }
         },
         "x-f5xc-description-short": "CreateResponse is the response format for the credential's create request.",
@@ -77256,7 +77256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.832749+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618747+00:00"
               },
               "deterministic": true
             },
@@ -77269,7 +77269,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.898868+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864804+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/schemaoidc_providerCustomCreateSpecType"
@@ -77313,7 +77313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.832815+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77340,7 +77340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.832863+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77444,7 +77444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.832918+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618821+00:00"
               },
               "deterministic": true
             },
@@ -77457,7 +77457,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.898989+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864868+00:00"
           },
           "namespace": {
             "type": "string",
@@ -77486,7 +77486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.832955+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618838+00:00"
               },
               "deterministic": true
             },
@@ -77499,7 +77499,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.899018+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864884+00:00"
           }
         },
         "x-f5xc-description-short": "DeleteRequest is the request payload for deleting an OIDC provider/SSO configuration.",
@@ -77535,8 +77535,8 @@
           "description": "Minimum configuration for schemaoidc_providerErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaoidc_providerErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaoidc_providerErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaoidc_provider_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -77601,7 +77601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.833026+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77659,7 +77659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:23:32.833074+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77706,7 +77706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.833128+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77745,7 +77745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.833165+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618929+00:00"
               },
               "deterministic": true
             },
@@ -77758,7 +77758,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.899153+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864954+00:00"
           },
           "namespace": {
             "type": "string",
@@ -77787,7 +77787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:23:32.833200+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618945+00:00"
               },
               "deterministic": true
             },
@@ -77800,7 +77800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.899182+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864970+00:00"
           },
           "provider_type": {
             "$ref": "#/components/schemas/oidc_providerProviderType"
@@ -77820,7 +77820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:23:32.833237+00:00"
+                "validatedAt": "2026-05-09T01:38:24.618960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77834,7 +77834,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:46.899222+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:11.864991+00:00"
           }
         },
         "x-f5xc-description-short": "Shape of the OIDC provider object in a list request's response body.",
@@ -77960,8 +77960,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -77983,8 +77983,8 @@
           "description": "Minimum configuration for schemaSyncMode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSyncMode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSyncMode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_sync_modes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -78010,8 +78010,8 @@
           "description": "Minimum configuration for schemaTaxExemptionType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTaxExemptionType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTaxExemptionType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tax_exemption_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -78034,8 +78034,8 @@
           "description": "Minimum configuration for schemaTenantType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTenantType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTenantType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tenant_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -78066,7 +78066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.575674+00:00"
+                "validatedAt": "2026-05-09T01:39:03.877939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78142,7 +78142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.575778+00:00"
+                "validatedAt": "2026-05-09T01:39:03.877982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78190,7 +78190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:01.575843+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878009+00:00"
               },
               "deterministic": true
             },
@@ -78261,8 +78261,8 @@
           "description": "Minimum configuration for schemasignupErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemasignupErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemasignupErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemasignup_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -78292,7 +78292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.575907+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78324,7 +78324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.575964+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78349,7 +78349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576015+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78378,7 +78378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576063+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78410,7 +78410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576114+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78423,7 +78423,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.061862+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.892481+00:00"
           },
           "email": {
             "type": "string",
@@ -78450,7 +78450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:25:01.576159+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878143+00:00"
               },
               "deterministic": true
             },
@@ -78476,7 +78476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576209+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78505,7 +78505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576261+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78537,7 +78537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576308+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78563,7 +78563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576365+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78589,7 +78589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576419+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78627,7 +78627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:25:01.576473+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78655,7 +78655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576523+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78682,7 +78682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576576+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78709,7 +78709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576639+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78738,7 +78738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576695+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78847,7 +78847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:25:01.576763+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878402+00:00"
               },
               "deterministic": true
             },
@@ -78873,7 +78873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576812+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78918,7 +78918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576884+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78943,7 +78943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576933+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78969,7 +78969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.576976+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79001,7 +79001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577034+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79028,7 +79028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577086+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79053,7 +79053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577136+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79131,7 +79131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577193+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79194,7 +79194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577248+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79220,7 +79220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577298+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79275,7 +79275,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.062238+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.892681+00:00"
           }
         },
         "x-f5xc-description-short": "Signup object including its status. Use it when you want to see the progress of the signup flow.",
@@ -79464,7 +79464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577425+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79506,7 +79506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:25:01.577473+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878702+00:00"
               },
               "deterministic": true
             },
@@ -79544,8 +79544,8 @@
           "description": "Minimum configuration for signupSendPasswordEmailResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for signupSendPasswordEmailResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for signupSendPasswordEmailResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/signup_send_password_email_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -79612,7 +79612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577531+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79638,7 +79638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577579+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79736,7 +79736,7 @@
             "maxLength": 18,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.062461+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.892798+00:00"
           },
           "user": {
             "type": "array",
@@ -79808,7 +79808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:01.577710+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878796+00:00"
               },
               "deterministic": true
             },
@@ -79821,7 +79821,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.062502+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.892820+00:00"
           },
           "namespace": {
             "type": "string",
@@ -79851,7 +79851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:01.577745+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878812+00:00"
               },
               "deterministic": true
             },
@@ -79864,7 +79864,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:49.062532+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:12.892836+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/schemacontactGlobalSpecType"
@@ -79980,7 +79980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:25:01.577825+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878845+00:00"
               },
               "deterministic": true
             },
@@ -80018,7 +80018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:25:01.577877+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80109,7 +80109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577939+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80134,7 +80134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:01.577990+00:00"
+                "validatedAt": "2026-05-09T01:39:03.878916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80179,8 +80179,8 @@
           "description": "Minimum configuration for userFSMState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for userFSMState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for userFSMState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_f_s_m_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -80203,8 +80203,8 @@
           "description": "Minimum configuration for userIdmType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for userIdmType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for userIdmType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_idm_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -80227,8 +80227,8 @@
           "description": "Minimum configuration for userUserType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for userUserType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for userUserType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_user_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -80259,7 +80259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:25:53.630257+00:00"
+                "validatedAt": "2026-05-09T01:39:28.187979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80284,7 +80284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.630309+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80311,7 +80311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.630341+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80340,7 +80340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:25:53.630389+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80431,7 +80431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:25:53.630456+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80475,7 +80475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.630519+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80574,7 +80574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.630634+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80650,7 +80650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.630685+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80675,7 +80675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.630727+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80687,7 +80687,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.777928+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.703810+00:00"
           }
         },
         "x-f5xc-description-short": "Email for user can be primary or secondary.",
@@ -80737,7 +80737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.630785+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80809,7 +80809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:25:53.630832+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80834,7 +80834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.630880+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80861,7 +80861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.630911+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80890,7 +80890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:25:53.630956+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80932,7 +80932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:53.630998+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188306+00:00"
               },
               "deterministic": true
             },
@@ -80945,7 +80945,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.778032+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.703868+00:00"
           },
           "schemas": {
             "type": "array",
@@ -81005,7 +81005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631050+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81030,7 +81030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631093+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81042,7 +81042,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.778084+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.703896+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -81105,7 +81105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631164+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81155,7 +81155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631232+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81182,7 +81182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631283+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81262,7 +81262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631355+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81318,7 +81318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631425+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81351,7 +81351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631479+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81408,7 +81408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631530+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81441,7 +81441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631597+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81473,7 +81473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631647+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81485,7 +81485,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.778239+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.703982+00:00"
           },
           "resourceType": {
             "type": "string",
@@ -81509,7 +81509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631702+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81542,7 +81542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631750+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81554,7 +81554,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.778278+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.704003+00:00"
           }
         },
         "x-f5xc-example": "Meta",
@@ -81596,7 +81596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631803+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81622,7 +81622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631851+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81647,7 +81647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631897+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81672,7 +81672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631948+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81698,7 +81698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.631999+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81723,7 +81723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632046+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81807,7 +81807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632102+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81880,7 +81880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632154+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81908,7 +81908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:25:53.632206+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81935,7 +81935,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.778424+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.704079+00:00"
           }
         },
         "x-f5xc-description-short": "PatchOperation is the PATCH operation where user can be updated replaced or remove..",
@@ -82011,7 +82011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632271+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82092,7 +82092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:25:53.632337+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188926+00:00"
               },
               "deterministic": true
             },
@@ -82126,7 +82126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632373+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82174,7 +82174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:25:53.632416+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188963+00:00"
               },
               "deterministic": true
             },
@@ -82187,7 +82187,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.778521+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.704131+00:00"
           },
           "schema": {
             "type": "string",
@@ -82209,7 +82209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632461+00:00"
+                "validatedAt": "2026-05-09T01:39:28.188982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82290,7 +82290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632527+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82302,7 +82302,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.778573+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.704166+00:00"
           },
           "resourceType": {
             "type": "string",
@@ -82327,7 +82327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632593+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82372,7 +82372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632647+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82445,7 +82445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632726+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82457,7 +82457,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:50.778661+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.704205+00:00"
           },
           "totalResults": {
             "type": "string",
@@ -82483,7 +82483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632779+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82570,7 +82570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.632864+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82721,7 +82721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:25:53.632952+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82772,7 +82772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.633017+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82831,7 +82831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.633070+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82862,7 +82862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.633121+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82950,7 +82950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.633195+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83011,7 +83011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.633245+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83038,7 +83038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:25:53.633277+00:00"
+                "validatedAt": "2026-05-09T01:39:28.189334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83072,8 +83072,8 @@
           "description": "Minimum configuration for schematenantEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schematenantEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schematenantEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schematenant_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -83102,8 +83102,8 @@
           "description": "Minimum configuration for schematenantFSMState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schematenantFSMState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schematenantFSMState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schematenant_f_s_m_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -83140,7 +83140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:26:21.963889+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664144+00:00"
               },
               "deterministic": true
             },
@@ -83255,7 +83255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964008+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83302,7 +83302,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964059+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83358,7 +83358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:26:21.964107+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664249+00:00"
               },
               "deterministic": true
             },
@@ -83385,7 +83385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964154+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83424,7 +83424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:21.964194+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664289+00:00"
               },
               "deterministic": true
             },
@@ -83437,7 +83437,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.262213+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.931478+00:00"
           },
           "reason": {
             "$ref": "#/components/schemas/tenantDeletionReason"
@@ -83479,8 +83479,8 @@
           "description": "Minimum configuration for tenantDeletionReason",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenantDeletionReason\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenantDeletionReason\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_deletion_reasons\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -83509,7 +83509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964233+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83566,7 +83566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964299+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83644,7 +83644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964359+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83668,7 +83668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964401+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83696,7 +83696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:26:21.964447+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664399+00:00"
               },
               "deterministic": true
             },
@@ -83720,7 +83720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964494+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83749,7 +83749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:26:21.964544+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664444+00:00"
               },
               "deterministic": true
             },
@@ -83780,7 +83780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964597+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83865,8 +83865,8 @@
           "description": "Minimum configuration for tenantOtpStatus",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenantOtpStatus\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenantOtpStatus\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_otp_statuses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -84016,8 +84016,8 @@
           "description": "Minimum configuration for tenantStatusResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenantStatusResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenantStatusResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_status_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -84042,7 +84042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964752+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84065,7 +84065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964788+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84109,7 +84109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964847+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84155,7 +84155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964908+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84180,7 +84180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.964958+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84204,7 +84204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.965000+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84217,7 +84217,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.262513+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.931633+00:00"
           },
           "max_credentials_expiry": {
             "$ref": "#/components/schemas/tenantCredentialsExpiry"
@@ -84252,7 +84252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:21.965042+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664651+00:00"
               },
               "deterministic": true
             },
@@ -84265,7 +84265,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.262553+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.931654+00:00"
           },
           "original_tenant": {
             "type": "string",
@@ -84283,7 +84283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.965095+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84395,7 +84395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:26:21.965161+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664702+00:00"
               },
               "deterministic": true
             },
@@ -84440,7 +84440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.965220+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84466,7 +84466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.965261+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84646,7 +84646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:26:21.965355+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664782+00:00"
               },
               "deterministic": true
             },
@@ -84729,7 +84729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.965419+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84754,7 +84754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:21.965471+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84813,7 +84813,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:21.965558+00:00"
+                "validatedAt": "2026-05-09T01:39:41.664872+00:00"
               },
               "deterministic": true
             },
@@ -85122,8 +85122,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_configurationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_configurationCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_configurations\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -85238,7 +85238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:26.500228+00:00"
+                "validatedAt": "2026-05-09T01:39:43.690476+00:00"
               },
               "deterministic": true
             },
@@ -85251,7 +85251,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.394667+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.991515+00:00"
           },
           "namespace": {
             "type": "string",
@@ -85281,7 +85281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:26.500266+00:00"
+                "validatedAt": "2026-05-09T01:39:43.690492+00:00"
               },
               "deterministic": true
             },
@@ -85294,7 +85294,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.394697+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.991533+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -85397,7 +85397,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.394795+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.991588+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -85497,7 +85497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:26.500418+00:00"
+                "validatedAt": "2026-05-09T01:39:43.690555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85560,7 +85560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:26.500486+00:00"
+                "validatedAt": "2026-05-09T01:39:43.690583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85572,7 +85572,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.394900+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.991647+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -85638,7 +85638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:26.500538+00:00"
+                "validatedAt": "2026-05-09T01:39:43.690608+00:00"
               },
               "deterministic": true
             },
@@ -85651,7 +85651,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.394969+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.991684+00:00"
           },
           "namespace": {
             "type": "string",
@@ -85680,7 +85680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:26.500575+00:00"
+                "validatedAt": "2026-05-09T01:39:43.690625+00:00"
               },
               "deterministic": true
             },
@@ -85693,7 +85693,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.394997+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.991700+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -85732,7 +85732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:26.500656+00:00"
+                "validatedAt": "2026-05-09T01:39:43.690653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85745,7 +85745,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.395054+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.991731+00:00"
           },
           "uid": {
             "type": "string",
@@ -85763,7 +85763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:26.500691+00:00"
+                "validatedAt": "2026-05-09T01:39:43.690667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85777,7 +85777,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.395084+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:13.991747+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tenant_configuration is returned in 'List'.",
@@ -85823,8 +85823,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_configurationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_configurationReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_configuration_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -85836,8 +85836,8 @@
           "description": "Minimum configuration for tenant_configurationReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_configurationReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_configurationReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_configuration_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -85943,8 +85943,8 @@
           "description": "Minimum configuration for tenant_managementSubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementSubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementSubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_management_subscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -85960,8 +85960,8 @@
           "description": "Minimum configuration for tenant_managementSubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementSubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementSubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_management_subscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -85977,8 +85977,8 @@
           "description": "Minimum configuration for tenant_managementUnsubscribeRequest",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementUnsubscribeRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_management_unsubscribe_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -85994,8 +85994,8 @@
           "description": "Minimum configuration for tenant_managementUnsubscribeResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_managementUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_managementUnsubscribeResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_management_unsubscribe_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -86028,7 +86028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:32.849973+00:00"
+                "validatedAt": "2026-05-09T01:39:46.518342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86053,7 +86053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:32.850025+00:00"
+                "validatedAt": "2026-05-09T01:39:46.518364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86123,7 +86123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.851636+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519051+00:00"
               },
               "deterministic": true
             },
@@ -86136,7 +86136,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.482946+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.032486+00:00"
           },
           "role": {
             "type": "string",
@@ -86166,7 +86166,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.851708+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86211,8 +86211,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_profileCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_profileCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_profiles\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -86280,7 +86280,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.851792+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86335,7 +86335,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.851888+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86415,7 +86415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.851932+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519195+00:00"
               },
               "deterministic": true
             },
@@ -86428,7 +86428,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.483109+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.032571+00:00"
           },
           "namespace": {
             "type": "string",
@@ -86458,7 +86458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.851971+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519212+00:00"
               },
               "deterministic": true
             },
@@ -86471,7 +86471,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.483138+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.032586+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -86613,7 +86613,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.852106+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86668,7 +86668,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.852199+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86743,7 +86743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.852242+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519333+00:00"
               },
               "deterministic": true
             },
@@ -86756,7 +86756,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.483306+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.032674+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -86786,7 +86786,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.852301+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86853,7 +86853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:32.852355+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86916,7 +86916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:32.852423+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86928,7 +86928,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.483382+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.032713+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -86994,7 +86994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.852473+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519434+00:00"
               },
               "deterministic": true
             },
@@ -87007,7 +87007,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.483450+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.032750+00:00"
           },
           "namespace": {
             "type": "string",
@@ -87036,7 +87036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.852509+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519449+00:00"
               },
               "deterministic": true
             },
@@ -87049,7 +87049,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.483479+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.032765+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -87072,7 +87072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:32.852560+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87085,7 +87085,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.483526+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.032790+00:00"
           },
           "uid": {
             "type": "string",
@@ -87102,7 +87102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:32.852607+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87116,7 +87116,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.483556+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.032805+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tenant_profile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -87165,8 +87165,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_profileReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_profileReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_profile_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -87178,8 +87178,8 @@
           "description": "Minimum configuration for tenant_profileReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tenant_profileReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tenant_profileReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tenant_profile_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -87219,7 +87219,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.852682+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87274,7 +87274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:32.852781+00:00"
+                "validatedAt": "2026-05-09T01:39:46.519558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87589,8 +87589,8 @@
           "description": "Minimum configuration for schemaAddonServiceAccess",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceAccess\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceAccess\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_accesses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -87612,8 +87612,8 @@
           "description": "Minimum configuration for schemaAddonServiceState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaAddonServiceState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaAddonServiceState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_addon_service_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -87706,7 +87706,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.844072+00:00"
+                "validatedAt": "2026-05-09T01:40:17.187864+00:00"
               },
               "deterministic": true
             },
@@ -87719,7 +87719,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.745126+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.613759+00:00"
           },
           "role": {
             "type": "string",
@@ -87749,7 +87749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.844146+00:00"
+                "validatedAt": "2026-05-09T01:40:17.187899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87792,8 +87792,8 @@
           "description": "Minimum configuration for schemaPlanType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaPlanType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaPlanType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_plan_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -87818,8 +87818,8 @@
           "description": "Minimum configuration for schemaSignupOrigin",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSignupOrigin\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSignupOrigin\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_signup_origins\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -87841,8 +87841,8 @@
           "description": "Minimum configuration for schemaTileAccessState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTileAccessState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTileAccessState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_tile_access_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -87857,8 +87857,8 @@
           "description": "Minimum configuration for schemauserEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemauserEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemauserEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemauser_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -87897,7 +87897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.845636+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188535+00:00"
               },
               "deterministic": true
             },
@@ -87910,7 +87910,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.745949+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614189+00:00"
           },
           "tos_accepted": {
             "type": "string",
@@ -87928,7 +87928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.845688+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87955,7 +87955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.845744+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87980,7 +87980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.845795+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88016,8 +88016,8 @@
           "description": "Minimum configuration for userAcceptTOSResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for userAcceptTOSResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for userAcceptTOSResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_accept_t_o_s_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -88042,8 +88042,8 @@
           "description": "Minimum configuration for userAccessType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for userAccessType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for userAccessType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_access_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -88083,7 +88083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.845836+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188617+00:00"
               },
               "deterministic": true
             },
@@ -88096,7 +88096,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.746012+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614222+00:00"
           },
           "namespaces_role": {
             "$ref": "#/components/schemas/userNamespacesRoleType"
@@ -88162,7 +88162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.845915+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88237,8 +88237,8 @@
           "description": "Minimum configuration for userBillingFlag",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for userBillingFlag\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for userBillingFlag\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_billing_flags\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -88261,8 +88261,8 @@
           "description": "Minimum configuration for userBillingFlagAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for userBillingFlagAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for userBillingFlagAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_billing_flag_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -88290,7 +88290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.845979+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88315,7 +88315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846031+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88340,7 +88340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846081+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88365,7 +88365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846128+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88432,7 +88432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:27:42.846184+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188764+00:00"
               },
               "deterministic": true
             },
@@ -88470,7 +88470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.846221+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188780+00:00"
               },
               "deterministic": true
             },
@@ -88483,7 +88483,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.746157+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614299+00:00"
           }
         },
         "x-f5xc-description-short": "CascadeDeleteRequest is the request to DELETE the user along with the associated namespace role objects.",
@@ -88544,7 +88544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:27:42.846268+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88620,7 +88620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.846311+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188818+00:00"
               },
               "deterministic": true
             },
@@ -88633,7 +88633,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.746221+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614338+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -88671,7 +88671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846352+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88696,7 +88696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846396+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88708,7 +88708,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.746262+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614360+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -88750,7 +88750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846460+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88806,7 +88806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846536+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88832,7 +88832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846578+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88858,7 +88858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846640+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88883,7 +88883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846695+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88950,7 +88950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:27:42.846749+00:00"
+                "validatedAt": "2026-05-09T01:40:17.188999+00:00"
               },
               "deterministic": true
             },
@@ -88975,7 +88975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846799+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89017,7 +89017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846865+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89064,7 +89064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846941+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189078+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89089,7 +89089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.846988+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89131,7 +89131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.847028+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189116+00:00"
               },
               "deterministic": true
             },
@@ -89144,7 +89144,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.746478+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614475+00:00"
           },
           "namespace": {
             "type": "string",
@@ -89174,7 +89174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.847065+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189133+00:00"
               },
               "deterministic": true
             },
@@ -89187,7 +89187,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.746508+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614491+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -89227,7 +89227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847137+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89268,7 +89268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847197+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89281,7 +89281,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.746625+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614547+00:00"
           },
           "tenant_flags": {
             "type": "object",
@@ -89311,7 +89311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847253+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89352,7 +89352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847313+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89379,7 +89379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847366+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89404,7 +89404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847421+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89429,7 +89429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847470+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89458,7 +89458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847520+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89583,7 +89583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:27:42.847600+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189358+00:00"
               },
               "deterministic": true
             },
@@ -89609,7 +89609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847650+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89654,7 +89654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847722+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89679,7 +89679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847770+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89705,7 +89705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847813+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89737,7 +89737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847870+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89764,7 +89764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847922+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89789,7 +89789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.847974+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89854,7 +89854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:27:42.848020+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89899,7 +89899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.848077+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89966,7 +89966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:27:42.848130+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189581+00:00"
               },
               "deterministic": true
             },
@@ -89992,7 +89992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.848178+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90039,7 +90039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.848253+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90064,7 +90064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.848301+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90103,7 +90103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.848338+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189669+00:00"
               },
               "deterministic": true
             },
@@ -90116,7 +90116,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.746998+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614765+00:00"
           },
           "namespace": {
             "type": "string",
@@ -90146,7 +90146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.848374+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189685+00:00"
               },
               "deterministic": true
             },
@@ -90159,7 +90159,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.747027+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614781+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -90210,7 +90210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.848439+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90223,7 +90223,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.747085+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614812+00:00"
           },
           "tenant_type": {
             "$ref": "#/components/schemas/schemaTenantType"
@@ -90282,7 +90282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.848490+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90311,7 +90311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.848546+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90370,8 +90370,8 @@
           "description": "Minimum configuration for userMSPNodeType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for userMSPNodeType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for userMSPNodeType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_m_s_p_node_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -90416,7 +90416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.848632+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90510,7 +90510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:27:42.848700+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189811+00:00"
               },
               "deterministic": true
             },
@@ -90574,7 +90574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:27:42.848751+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189832+00:00"
               },
               "deterministic": true
             },
@@ -90612,7 +90612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.848787+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189849+00:00"
               },
               "deterministic": true
             },
@@ -90625,7 +90625,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.747252+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614908+00:00"
           }
         },
         "x-f5xc-description-short": "SendPasswordEmailRequest is the request parameters for sending the password update.",
@@ -90654,8 +90654,8 @@
           "description": "Minimum configuration for userSendPasswordEmailResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for userSendPasswordEmailResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for userSendPasswordEmailResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_send_password_email_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -90739,7 +90739,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.848892+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189895+00:00"
               },
               "byteLength": {
                 "max": 320,
@@ -90829,7 +90829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:27:42.848944+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189918+00:00"
               },
               "deterministic": true
             },
@@ -90862,7 +90862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.848994+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90915,7 +90915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:42.849065+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189970+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90956,7 +90956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.849104+00:00"
+                "validatedAt": "2026-05-09T01:40:17.189987+00:00"
               },
               "deterministic": true
             },
@@ -90969,7 +90969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.747380+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614975+00:00"
           },
           "namespace": {
             "type": "string",
@@ -90999,7 +90999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:42.849139+00:00"
+                "validatedAt": "2026-05-09T01:40:17.190003+00:00"
               },
               "deterministic": true
             },
@@ -91012,7 +91012,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.747410+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.614991+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -91066,8 +91066,8 @@
           "description": "Minimum configuration for schemauser_groupEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemauser_groupEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemauser_groupEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemauser_group_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -91098,7 +91098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:47.313255+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91199,8 +91199,8 @@
           "description": "Minimum configuration for user_groupDeletionAnalysis",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for user_groupDeletionAnalysis\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for user_groupDeletionAnalysis\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_group_deletion_analysises\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -91285,7 +91285,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839097+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658186+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -91339,7 +91339,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:47.313433+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147247+00:00"
               },
               "deterministic": true
             },
@@ -91405,7 +91405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:27:47.313490+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91468,7 +91468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:47.313558+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91480,7 +91480,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839185+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658234+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -91546,7 +91546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:47.313628+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147318+00:00"
               },
               "deterministic": true
             },
@@ -91559,7 +91559,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839255+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658271+00:00"
           },
           "namespace": {
             "type": "string",
@@ -91588,7 +91588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:47.313666+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147334+00:00"
               },
               "deterministic": true
             },
@@ -91601,7 +91601,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839284+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658287+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -91640,7 +91640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:47.313733+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91653,7 +91653,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839342+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658319+00:00"
           },
           "uid": {
             "type": "string",
@@ -91670,7 +91670,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:47.313767+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91684,7 +91684,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839372+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658335+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of user_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -91787,7 +91787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:47.313827+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147399+00:00"
               },
               "deterministic": true
             },
@@ -91800,7 +91800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839416+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658358+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -91868,7 +91868,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:47.313931+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91904,7 +91904,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:47.314018+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91964,7 +91964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:47.314066+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92077,7 +92077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:47.314170+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92089,7 +92089,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839541+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658426+00:00"
           },
           "display_name": {
             "type": "string",
@@ -92111,7 +92111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:47.314206+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92150,7 +92150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:47.314245+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147578+00:00"
               },
               "deterministic": true
             },
@@ -92163,7 +92163,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839580+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658447+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -92197,7 +92197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:47.314306+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92271,7 +92271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:47.314384+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92283,7 +92283,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839653+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658482+00:00"
           },
           "display_name": {
             "type": "string",
@@ -92305,7 +92305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:47.314420+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92335,7 +92335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:47.314455+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92374,7 +92374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:47.314493+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147682+00:00"
               },
               "deterministic": true
             },
@@ -92387,7 +92387,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839711+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658514+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -92436,7 +92436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:47.314559+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92465,7 +92465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:47.314611+00:00"
+                "validatedAt": "2026-05-09T01:40:19.147724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92479,7 +92479,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.839782+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.658555+00:00"
           },
           "usernames": {
             "type": "array",
@@ -92619,7 +92619,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.627150+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035698+00:00"
               },
               "deterministic": true
             },
@@ -92696,7 +92696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.627191+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035717+00:00"
               },
               "deterministic": true
             },
@@ -92709,7 +92709,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.911687+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.692018+00:00"
           },
           "namespace": {
             "type": "string",
@@ -92739,7 +92739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.627228+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035734+00:00"
               },
               "deterministic": true
             },
@@ -92752,7 +92752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.911717+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.692034+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -92855,7 +92855,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.911817+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.692086+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -92922,7 +92922,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.627390+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035805+00:00"
               },
               "deterministic": true
             },
@@ -92991,7 +92991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:27:51.627442+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93054,7 +93054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:51.627511+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93066,7 +93066,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.911905+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.692132+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -93132,7 +93132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.627563+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035876+00:00"
               },
               "deterministic": true
             },
@@ -93145,7 +93145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.911973+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.692174+00:00"
           },
           "namespace": {
             "type": "string",
@@ -93174,7 +93174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.627615+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035893+00:00"
               },
               "deterministic": true
             },
@@ -93187,7 +93187,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.912002+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.692190+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -93226,7 +93226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:51.627684+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93239,7 +93239,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.912059+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.692221+00:00"
           },
           "uid": {
             "type": "string",
@@ -93257,7 +93257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:51.627718+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93271,7 +93271,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.912089+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.692237+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of user_identification is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -93335,8 +93335,8 @@
           "description": "Minimum configuration for user_identificationReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for user_identificationReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for user_identificationReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/user_identification_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -93382,7 +93382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.627809+00:00"
+                "validatedAt": "2026-05-09T01:40:21.035975+00:00"
               },
               "deterministic": true
             },
@@ -93522,7 +93522,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.627953+00:00"
+                "validatedAt": "2026-05-09T01:40:21.036036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93581,7 +93581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.628041+00:00"
+                "validatedAt": "2026-05-09T01:40:21.036075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93640,7 +93640,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.628132+00:00"
+                "validatedAt": "2026-05-09T01:40:21.036116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93706,7 +93706,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.628228+00:00"
+                "validatedAt": "2026-05-09T01:40:21.036164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93765,7 +93765,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:27:51.628317+00:00"
+                "validatedAt": "2026-05-09T01:40:21.036205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93861,7 +93861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898227+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93922,7 +93922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898277+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93951,7 +93951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:27:53.898349+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93963,7 +93963,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:52.994149+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.723790+00:00"
           },
           "enabled": {
             "type": "boolean",
@@ -93996,7 +93996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898395+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94117,7 +94117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898479+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94304,7 +94304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898572+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94330,7 +94330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898637+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94377,7 +94377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898690+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94427,7 +94427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:27:53.898741+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031754+00:00"
               },
               "deterministic": true
             },
@@ -94455,7 +94455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898791+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94482,7 +94482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898834+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94584,7 +94584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898921+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94611,7 +94611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.898964+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94636,7 +94636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.899014+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94702,7 +94702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:27:53.899063+00:00"
+                "validatedAt": "2026-05-09T01:40:22.031890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94845,8 +94845,8 @@
           "description": "Minimum configuration for usersettingEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for usersettingEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for usersettingEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/usersetting_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "tenant_and_identity"
@@ -94874,7 +94874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:53.854405+00:00"
+                "validatedAt": "2026-05-09T01:40:48.068375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94901,7 +94901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:28:53.854520+00:00"
+                "validatedAt": "2026-05-09T01:40:48.068415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94927,7 +94927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:28:53.854626+00:00"
+                "validatedAt": "2026-05-09T01:40:48.068435+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/threat_campaign.json
+++ b/docs/specifications/api/threat_campaign.json
@@ -392,8 +392,8 @@
           "description": "Minimum configuration for app_firewallAppFirewallViolationType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_firewallAppFirewallViolationType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_firewallAppFirewallViolationType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_firewall_app_firewall_violation_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -440,8 +440,8 @@
           "description": "Minimum configuration for app_firewallAttackType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_firewallAttackType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_firewallAttackType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_firewall_attack_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -476,7 +476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.259853+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -500,7 +500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.259945+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -565,7 +565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260033+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943630+00:00"
               },
               "deterministic": true
             },
@@ -578,7 +578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052031+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465550+00:00"
           },
           "namespace": {
             "type": "string",
@@ -608,7 +608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260089+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943648+00:00"
               },
               "deterministic": true
             },
@@ -621,7 +621,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052064+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465566+00:00"
           },
           "path": {
             "type": "string",
@@ -652,7 +652,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260178+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943688+00:00"
               },
               "deterministic": true
             },
@@ -737,7 +737,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260277+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -800,7 +800,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260381+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -840,7 +840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260423+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943799+00:00"
               },
               "deterministic": true
             },
@@ -853,7 +853,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052160+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465614+00:00"
           },
           "namespace": {
             "type": "string",
@@ -883,7 +883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260460+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943815+00:00"
               },
               "deterministic": true
             },
@@ -896,7 +896,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052190+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465630+00:00"
           },
           "user_id": {
             "type": "string",
@@ -920,7 +920,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260537+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -990,7 +990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260580+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943870+00:00"
               },
               "deterministic": true
             },
@@ -1003,7 +1003,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052243+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465657+00:00"
           },
           "rule": {
             "$ref": "#/components/schemas/common_wafSimpleClientSrcRule"
@@ -1061,7 +1061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260679+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1107,7 +1107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260725+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943929+00:00"
               },
               "deterministic": true
             },
@@ -1120,7 +1120,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052322+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465698+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1150,7 +1150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260762+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943946+00:00"
               },
               "deterministic": true
             },
@@ -1163,7 +1163,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052352+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465714+00:00"
           },
           "tls_fingerprint_matcher": {
             "$ref": "#/components/schemas/policyTlsFingerprintMatcherType"
@@ -1217,7 +1217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.260831+00:00"
+                "validatedAt": "2026-05-09T01:32:11.943975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1300,7 +1300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260891+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944004+00:00"
               },
               "deterministic": true
             },
@@ -1313,7 +1313,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052442+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465762+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1343,7 +1343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.260927+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944022+00:00"
               },
               "deterministic": true
             },
@@ -1356,7 +1356,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052471+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465778+00:00"
           },
           "path": {
             "type": "string",
@@ -1387,7 +1387,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261012+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944065+00:00"
               },
               "deterministic": true
             },
@@ -1489,7 +1489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261063+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944089+00:00"
               },
               "deterministic": true
             },
@@ -1502,7 +1502,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052553+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465835+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1532,7 +1532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261099+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944106+00:00"
               },
               "deterministic": true
             },
@@ -1545,7 +1545,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052608+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465851+00:00"
           },
           "path": {
             "type": "string",
@@ -1576,7 +1576,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261180+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944145+00:00"
               },
               "deterministic": true
             },
@@ -1672,7 +1672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261226+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944174+00:00"
               },
               "deterministic": true
             },
@@ -1685,7 +1685,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052697+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465895+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1715,7 +1715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261261+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944190+00:00"
               },
               "deterministic": true
             },
@@ -1728,7 +1728,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052727+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465911+00:00"
           },
           "path": {
             "type": "string",
@@ -1759,7 +1759,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261341+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944228+00:00"
               },
               "deterministic": true
             },
@@ -1844,7 +1844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261431+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1907,7 +1907,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261530+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1963,7 +1963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261574+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944333+00:00"
               },
               "deterministic": true
             },
@@ -1976,7 +1976,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052831+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465965+00:00"
           },
           "namespace": {
             "type": "string",
@@ -2006,7 +2006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261628+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944351+00:00"
               },
               "deterministic": true
             },
@@ -2019,7 +2019,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052861+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.465980+00:00"
           },
           "sec_event_name": {
             "type": "string",
@@ -2036,7 +2036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.261683+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2075,7 +2075,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261748+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2123,7 +2123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261829+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2197,7 +2197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261871+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944460+00:00"
               },
               "deterministic": true
             },
@@ -2210,7 +2210,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052943+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466023+00:00"
           },
           "rule": {
             "$ref": "#/components/schemas/common_wafSimpleClientSrcRule"
@@ -2266,7 +2266,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.261956+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2279,7 +2279,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.052997+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466050+00:00"
           },
           "exclude_bot_names": {
             "type": "array",
@@ -2310,7 +2310,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262021+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2349,7 +2349,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262085+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2388,7 +2388,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262148+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2428,7 +2428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262184+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944609+00:00"
               },
               "deterministic": true
             },
@@ -2441,7 +2441,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053057+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466081+00:00"
           },
           "namespace": {
             "type": "string",
@@ -2471,7 +2471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262222+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944626+00:00"
               },
               "deterministic": true
             },
@@ -2484,7 +2484,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053086+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466097+00:00"
           },
           "req_path": {
             "type": "string",
@@ -2508,7 +2508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262297+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2542,7 +2542,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262392+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2614,7 +2614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262437+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944725+00:00"
               },
               "deterministic": true
             },
@@ -2627,7 +2627,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053148+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466129+00:00"
           },
           "waf_exclusion_policy": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -2688,7 +2688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262483+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944746+00:00"
               },
               "deterministic": true
             },
@@ -2701,7 +2701,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053199+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466160+00:00"
           },
           "namespace": {
             "type": "string",
@@ -2730,7 +2730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262518+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944762+00:00"
               },
               "deterministic": true
             },
@@ -2743,7 +2743,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053229+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466176+00:00"
           },
           "request_data": {
             "$ref": "#/components/schemas/app_securityRequestData"
@@ -2791,7 +2791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.262570+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2819,7 +2819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.262630+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2847,7 +2847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.262677+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2910,7 +2910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262744+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2922,7 +2922,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053330+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466229+00:00"
           }
         },
         "x-f5xc-description-short": "Metric label filter can be specified to query specific metrics based on label match.",
@@ -2956,8 +2956,8 @@
           "description": "Minimum configuration for app_securitySearchLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securitySearchLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securitySearchLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_security_search_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -2978,8 +2978,8 @@
           "description": "Minimum configuration for app_securitySearchLabelOperator",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securitySearchLabelOperator\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securitySearchLabelOperator\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_security_search_label_operators\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -3016,7 +3016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262808+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3054,7 +3054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262849+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944902+00:00"
               },
               "deterministic": true
             },
@@ -3067,7 +3067,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053375+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466252+00:00"
           }
         },
         "x-f5xc-description-short": "GET a list of virtual hosts in all the namespaces matching filter provided in the request.",
@@ -3148,8 +3148,8 @@
           "description": "Minimum configuration for app_securitySecEventType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securitySecEventType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securitySecEventType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_security_sec_event_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -3198,7 +3198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.262928+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3236,7 +3236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.262966+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944950+00:00"
               },
               "deterministic": true
             },
@@ -3249,7 +3249,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053443+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466287+00:00"
           },
           "query": {
             "type": "string",
@@ -3269,7 +3269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.263020+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3302,7 +3302,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263072+00:00"
+                "validatedAt": "2026-05-09T01:32:11.944995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3369,7 +3369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263130+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3424,7 +3424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263182+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3496,7 +3496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.263252+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945072+00:00"
               },
               "deterministic": true
             },
@@ -3509,7 +3509,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053547+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466341+00:00"
           },
           "start_time": {
             "type": "string",
@@ -3534,7 +3534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263303+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3567,7 +3567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263345+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3642,7 +3642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263401+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3691,7 +3691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263443+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3719,7 +3719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263488+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3747,7 +3747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263533+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3816,7 +3816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263600+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3845,7 +3845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.263647+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3883,7 +3883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.263685+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945261+00:00"
               },
               "deterministic": true
             },
@@ -3896,7 +3896,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053700+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466411+00:00"
           },
           "query": {
             "type": "string",
@@ -3916,7 +3916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.263738+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3961,7 +3961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263790+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3994,7 +3994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263847+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4081,7 +4081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263916+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4110,7 +4110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.263965+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4172,7 +4172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264003+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945395+00:00"
               },
               "deterministic": true
             },
@@ -4185,7 +4185,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053823+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466475+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -4203,7 +4203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264050+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4274,7 +4274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264105+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4312,7 +4312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264141+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945456+00:00"
               },
               "deterministic": true
             },
@@ -4325,7 +4325,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053886+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466507+00:00"
           },
           "query": {
             "type": "string",
@@ -4345,7 +4345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.264192+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4378,7 +4378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264243+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4445,7 +4445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264298+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4514,7 +4514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264354+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4543,7 +4543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.264395+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4581,7 +4581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264430+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945582+00:00"
               },
               "deterministic": true
             },
@@ -4594,7 +4594,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.053992+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466562+00:00"
           },
           "query": {
             "type": "string",
@@ -4614,7 +4614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.264482+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4659,7 +4659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264534+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4692,7 +4692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264598+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4779,7 +4779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264671+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4808,7 +4808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264719+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4870,7 +4870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264758+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945717+00:00"
               },
               "deterministic": true
             },
@@ -4883,7 +4883,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054115+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466626+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -4901,7 +4901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264804+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4972,7 +4972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264859+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5010,7 +5010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.264895+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945788+00:00"
               },
               "deterministic": true
             },
@@ -5023,7 +5023,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054178+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466658+00:00"
           },
           "query": {
             "type": "string",
@@ -5043,7 +5043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.264945+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5076,7 +5076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.264995+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5143,7 +5143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265050+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5212,7 +5212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265118+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5241,7 +5241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.265164+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5279,7 +5279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.265202+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945925+00:00"
               },
               "deterministic": true
             },
@@ -5292,7 +5292,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054282+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466722+00:00"
           },
           "query": {
             "type": "string",
@@ -5312,7 +5312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.265258+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5357,7 +5357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265315+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5390,7 +5390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265370+00:00"
+                "validatedAt": "2026-05-09T01:32:11.945994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5477,7 +5477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265442+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5506,7 +5506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265494+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5568,7 +5568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.265534+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946060+00:00"
               },
               "deterministic": true
             },
@@ -5581,7 +5581,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054404+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466786+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -5599,7 +5599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265597+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5648,7 +5648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265655+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5677,7 +5677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:37.265716+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5689,7 +5689,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054456+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466812+00:00"
           },
           "id": {
             "type": "string",
@@ -5715,7 +5715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265752+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5740,7 +5740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265795+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5773,7 +5773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265847+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5844,7 +5844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.265908+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946220+00:00"
               },
               "deterministic": true
             },
@@ -5857,7 +5857,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.054525+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.466848+00:00"
           },
           "references": {
             "type": "array",
@@ -5898,7 +5898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.265971+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5999,7 +5999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.266043+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6116,8 +6116,8 @@
           "description": "Minimum configuration for app_securityincidentsKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securityincidentsKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securityincidentsKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_securityincidents_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -6136,8 +6136,8 @@
           "description": "Minimum configuration for app_securityincidentsMetricField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securityincidentsMetricField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securityincidentsMetricField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_securityincidents_metric_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -6235,8 +6235,8 @@
           "description": "Minimum configuration for app_securityincidentsMultiKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securityincidentsMultiKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securityincidentsMultiKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_securityincidents_multi_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -6321,7 +6321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.266180+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6422,8 +6422,8 @@
           "description": "Minimum configuration for app_securitysuspicious_user_logKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for app_securitysuspicious_user_logKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for app_securitysuspicious_user_logKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/app_securitysuspicious_user_log_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -6530,7 +6530,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266305+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6603,7 +6603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.266385+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6682,7 +6682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266493+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6727,7 +6727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266604+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6827,7 +6827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266681+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6865,7 +6865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266767+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946580+00:00"
               },
               "deterministic": true
             },
@@ -6932,7 +6932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266863+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6978,7 +6978,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.266963+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7034,8 +7034,8 @@
           "description": "Minimum configuration for common_wafClientSrcRuleAction",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for common_wafClientSrcRuleAction\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for common_wafClientSrcRuleAction\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/common_waf_client_src_rule_actions\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -7076,7 +7076,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267029+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7143,7 +7143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267125+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7182,7 +7182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267205+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7255,7 +7255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267287+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946816+00:00"
               },
               "deterministic": true
             },
@@ -7319,7 +7319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-08T20:09:37.267340+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7543,7 +7543,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267473+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7617,7 +7617,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267550+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7680,7 +7680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267657+00:00"
+                "validatedAt": "2026-05-09T01:32:11.946972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7719,7 +7719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267739+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7760,7 +7760,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267831+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7834,7 +7834,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.267900+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7903,7 +7903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.267987+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7938,7 +7938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268045+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7976,7 +7976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268103+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8020,7 +8020,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268197+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8170,7 +8170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268280+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8267,7 +8267,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268374+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8338,7 +8338,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268454+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947333+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8354,7 +8354,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055773+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467481+00:00"
           },
           "presence": {
             "type": "boolean",
@@ -8399,7 +8399,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268545+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947375+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -8460,7 +8460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268599+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8473,7 +8473,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055827+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467508+00:00"
           },
           "name": {
             "type": "string",
@@ -8506,7 +8506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268636+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947408+00:00"
               },
               "deterministic": true
             },
@@ -8519,7 +8519,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055857+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467524+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8550,7 +8550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.268672+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947425+00:00"
               },
               "deterministic": true
             },
@@ -8563,7 +8563,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055886+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467540+00:00"
           },
           "tenant": {
             "type": "string",
@@ -8582,7 +8582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268716+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8596,7 +8596,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055915+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467555+00:00"
           },
           "uid": {
             "type": "string",
@@ -8615,7 +8615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268750+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8630,7 +8630,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055946+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467571+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -8670,7 +8670,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.055978+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467588+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -8706,7 +8706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268811+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8755,7 +8755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268859+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8794,7 +8794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-08T20:09:37.268914+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947526+00:00"
               },
               "deterministic": true
             },
@@ -8861,7 +8861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.268977+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8906,7 +8906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269020+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8929,7 +8929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269055+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8941,7 +8941,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056111+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467655+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -9034,7 +9034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269130+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947617+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9058,7 +9058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269165+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9070,7 +9070,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056196+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467698+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -9112,7 +9112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269214+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9136,7 +9136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269248+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9148,7 +9148,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056249+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467725+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -9186,7 +9186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269292+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9243,7 +9243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269340+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9267,7 +9267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269374+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9279,7 +9279,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056315+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467759+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -9329,7 +9329,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056358+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467781+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -9386,7 +9386,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056402+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467803+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -9422,7 +9422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269458+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9533,7 +9533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269532+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9599,7 +9599,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056516+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467862+00:00"
           },
           "value": {
             "type": "number",
@@ -9615,7 +9615,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056544+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467876+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -9652,7 +9652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269619+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9767,7 +9767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.269696+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947848+00:00"
               },
               "deterministic": true
             },
@@ -9780,7 +9780,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056635+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467915+00:00"
           },
           "sec_event_type": {
             "type": "string",
@@ -9797,7 +9797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269749+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9822,7 +9822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269800+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9847,7 +9847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269845+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9872,7 +9872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269890+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9920,8 +9920,8 @@
           "description": "Minimum configuration for metricsSecurityMetricLabel",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for metricsSecurityMetricLabel\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for metricsSecurityMetricLabel\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/metrics_security_metric_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "label"
@@ -9953,7 +9953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.269940+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9965,7 +9965,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056726+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467962+00:00"
           }
         },
         "x-f5xc-description-short": "Label based filtering for Security Events metrics. Security Events metrics are tagged with labels mentioned in MetricLabel.",
@@ -10000,8 +10000,8 @@
           "description": "Minimum configuration for metricsSecurityMetricLabelOp",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for metricsSecurityMetricLabelOp\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for metricsSecurityMetricLabelOp\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/metrics_security_metric_label_ops\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "label"
@@ -10043,7 +10043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.270000+00:00"
+                "validatedAt": "2026-05-09T01:32:11.947975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10055,7 +10055,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.056770+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.467985+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Security Events Metrics query.",
@@ -10106,7 +10106,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270093+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10169,7 +10169,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270165+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10207,7 +10207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270229+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10244,7 +10244,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270296+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10281,7 +10281,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270359+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10343,7 +10343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270447+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10432,7 +10432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270555+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10506,7 +10506,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270641+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10565,7 +10565,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270701+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10618,7 +10618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.270755+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10769,7 +10769,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270883+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948384+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -10785,7 +10785,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057097+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468157+00:00"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -11073,8 +11073,8 @@
           "description": "Minimum configuration for policyCountryCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyCountryCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyCountryCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_country_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11103,8 +11103,8 @@
           "description": "Minimum configuration for policyDetectionContext",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyDetectionContext\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyDetectionContext\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_detection_contexts\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11160,7 +11160,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.270951+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11213,8 +11213,8 @@
           "description": "Minimum configuration for policyIPThreatCategory",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyIPThreatCategory\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_i_p_threat_categories\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11266,7 +11266,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271018+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11328,7 +11328,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271081+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11422,7 +11422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271169+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948519+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11438,7 +11438,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057227+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468224+00:00"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -11488,8 +11488,8 @@
           "description": "Minimum configuration for policyKnownTlsFingerprintClass",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyKnownTlsFingerprintClass\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyKnownTlsFingerprintClass\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_known_tls_fingerprint_classes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -11535,7 +11535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271232+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11581,7 +11581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271291+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11619,7 +11619,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271351+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11698,7 +11698,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271419+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11755,7 +11755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271482+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11792,7 +11792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271555+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948711+00:00"
               },
               "deterministic": true
             },
@@ -11828,7 +11828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271626+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11863,7 +11863,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271687+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11939,7 +11939,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271789+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11972,7 +11972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.271845+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12015,7 +12015,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271914+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12051,7 +12051,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.271997+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12094,7 +12094,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272078+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12139,7 +12139,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272162+00:00"
+                "validatedAt": "2026-05-09T01:32:11.948990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12216,7 +12216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272227+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12257,7 +12257,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272289+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12299,7 +12299,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272350+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12349,8 +12349,8 @@
           "description": "Minimum configuration for policyTransformer",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for policyTransformer\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/policy_transformers\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12373,8 +12373,8 @@
           "description": "Minimum configuration for rate_limiterRateLimitPeriodUnit",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for rate_limiterRateLimitPeriodUnit\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/rate_limiter_rate_limit_period_units\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "rate_limiting"
@@ -12389,8 +12389,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12420,8 +12420,8 @@
           "description": "Minimum configuration for schemaHttpMethod",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaHttpMethod\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_http_methods\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12470,7 +12470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272414+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12527,7 +12527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272508+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949157+00:00"
               },
               "deterministic": true
             },
@@ -12540,7 +12540,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057510+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468370+00:00"
           },
           "name": {
             "type": "string",
@@ -12584,7 +12584,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272574+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949190+00:00"
               },
               "deterministic": true
             },
@@ -12596,7 +12596,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057539+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468385+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -12637,8 +12637,8 @@
           "description": "Minimum configuration for schemaOpenApiValidationProperties",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaOpenApiValidationProperties\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_open_api_validation_propertieses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12659,8 +12659,8 @@
           "description": "Minimum configuration for schemaSortOrder",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaSortOrder\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_sort_orders\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12681,8 +12681,8 @@
           "description": "Minimum configuration for schemaTrendSentiment",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaTrendSentiment\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_trend_sentiments\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -12710,7 +12710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:09:37.272653+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12722,7 +12722,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468404+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -12737,7 +12737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.272705+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12763,7 +12763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.272754+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12775,7 +12775,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057639+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468430+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -12838,7 +12838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:37.272803+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13006,8 +13006,8 @@
           "description": "Minimum configuration for schemaapp_securityKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaapp_securityKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaapp_securityKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaapp_security_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -13026,8 +13026,8 @@
           "description": "Minimum configuration for schemaapp_securityMetricField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaapp_securityMetricField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaapp_securityMetricField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaapp_security_metric_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -13138,8 +13138,8 @@
           "description": "Minimum configuration for schemaapp_securityMultiKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaapp_securityMultiKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaapp_securityMultiKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schemaapp_security_multi_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "virtual"
@@ -13253,7 +13253,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.272982+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949355+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13269,7 +13269,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057867+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468546+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -13329,7 +13329,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273046+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13412,7 +13412,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273133+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13424,7 +13424,7 @@
             "x-original-maxLength": 256,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057949+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468589+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -13495,7 +13495,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273206+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949458+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13511,7 +13511,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.057981+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468605+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13548,7 +13548,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273273+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949491+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13564,7 +13564,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.058011+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468621+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13593,7 +13593,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:09:37.273347+00:00"
+                "validatedAt": "2026-05-09T01:32:11.949525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13607,7 +13607,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:29.058041+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:03.468637+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -13723,8 +13723,8 @@
           "description": "Minimum configuration for suspicious_user_logNumKeyField",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for suspicious_user_logNumKeyField\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for suspicious_user_logNumKeyField\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/suspicious_user_log_num_key_fields\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "statistics"
@@ -13752,7 +13752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:09:43.639801+00:00"
+                "validatedAt": "2026-05-09T01:32:14.743275+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/users.json
+++ b/docs/specifications/api/users.json
@@ -3387,7 +3387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:18:18.206619+00:00"
+                "validatedAt": "2026-05-09T01:36:02.664191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3399,7 +3399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.796554+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.043482+00:00"
           },
           "key": {
             "type": "string",
@@ -3416,7 +3416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:18.206692+00:00"
+                "validatedAt": "2026-05-09T01:36:02.664210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3428,7 +3428,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.796602+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.043499+00:00"
           },
           "value": {
             "type": "string",
@@ -3445,7 +3445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:18:18.206767+00:00"
+                "validatedAt": "2026-05-09T01:36:02.664228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3457,7 +3457,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:40.796635+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.043515+00:00"
           }
         },
         "x-f5xc-description-short": "Generic Label type label.key(label.value).",
@@ -3501,7 +3501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:29.235282+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3513,7 +3513,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191487+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692444+00:00"
           },
           "key": {
             "type": "string",
@@ -3530,7 +3530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:29.235349+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3542,7 +3542,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191521+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692460+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3571,7 +3571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:29.235418+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417492+00:00"
               },
               "deterministic": true
             },
@@ -3584,7 +3584,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191552+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692477+00:00"
           },
           "value": {
             "type": "string",
@@ -3607,7 +3607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:29.235505+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3619,7 +3619,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191599+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692493+00:00"
           }
         },
         "x-f5xc-description-short": "Create label request in shared namespace. Only shared namespace supported.",
@@ -3683,7 +3683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:29.235599+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3695,7 +3695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191648+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692515+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3724,7 +3724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:29.235647+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417558+00:00"
               },
               "deterministic": true
             },
@@ -3737,7 +3737,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191677+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692531+00:00"
           },
           "value": {
             "type": "string",
@@ -3760,7 +3760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:29.235694+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3772,7 +3772,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191706+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692547+00:00"
           }
         },
         "x-f5xc-description-short": "Deletes Label matching label.key=label.value.",
@@ -3800,8 +3800,8 @@
           "description": "Minimum configuration for known_labelDeleteResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for known_labelDeleteResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for known_labelDeleteResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/known_labels\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -3867,7 +3867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:29.235784+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417613+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3879,7 +3879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191753+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692570+00:00"
           },
           "key": {
             "type": "string",
@@ -3896,7 +3896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:29.235818+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3908,7 +3908,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191782+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692586+00:00"
           },
           "value": {
             "type": "string",
@@ -3925,7 +3925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:29.235861+00:00"
+                "validatedAt": "2026-05-09T01:36:34.417646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3937,7 +3937,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.191811+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.692602+00:00"
           }
         },
         "x-f5xc-description-short": "Generic Label type label.key(label.value).",
@@ -3981,7 +3981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:35.323940+00:00"
+                "validatedAt": "2026-05-09T01:36:37.203796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3993,7 +3993,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.270660+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.729641+00:00"
           },
           "key": {
             "type": "string",
@@ -4010,7 +4010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:35.324009+00:00"
+                "validatedAt": "2026-05-09T01:36:37.203816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4022,7 +4022,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.270698+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.729658+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4051,7 +4051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:35.324078+00:00"
+                "validatedAt": "2026-05-09T01:36:37.203838+00:00"
               },
               "deterministic": true
             },
@@ -4064,7 +4064,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.270729+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.729674+00:00"
           }
         },
         "x-f5xc-description-short": "Create label Key request in shared namespace. Only shared namespace supported.",
@@ -4127,7 +4127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:35.324151+00:00"
+                "validatedAt": "2026-05-09T01:36:37.203857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4139,7 +4139,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.270774+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.729698+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4169,7 +4169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:19:35.324227+00:00"
+                "validatedAt": "2026-05-09T01:36:37.203876+00:00"
               },
               "deterministic": true
             },
@@ -4182,7 +4182,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.270805+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.729714+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4208,8 +4208,8 @@
           "description": "Minimum configuration for known_label_keyDeleteResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for known_label_keyDeleteResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for known_label_keyDeleteResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/known_label_keies\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -4276,7 +4276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:19:35.324316+00:00"
+                "validatedAt": "2026-05-09T01:36:37.203915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4288,7 +4288,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.270852+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.729738+00:00"
           },
           "key": {
             "type": "string",
@@ -4305,7 +4305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:19:35.324349+00:00"
+                "validatedAt": "2026-05-09T01:36:37.203930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4317,7 +4317,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:42.270881+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:09.729754+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4350,7 +4350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.778208+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4373,7 +4373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.778274+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4385,7 +4385,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.777926+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170716+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4431,7 +4431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-08T20:26:48.778326+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545506+00:00"
               },
               "deterministic": true
             },
@@ -4457,7 +4457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.778381+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4484,7 +4484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.778425+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4496,7 +4496,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.777987+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170745+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4513,7 +4513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.778477+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4546,7 +4546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.778528+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4558,7 +4558,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778029+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170766+00:00"
           },
           "type": {
             "type": "string",
@@ -4583,7 +4583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.778570+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545616+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4637,8 +4637,8 @@
           "description": "Minimum configuration for schemaErrorCode",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaErrorCode\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_error_codes\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -4671,7 +4671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.778644+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4733,7 +4733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.778688+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545660+00:00"
               },
               "deterministic": true
             },
@@ -4746,7 +4746,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778108+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170814+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -4864,7 +4864,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.778820+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545722+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4880,7 +4880,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778176+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170849+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4950,7 +4950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.778874+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545745+00:00"
               },
               "deterministic": true
             },
@@ -4963,7 +4963,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778228+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170875+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4994,7 +4994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.778911+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545762+00:00"
               },
               "deterministic": true
             },
@@ -5007,7 +5007,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778259+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170891+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -5089,7 +5089,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779011+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545808+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5105,7 +5105,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778303+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170914+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5177,7 +5177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779060+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545831+00:00"
               },
               "deterministic": true
             },
@@ -5190,7 +5190,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778355+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170940+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5221,7 +5221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779096+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545848+00:00"
               },
               "deterministic": true
             },
@@ -5234,7 +5234,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778386+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170956+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5316,7 +5316,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779194+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545894+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5332,7 +5332,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778430+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.170979+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5404,7 +5404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779243+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545916+00:00"
               },
               "deterministic": true
             },
@@ -5417,7 +5417,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778481+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171008+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5448,7 +5448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779278+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545933+00:00"
               },
               "deterministic": true
             },
@@ -5461,7 +5461,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778512+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171024+00:00"
           },
           "uid": {
             "type": "string",
@@ -5480,7 +5480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779311+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5495,7 +5495,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778544+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171041+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -5542,7 +5542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779350+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5555,7 +5555,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778577+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171061+00:00"
           },
           "name": {
             "type": "string",
@@ -5588,7 +5588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779386+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545981+00:00"
               },
               "deterministic": true
             },
@@ -5601,7 +5601,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778624+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171078+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5632,7 +5632,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779422+00:00"
+                "validatedAt": "2026-05-09T01:39:53.545998+00:00"
               },
               "deterministic": true
             },
@@ -5645,7 +5645,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778654+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171097+00:00"
           },
           "tenant": {
             "type": "string",
@@ -5664,7 +5664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779463+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5678,7 +5678,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778685+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171117+00:00"
           },
           "uid": {
             "type": "string",
@@ -5697,7 +5697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779496+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5712,7 +5712,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778716+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171133+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -5794,7 +5794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779610+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546077+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5810,7 +5810,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778762+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171160+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5880,7 +5880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779661+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546097+00:00"
               },
               "deterministic": true
             },
@@ -5893,7 +5893,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778814+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171187+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5924,7 +5924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.779695+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546113+00:00"
               },
               "deterministic": true
             },
@@ -5937,7 +5937,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778844+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171203+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -5982,7 +5982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779750+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6010,7 +6010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779800+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6038,7 +6038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779847+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6067,7 +6067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779895+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6094,7 +6094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779927+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6108,7 +6108,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778928+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171245+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -6124,7 +6124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.779971+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6187,8 +6187,8 @@
           "description": "Minimum configuration for schemaStatusPublishType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaStatusPublishType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_status_publish_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"
@@ -6233,7 +6233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780033+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6245,7 +6245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.778993+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171278+00:00"
           },
           "status": {
             "type": "string",
@@ -6263,7 +6263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780076+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6275,7 +6275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779022+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171293+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -6317,7 +6317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780130+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6344,7 +6344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780179+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6371,7 +6371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780226+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6399,7 +6399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780279+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6464,7 +6464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780356+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6513,7 +6513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780420+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6526,7 +6526,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779156+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171362+00:00"
           },
           "uid": {
             "type": "string",
@@ -6545,7 +6545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780452+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6559,7 +6559,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779187+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171378+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -6611,7 +6611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780505+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6639,7 +6639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780554+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6668,7 +6668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780618+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6695,7 +6695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780665+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6724,7 +6724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780716+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6749,7 +6749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780767+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6814,7 +6814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780846+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6852,7 +6852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.780909+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6864,7 +6864,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779319+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171451+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -6905,7 +6905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.780973+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6949,7 +6949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.781019+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6963,7 +6963,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779387+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171487+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -6982,7 +6982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.781067+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7009,7 +7009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.781099+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7024,7 +7024,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779428+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171518+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -7039,7 +7039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.781143+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7120,7 +7120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.781188+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7132,7 +7132,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779480+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171545+00:00"
           },
           "name": {
             "type": "string",
@@ -7165,7 +7165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.781224+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546846+00:00"
               },
               "deterministic": true
             },
@@ -7178,7 +7178,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779510+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171560+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7209,7 +7209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.781260+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546864+00:00"
               },
               "deterministic": true
             },
@@ -7222,7 +7222,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779539+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171576+00:00"
           },
           "uid": {
             "type": "string",
@@ -7239,7 +7239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.781293+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7253,7 +7253,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779569+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171592+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -7293,8 +7293,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tokenCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tokenCreateRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tokens\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -7339,8 +7339,8 @@
           "description": "Minimum configuration for tokenCreateSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tokenCreateSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tokenCreateSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/tokens\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -7395,7 +7395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.781354+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546905+00:00"
               },
               "deterministic": true
             },
@@ -7408,7 +7408,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779680+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171640+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7438,7 +7438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.781389+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546922+00:00"
               },
               "deterministic": true
             },
@@ -7451,7 +7451,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779710+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171656+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7488,7 +7488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.781443+00:00"
+                "validatedAt": "2026-05-09T01:39:53.546946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7500,7 +7500,7 @@
             "x-original-maxLength": 1024,
             "minLength": 279,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779745+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171673+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7601,7 +7601,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779844+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171725+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -7717,7 +7717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-08T20:26:48.781600+00:00"
+                "validatedAt": "2026-05-09T01:39:53.547009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7779,7 +7779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-08T20:26:48.781666+00:00"
+                "validatedAt": "2026-05-09T01:39:53.547038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7791,7 +7791,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.779945+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171776+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7857,7 +7857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.781719+00:00"
+                "validatedAt": "2026-05-09T01:39:53.547062+00:00"
               },
               "deterministic": true
             },
@@ -7870,7 +7870,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.780014+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171812+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7899,7 +7899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.781754+00:00"
+                "validatedAt": "2026-05-09T01:39:53.547079+00:00"
               },
               "deterministic": true
             },
@@ -7912,7 +7912,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.780044+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171827+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7951,7 +7951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.781818+00:00"
+                "validatedAt": "2026-05-09T01:39:53.547105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7964,7 +7964,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.780102+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171857+00:00"
           },
           "uid": {
             "type": "string",
@@ -7981,7 +7981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-08T20:26:48.781851+00:00"
+                "validatedAt": "2026-05-09T01:39:53.547119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7995,7 +7995,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.780133+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171873+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of token is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -8102,8 +8102,8 @@
             "spec"
           ],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tokenReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec:",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tokenReplaceRequest\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/token_replace_requests\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -8115,8 +8115,8 @@
           "description": "Minimum configuration for tokenReplaceResponse",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tokenReplaceResponse\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tokenReplaceResponse\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/token_replace_responses\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -8133,8 +8133,8 @@
           "description": "Minimum configuration for tokenReplaceSpecType",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tokenReplaceSpecType\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tokenReplaceSpecType\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/token_replace_spec_types\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -8179,8 +8179,8 @@
           "description": "Minimum configuration for tokenState",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for tokenState\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for tokenState\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/token_states\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "users"
@@ -8222,7 +8222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.781915+00:00"
+                "validatedAt": "2026-05-09T01:39:53.547148+00:00"
               },
               "deterministic": true
             },
@@ -8235,7 +8235,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.780248+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171930+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8264,7 +8264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-08T20:26:48.781949+00:00"
+                "validatedAt": "2026-05-09T01:39:53.547171+00:00"
               },
               "deterministic": true
             },
@@ -8277,7 +8277,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-08T20:29:51.780278+00:00"
+            "x-reconciled-at": "2026-05-09T01:41:14.171946+00:00"
           },
           "state": {
             "$ref": "#/components/schemas/tokenState"

--- a/docs/specifications/api/validation.json
+++ b/docs/specifications/api/validation.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "version": "2.1.0",
   "description": "Centralized validation specification for F5 XC API",
-  "generated_at": "2026-05-08T20:30:20.092329+00:00",
+  "generated_at": "2026-05-09T01:41:28.192834+00:00",
   "source": "api-specs-enriched",
   "required_fields": {
     "common": {
@@ -976,8 +976,5 @@
     "oneof_defaults_exported": 0,
     "ui_vs_server_defaults_exported": 1,
     "warnings": []
-  },
-  "info": {
-    "version": "2.1.78"
   }
 }

--- a/docs/specifications/api/vpm_and_node_management.json
+++ b/docs/specifications/api/vpm_and_node_management.json
@@ -354,8 +354,8 @@
           "description": "Minimum configuration for schemaEmpty",
           "required_fields": [],
           "mutually_exclusive_groups": [],
-          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default",
-          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  }\n}",
+          "example_yaml": "# Minimal example for schemaEmpty\nmetadata:\n  name: example\n  namespace: default\nspec: {}",
+          "example_json": "{\n  \"metadata\": {\n    \"name\": \"example\",\n    \"namespace\": \"default\"\n  },\n  \"spec\": {}\n}",
           "example_curl": "curl -X POST \"$F5XC_API_URL/api/config/namespaces/default/schema_empties\" \\\n  -H \"Authorization: APIToken $F5XC_API_TOKEN\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @example.json"
         },
         "x-f5xc-cli-domain": "other"

--- a/scripts/utils/minimum_configuration_enricher.py
+++ b/scripts/utils/minimum_configuration_enricher.py
@@ -319,13 +319,18 @@ class MinimumConfigurationEnricher:
         ]
 
         if required_fields:
-            lines.append("spec:")
             spec_fields = [
                 f"  {field}: value"
                 for field in required_fields[:5]
                 if field not in ["metadata", "apiVersion", "kind", "spec"]
             ]
-            lines.extend(spec_fields)
+            if spec_fields:
+                lines.append("spec:")
+                lines.extend(spec_fields)
+            else:
+                lines.append("spec: {}")
+        else:
+            lines.append("spec: {}")
 
         return "\n".join(lines)
 
@@ -354,6 +359,10 @@ class MinimumConfigurationEnricher:
             }
             if spec_fields:
                 example["spec"] = spec_fields
+            else:
+                example["spec"] = {}
+        else:
+            example["spec"] = {}
 
         return json.dumps(example, indent=2)
 
@@ -542,10 +551,14 @@ class MinimumConfigurationEnricher:
             return schema_name
 
         # Remove common prefixes (e.g., "views", "api", "schema")
+        # Skip stripping when remainder starts with underscore — the prefix
+        # is part of the resource name (e.g., "api_definition"), not a namespace.
         working_name = schema_name
         for prefix in ["views", "api", "schema"]:
             if working_name.startswith(prefix):
-                working_name = working_name[len(prefix) :]
+                remaining = working_name[len(prefix) :]
+                if remaining and remaining[0] != "_":
+                    working_name = remaining
                 break
 
         # Remove common suffixes in order of specificity

--- a/tests/test_minimum_configuration_enricher.py
+++ b/tests/test_minimum_configuration_enricher.py
@@ -942,5 +942,76 @@ class TestSubSchemaNotConfigEnriched:
         assert "x-f5xc-cli-domain" in schema
 
 
+class TestPrefixStrippingFix:
+    """Test that resource names starting with 'api_' are not broken by prefix stripping."""
+
+    def test_api_definition_create_request_detected(self):
+        """api_definitionCreateRequest should detect as api_definition, not None."""
+        enricher = MinimumConfigurationEnricher()
+        result = enricher._detect_resource_type("api_definitionCreateRequest")
+        assert result == "api_definition"
+
+    def test_api_discovery_create_request_detected(self):
+        """api_discoveryCreateRequest should detect as api_discovery."""
+        enricher = MinimumConfigurationEnricher()
+        result = enricher._detect_resource_type("api_discoveryCreateRequest")
+        assert result == "api_discovery"
+
+    def test_views_prefix_still_stripped(self):
+        """viewsorigin_poolCreateSpecType should still strip 'views' prefix."""
+        enricher = MinimumConfigurationEnricher()
+        result = enricher._detect_resource_type("viewsorigin_poolCreateSpecType")
+        assert result == "origin_pool"
+
+    def test_schema_prefix_still_stripped(self):
+        """schemaservice_policyCreateSpecType should still strip 'schema' prefix."""
+        enricher = MinimumConfigurationEnricher()
+        result = enricher._detect_resource_type("schemaservice_policyCreateSpecType")
+        assert result == "service_policy"
+
+
+class TestSpecKeyAlwaysPresent:
+    """Test that auto-generated min configs always include spec: {} (#344)."""
+
+    def _make_spec_with_schema(self, schema_name, schema):
+        return {"components": {"schemas": {schema_name: schema}}}
+
+    def test_json_includes_spec_key_when_no_spec_fields(self):
+        """Auto-generated JSON should include 'spec': {} even with no required spec fields."""
+        enricher = MinimumConfigurationEnricher()
+        schema = {
+            "type": "object",
+            "properties": {
+                "metadata": {"type": "object"},
+                "spec": {"$ref": "#/components/schemas/SomeSpec"},
+            },
+        }
+        spec = self._make_spec_with_schema("UnknownResourceCreateRequest", schema)
+        enriched = enricher.enrich_spec(spec)
+        mc = enriched["components"]["schemas"]["UnknownResourceCreateRequest"]
+        example_json = mc.get("x-f5xc-minimum-configuration", {}).get("example_json", "")
+        assert '"spec": {}' in example_json or '"spec": {' in example_json, (
+            f"spec key must be present in auto-generated JSON, got: {example_json}"
+        )
+
+    def test_yaml_includes_spec_key_when_no_spec_fields(self):
+        """Auto-generated YAML should include 'spec: {}' even with no required spec fields."""
+        enricher = MinimumConfigurationEnricher()
+        schema = {
+            "type": "object",
+            "properties": {
+                "metadata": {"type": "object"},
+                "spec": {"$ref": "#/components/schemas/SomeSpec"},
+            },
+        }
+        spec = self._make_spec_with_schema("UnknownResourceCreateRequest", schema)
+        enriched = enricher.enrich_spec(spec)
+        mc = enriched["components"]["schemas"]["UnknownResourceCreateRequest"]
+        example_yaml = mc.get("x-f5xc-minimum-configuration", {}).get("example_yaml", "")
+        assert "spec: {}" in example_yaml or "spec:" in example_yaml, (
+            f"spec key must be present in auto-generated YAML, got: {example_yaml}"
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes #344. Fixes #345. Fixes #346.

**Four fixes in one PR:**

1. **Prefix stripping fix** (`minimum_configuration_enricher.py`) — `_detect_resource_type()` stripped "api" from "api_definitionCreateRequest" leaving "_definitionCreateRequest" which didn't match any resource. Fix: don't strip prefix when remainder starts with underscore (indicates prefix is part of resource name, not a namespace).

2. **spec:{} always included** (`minimum_configuration_enricher.py`) — Auto-generated min config JSON omitted the `spec` key when no spec fields were found. The F5 XC API requires `spec: {}`. Fix: always include `spec: {}` in both JSON and YAML generators.

3. **rate_limiter_policy required fields** (`minimum_configs.yaml`) — API requires `burst_size >= 1` and `committed_information_rate >= 1`. Updated required_fields and examples.

4. **Certificate private_key oneOf** (`discovered_defaults.yaml`) — Added nested `private_key` oneOf recommendation with `clear_secret_info` as recommended variant (simpler for testing than `blindfold_secret_info`).

## Test plan

- [ ] 6 new tests: prefix stripping (4) + spec key always present (2)
- [ ] 63 total tests pass, 0 regressions
- [ ] ruff, pylint (10/10), mypy all clean
- [ ] CI checks pass