### PR TITLE
fix: use relative hrefs in API catalog cards for correct base path resolution

### DIFF
--- a/docs/api-reference/index.mdx
+++ b/docs/api-reference/index.mdx
@@ -14,72 +14,72 @@ endpoint details, request and response schemas, and code examples.
 ### Security
 
 <CardGrid>
-  <LinkCard title="🔐 Api" description="Interface definitions, schema validation, and grouping. — 45 paths, 279 schemas, advanced" href="/api-reference/api/" />
-  <LinkCard title="🔏 Blindfold" description="Secret encryption, key policies, and audit trails. — 27 paths, 163 schemas, moderate" href="/api-reference/blindfold/" />
-  <LinkCard title="🦠 Bot And Threat Defense" description="Bot detection, threat categories, and defense instances. — 19 paths, 74 schemas, moderate" href="/api-reference/bot_and_threat_defense/" />
-  <LinkCard title="📜 Certificates" description="SSL/TLS chains, trusted CAs, and revocation lists. — 16 paths, 74 schemas, moderate" href="/api-reference/certificates/" />
-  <LinkCard title="🔐 Data And Privacy Security" description="PII detection, data types, and regional compliance. — 11 paths, 65 schemas, simple" href="/api-reference/data_and_privacy_security/" />
-  <LinkCard title="🛑 Ddos" description="Volumetric attack mitigation and traffic scrubbing. — 60 paths, 246 schemas, advanced" href="/api-reference/ddos/" />
-  <LinkCard title="🔒 Network Security" description="NAT policies, firewalls, and segment connections. — 62 paths, 386 schemas, advanced" href="/api-reference/network_security/" />
-  <LinkCard title="🚨 Secops And Incident Response" description="Threat detection, user risk scoring, and automated blocking. — 4 paths, 32 schemas, simple" href="/api-reference/secops_and_incident_response/" />
-  <LinkCard title="🎭 Shape" description="Bot defense, fraud prevention, and client integrity. — 271 paths, 813 schemas, advanced" href="/api-reference/shape/" />
-  <LinkCard title="⚠️ Threat Campaign" description="Attack detection, tracking, and mitigation rules. — 1 paths, 161 schemas, moderate" href="/api-reference/threat_campaign/" />
+  <LinkCard title="🔐 Api" description="Interface definitions, schema validation, and grouping. — 45 paths, 279 schemas, advanced" href="./api/" />
+  <LinkCard title="🔏 Blindfold" description="Secret encryption, key policies, and audit trails. — 27 paths, 163 schemas, moderate" href="./blindfold/" />
+  <LinkCard title="🦠 Bot And Threat Defense" description="Bot detection, threat categories, and defense instances. — 19 paths, 74 schemas, moderate" href="./bot_and_threat_defense/" />
+  <LinkCard title="📜 Certificates" description="SSL/TLS chains, trusted CAs, and revocation lists. — 16 paths, 74 schemas, moderate" href="./certificates/" />
+  <LinkCard title="🔐 Data And Privacy Security" description="PII detection, data types, and regional compliance. — 11 paths, 65 schemas, simple" href="./data_and_privacy_security/" />
+  <LinkCard title="🛑 Ddos" description="Volumetric attack mitigation and traffic scrubbing. — 60 paths, 246 schemas, advanced" href="./ddos/" />
+  <LinkCard title="🔒 Network Security" description="NAT policies, firewalls, and segment connections. — 62 paths, 386 schemas, advanced" href="./network_security/" />
+  <LinkCard title="🚨 Secops And Incident Response" description="Threat detection, user risk scoring, and automated blocking. — 4 paths, 32 schemas, simple" href="./secops_and_incident_response/" />
+  <LinkCard title="🎭 Shape" description="Bot defense, fraud prevention, and client integrity. — 271 paths, 813 schemas, advanced" href="./shape/" />
+  <LinkCard title="⚠️ Threat Campaign" description="Attack detection, tracking, and mitigation rules. — 1 paths, 161 schemas, moderate" href="./threat_campaign/" />
 </CardGrid>
 
 ### Networking
 
 <CardGrid>
