### PR TITLE
feat: enable repository dispatch to vscode-f5xc-tools

### DIFF
--- a/config/downstream_repos.yaml
+++ b/config/downstream_repos.yaml
@@ -18,11 +18,11 @@ downstream_repositories:
     enabled: true
     description: Interactive CLI shell for F5 XC resource management
 
-  # VS Code F5 XC Tools - VS Code extension (repo does not exist)
+  # VS Code F5 XC Tools - VS Code extension
   - owner: f5xc-salesdemos
     repo: vscode-f5xc-tools
     event_type: enriched-specs-updated
-    enabled: false
+    enabled: true
     description: VS Code extension for F5 XC development
 
 # Payload sent to downstream repositories (for documentation):


### PR DESCRIPTION
## Summary

- Enable the `vscode-f5xc-tools` downstream repository dispatch entry in `config/downstream_repos.yaml`
- Change `enabled: false` to `enabled: true` and update the comment to remove the "repo does not exist" note
- The VS Code extension repo now exists in the org and needs to receive `enriched-specs-updated` dispatch events for automatic CI rebuilds when API specs change

Closes #420

## Test plan

- [ ] CI checks pass (`Check linked issues` and `Lint Code Base`)
- [ ] Verify the YAML change is syntactically correct (yamllint passes)
- [ ] Confirm the dispatch workflow picks up the enabled flag on next spec release