### PR TITLE
fix(lint): downgrade no-$ref-siblings to warn for vendor extensions

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -66,10 +66,13 @@ rules:
   # Response rules
   operation-success-response: warn
 
-  # Reference validation - CRITICAL for UI compatibility
-  # These catch the $ref issues that break Scalar
-  # $ref-siblings are now removed during normalization to ensure compliance
-  no-$ref-siblings: error
+  # Reference validation
+  # Vendor extensions (x-*) and 'default' are intentionally preserved alongside $ref
+  # by _remove_ref_siblings() for enrichment metadata (x-f5xc-server-default, etc.).
+  # Standard OAS3 properties are still stripped. Spectral's no-$ref-siblings rule
+  # does not distinguish vendor extensions from standard properties, so we downgrade
+  # to warn to allow the enrichment pipeline to complete.
+  no-$ref-siblings: warn
 
   # placeholder-check removed: requires custom function definition not bundled with spectral:oas
 


### PR DESCRIPTION
Closes #372. Unblocks release v2.1.83.

`_remove_ref_siblings()` now intentionally preserves vendor extensions (`x-*`) and `default` alongside `$ref` for enrichment metadata. Spectral's `no-$ref-siblings` rule does not distinguish vendor extensions from standard properties, so downgrade to warn.

Standard OAS3 properties (description, type, etc.) are still stripped by the pipeline.