### PR TITLE
feat: CRUD-verified enrichment for k8s_cluster, network_firewall, enhanced_firewall_policy

### DIFF
--- a/config/discovered_defaults.yaml
+++ b/config/discovered_defaults.yaml
@@ -1125,3 +1125,40 @@ resources:
       - "Empty spec returns 400: Field spec.receiver should be not nil"
       - "No server-applied defaults in spec"
       - "CRUD-verified: POST with {email: {email_address: ...}} succeeds"
+
+  k8s_cluster:
+    description: "Kubernetes cluster server-applied defaults (verified 2026-05-21)"
+    schema_pattern: "k8s_cluster.*SpecType"
+    defaults:
+      no_local_access: {}
+      no_global_access: {}
+      use_default_psp: {}
+      use_default_cluster_roles: {}
+      use_default_cluster_role_bindings: {}
+      no_cluster_wide_apps: {}
+      no_insecure_registries: {}
+      cluster_scoped_access_deny: {}
+      vk8s_namespace_access_deny: {}
+    notes:
+      - "Empty spec accepted — server applies all defaults"
+      - "CRUD-verified against staging API 2026-05-21"
+
+  network_firewall:
+    description: "Network firewall server-applied defaults (verified 2026-05-21)"
+    schema_pattern: "network_firewall.*SpecType"
+    defaults:
+      disable_network_policy: {}
+      disable_forward_proxy_policy: {}
+      disable_fast_acl: {}
+    notes:
+      - "Empty spec accepted — server disables all policy types by default"
+      - "CRUD-verified against staging API 2026-05-21"
+
+  enhanced_firewall_policy:
+    description: "Enhanced firewall policy server-applied defaults (verified 2026-05-21)"
+    schema_pattern: "enhanced_firewall_policy.*SpecType"
+    defaults:
+      allow_all: {}
+    notes:
+      - "Empty spec accepted — server defaults to allow_all"
+      - "CRUD-verified against staging API 2026-05-21"

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -1873,6 +1873,70 @@ resources:
       - "API requires spec.receiver oneOf — empty spec returns 400"
       - "CRUD-verified against staging API 2026-05-20"
 
+  # ============================================================================
+
+  k8s_cluster:
+    description: "Kubernetes cluster configuration for F5 XC managed K8s"
+    domain: "container_services"
+    resource_type: "k8s_cluster"
+
+    required_fields:
+      - "metadata.name"
+      - "metadata.namespace"
+
+    example_yaml: |
+      metadata:
+        name: my-k8s-cluster
+        namespace: system
+      spec: {}
+
+    notes:
+      - "Empty spec accepted — server applies all K8s defaults"
+      - "Server defaults: no_local_access, no_global_access, use_default_psp, etc."
+      - "CRUD-verified against staging API 2026-05-21"
+
+  # ============================================================================
+
+  network_firewall:
+    description: "Network firewall policy for site-level traffic filtering"
+    domain: "network_security"
+    resource_type: "network_firewall"
+
+    required_fields:
+      - "metadata.name"
+      - "metadata.namespace"
+
+    example_yaml: |
+      metadata:
+        name: my-network-firewall
+        namespace: system
+      spec: {}
+
+    notes:
+      - "Empty spec accepted — server defaults to disable_network_policy, disable_forward_proxy_policy, disable_fast_acl"
+      - "CRUD-verified against staging API 2026-05-21"
+
+  # ============================================================================
+
+  enhanced_firewall_policy:
+    description: "Enhanced L4 firewall policy with segment-based access control"
+    domain: "network_security"
+    resource_type: "enhanced_firewall_policy"
+
+    required_fields:
+      - "metadata.name"
+      - "metadata.namespace"
+
+    example_yaml: |
+      metadata:
+        name: my-efp
+        namespace: default
+      spec: {}
+
+    notes:
+      - "Empty spec accepted — server defaults to allow_all"
+      - "CRUD-verified against staging API 2026-05-21"
+
 # Field-level requirements for cross-resource patterns
 field_requirements:
   # These patterns apply across all resources


### PR DESCRIPTION
Closes #453

Adds discovered_defaults.yaml and minimum_configs.yaml entries for 3 resources.

- k8s_cluster: 9 server defaults (empty spec accepted)
- network_firewall: 3 server defaults (disable all policies)
- enhanced_firewall_policy: 1 server default (allow_all)

All CRUD-verified against staging API 2026-05-21. Related: #441