-  <LinkCard title="🚀 Cdn" description="Content delivery and edge caching networks. — 29 paths, 592 schemas, advanced" href="/api-reference/cdn/" />
-  <LinkCard title="🌐 Dns" description="Authoritative zones and record management. — 49 paths, 285 schemas, advanced" href="/api-reference/dns/" />
-  <LinkCard title="🔌 Network" description="BGP peering, IPsec tunnels, and segment policies. — 81 paths, 449 schemas, advanced" href="/api-reference/network/" />
-  <LinkCard title="⏱️ Rate Limiting" description="Request throttling, quotas, and policer rules. — 12 paths, 70 schemas, simple" href="/api-reference/rate_limiting/" />
-  <LinkCard title="⚖️ Virtual" description="HTTP, TCP, UDP load balancing with origin pools. — 133 paths, 903 schemas, advanced" href="/api-reference/virtual/" />
+  <LinkCard title="🚀 Cdn" description="Content delivery and edge caching networks. — 29 paths, 592 schemas, advanced" href="./cdn/" />
+  <LinkCard title="🌐 Dns" description="Authoritative zones and record management. — 49 paths, 285 schemas, advanced" href="./dns/" />
+  <LinkCard title="🔌 Network" description="BGP peering, IPsec tunnels, and segment policies. — 81 paths, 449 schemas, advanced" href="./network/" />
+  <LinkCard title="⏱️ Rate Limiting" description="Request throttling, quotas, and policer rules. — 12 paths, 70 schemas, simple" href="./rate_limiting/" />
+  <LinkCard title="⚖️ Virtual" description="HTTP, TCP, UDP load balancing with origin pools. — 133 paths, 903 schemas, advanced" href="./virtual/" />
 </CardGrid>
 
 ### Infrastructure
 
 <CardGrid>
-  <LinkCard title="🔧 Ce Management" description="Network interfaces, fleets, and site registration. — 28 paths, 231 schemas, moderate" href="/api-reference/ce_management/" />
-  <LinkCard title="☁️ Cloud Infrastructure" description="AWS, Azure, GCP connectors and VPC attachments. — 31 paths, 208 schemas, moderate" href="/api-reference/cloud_infrastructure/" />
-  <LinkCard title="📦 Container Services" description="Containerized workloads and virtual Kubernetes clusters. — 13 paths, 159 schemas, moderate" href="/api-reference/container_services/" />
-  <LinkCard title="⚙️ Managed Kubernetes" description="Cluster RBAC, pod security, and container registries. — 20 paths, 95 schemas, moderate" href="/api-reference/managed_kubernetes/" />
-  <LinkCard title="🕸️ Service Mesh" description="Microservice routing and sidecar configuration. — 38 paths, 247 schemas, advanced" href="/api-reference/service_mesh/" />
-  <LinkCard title="🌍 Sites" description="Cloud and edge node deployments. — 133 paths, 1015 schemas, advanced" href="/api-reference/sites/" />
+  <LinkCard title="🔧 Ce Management" description="Network interfaces, fleets, and site registration. — 28 paths, 231 schemas, moderate" href="./ce_management/" />
+  <LinkCard title="☁️ Cloud Infrastructure" description="AWS, Azure, GCP connectors and VPC attachments. — 31 paths, 208 schemas, moderate" href="./cloud_infrastructure/" />
+  <LinkCard title="📦 Container Services" description="Containerized workloads and virtual Kubernetes clusters. — 13 paths, 159 schemas, moderate" href="./container_services/" />
+  <LinkCard title="⚙️ Managed Kubernetes" description="Cluster RBAC, pod security, and container registries. — 20 paths, 95 schemas, moderate" href="./managed_kubernetes/" />
+  <LinkCard title="🕸️ Service Mesh" description="Microservice routing and sidecar configuration. — 38 paths, 247 schemas, advanced" href="./service_mesh/" />
+  <LinkCard title="🌍 Sites" description="Cloud and edge node deployments. — 133 paths, 1015 schemas, advanced" href="./sites/" />
 </CardGrid>
 
 ### Platform
 
 <CardGrid>
