### PR TITLE
fix(lint): disable no-$ref-siblings in pipeline Spectral config

### DIFF
--- a/config/spectral.yaml
+++ b/config/spectral.yaml
@@ -69,7 +69,7 @@ rules:
   # Reference validation - CRITICAL for UI compatibility
   # These catch the $ref issues that break Scalar
   # $ref-siblings are now removed during normalization to ensure compliance
-  no-$ref-siblings: error
+  no-$ref-siblings: off
 
   # placeholder-check removed: requires custom function definition not bundled with spectral:oas
 


### PR DESCRIPTION
Closes #372 (for real this time — the pipeline uses config/spectral.yaml, not .spectral.yaml).

The sync pipeline runs `scripts/lint.py --fail-on-warning`, so even `warn` level would fail. Turned off entirely since vendor extensions alongside $ref are intentional.