### PR TITLE
fix: add additional upstream API typo corrections to generated MDX

### DIFF
--- a/scripts/generate_api_viewer.py
+++ b/scripts/generate_api_viewer.py
@@ -121,6 +121,11 @@ endpoint details, request and response schemas, and code examples.
 
 UPSTREAM_TYPOS = {
     "Con" + "nnect": "Connect",
+    "Subsci" + "ption": "Subscription",
+    "Insatn" + "ce": "Instance",
+    "avaialab" + "le": "available",
+    "Sou" + "ce": "Source",
+    "pro" + "xys": "proxies",
 }
 
 


### PR DESCRIPTION
## Summary

- Add five new upstream F5 API typos to the `UPSTREAM_TYPOS` dictionary in `generate_api_viewer.py`: "Subsciption", "Insatnce", "avaialable", "Souce", "proxys"
- These typos originate from upstream API definitions we do not control and were causing CI codespell failures on auto-generated MDX files

Closes #516

## Test plan

- [ ] CI `Lint Code Base` check passes (codespell no longer flags these words)
- [ ] CI `Check linked issues` check passes
- [ ] Generated MDX output contains corrected spellings