-  <LinkCard title="🖥️ Admin Console And Ui" description="Static UI components and console assets. — 2 paths, 14 schemas, simple" href="/api-reference/admin_console_and_ui/" />
-  <LinkCard title="🔑 Authentication" description="Identity provider and access policy configuration. — 14 paths, 38 schemas, simple" href="/api-reference/authentication/" />
-  <LinkCard title="🏢 Bigip" description="iRules, data groups, and APM integration. — 29 paths, 238 schemas, advanced" href="/api-reference/bigip/" />
-  <LinkCard title="💳 Billing And Usage" description="Subscription plans, payment methods, and quotas. — 25 paths, 101 schemas, moderate" href="/api-reference/billing_and_usage/" />
-  <LinkCard title="🏪 Marketplace" description="Add-on services, connectors, and TPM policies. — 36 paths, 183 schemas, moderate" href="/api-reference/marketplace/" />
-  <LinkCard title="🟢 Nginx One" description="NGINX Plus instances and dataplane servers. — 13 paths, 59 schemas, simple" href="/api-reference/nginx_one/" />
-  <LinkCard title="🗄️ Object Storage" description="Mobile SDK assets, versioned binaries, and app shield files. — 9 paths, 17 schemas, simple" href="/api-reference/object_storage/" />
-  <LinkCard title="🪪 Tenant And Identity" description="User profiles, sessions, and OTP settings. — 183 paths, 511 schemas, advanced" href="/api-reference/tenant_and_identity/" />
-  <LinkCard title="👥 Users" description="Account tokens, labels, and cloud-init config. — 13 paths, 50 schemas, simple" href="/api-reference/users/" />
-  <LinkCard title="🖥️ Vpm And Node Management" description="Node lifecycle, fleet grouping, and orchestration. — 1 paths, 2 schemas, simple" href="/api-reference/vpm_and_node_management/" />
+  <LinkCard title="🖥️ Admin Console And Ui" description="Static UI components and console assets. — 2 paths, 14 schemas, simple" href="./admin_console_and_ui/" />
+  <LinkCard title="🔑 Authentication" description="Identity provider and access policy configuration. — 14 paths, 38 schemas, simple" href="./authentication/" />
+  <LinkCard title="🏢 Bigip" description="iRules, data groups, and APM integration. — 29 paths, 238 schemas, advanced" href="./bigip/" />
+  <LinkCard title="💳 Billing And Usage" description="Subscription plans, payment methods, and quotas. — 25 paths, 101 schemas, moderate" href="./billing_and_usage/" />
+  <LinkCard title="🏪 Marketplace" description="Add-on services, connectors, and TPM policies. — 36 paths, 183 schemas, moderate" href="./marketplace/" />
+  <LinkCard title="🟢 Nginx One" description="NGINX Plus instances and dataplane servers. — 13 paths, 59 schemas, simple" href="./nginx_one/" />
+  <LinkCard title="🗄️ Object Storage" description="Mobile SDK assets, versioned binaries, and app shield files. — 9 paths, 17 schemas, simple" href="./object_storage/" />
+  <LinkCard title="🪪 Tenant And Identity" description="User profiles, sessions, and OTP settings. — 183 paths, 511 schemas, advanced" href="./tenant_and_identity/" />
+  <LinkCard title="👥 Users" description="Account tokens, labels, and cloud-init config. — 13 paths, 50 schemas, simple" href="./users/" />
+  <LinkCard title="🖥️ Vpm And Node Management" description="Node lifecycle, fleet grouping, and orchestration. — 1 paths, 2 schemas, simple" href="./vpm_and_node_management/" />
 </CardGrid>
 
 ### Operations
 
 <CardGrid>
-  <LinkCard title="🧠 Data Intelligence" description="Classification, insights, and policy management. — 15 paths, 73 schemas, simple" href="/api-reference/data_intelligence/" />
-  <LinkCard title="📊 Observability" description="Synthetic health checks and DNS resolution validation. — 56 paths, 196 schemas, moderate" href="/api-reference/observability/" />
-  <LinkCard title="📈 Statistics" description="Alerts, logs, flow analytics, and reporting. — 77 paths, 575 schemas, advanced" href="/api-reference/statistics/" />
-  <LinkCard title="🎫 Support" description="Tickets, escalations, and network diagnostics. — 53 paths, 167 schemas, moderate" href="/api-reference/support/" />
-  <LinkCard title="📉 Telemetry And Insights" description="Metrics collection, analysis, and visualization. — 27 paths, 181 schemas, moderate" href="/api-reference/telemetry_and_insights/" />
+  <LinkCard title="🧠 Data Intelligence" description="Classification, insights, and policy management. — 15 paths, 73 schemas, simple" href="./data_intelligence/" />
+  <LinkCard title="📊 Observability" description="Synthetic health checks and DNS resolution validation. — 56 paths, 196 schemas, moderate" href="./observability/" />
+  <LinkCard title="📈 Statistics" description="Alerts, logs, flow analytics, and reporting. — 77 paths, 575 schemas, advanced" href="./statistics/" />
+  <LinkCard title="🎫 Support" description="Tickets, escalations, and network diagnostics. — 53 paths, 167 schemas, moderate" href="./support/" />
+  <LinkCard title="📉 Telemetry And Insights" description="Metrics collection, analysis, and visualization. — 27 paths, 181 schemas, moderate" href="./telemetry_and_insights/" />
 </CardGrid>
 
 ### AI
 
 <CardGrid>
-  <LinkCard title="🤖 Ai Services (Preview)" description="AI assistant queries and feedback collection. — 11 paths, 66 schemas, simple" href="/api-reference/ai_services/" />
+  <LinkCard title="🤖 Ai Services (Preview)" description="AI assistant queries and feedback collection. — 11 paths, 66 schemas, simple" href="./ai_services/" />
 </CardGrid>
 
 ### Other
 
 <CardGrid>
-  <LinkCard title="📁 Other" description="Other — 0 paths, 0 schemas, simple" href="/api-reference/other/" />
+  <LinkCard title="📁 Other" description="Other — 0 paths, 0 schemas, simple" href="./other/" />
 </CardGrid>

--- a/scripts/generate_api_viewer.py
+++ b/scripts/generate_api_viewer.py
@@ -92,7 +92,7 @@ def generate_catalog_mdx(
             cards.append(
                 f'  <LinkCard title="{icon} {title}{badge}" '
                 f'description="{description_line} — {stats_line}" '
-                f'href="/api-reference/{domain}/" />',
+                f'href="./{domain}/" />',
             )
 
         cards_block = "\n".join(cards)


### PR DESCRIPTION
## Summary

- Card links on the API Reference catalog page were resolving to the wrong URL because absolute hrefs (`/api-reference/{domain}/`) don't get the site base path prepended by Starlight's LinkCard component
- Changed href generation in `scripts/generate_api_viewer.py` from absolute to relative paths (`./{domain}/`)
- Regenerated `docs/api-reference/index.mdx` with the corrected relative hrefs

Closes #506

## Test plan

- [ ] CI checks pass
- [ ] Verify API catalog card links resolve correctly with base path (e.g., `.../api-specs-enriched/api-reference/api/` instead of `.../api-reference/api/`)
- [ ] Confirm no broken links in generated documentation