### PR TITLE
fix: correct service_policy API endpoint path to service_policys

### DIFF
--- a/scripts/discovery/constraint_prober.py
+++ b/scripts/discovery/constraint_prober.py
@@ -34,7 +34,7 @@ RESOURCE_ENDPOINTS: dict[str, str] = {
     "http_loadbalancer": "http_loadbalancers",
     "tcp_loadbalancer": "tcp_loadbalancers",
     "app_firewall": "app_firewalls",
-    "service_policy": "service_policies",
+    "service_policy": "service_policys",
 }
 
 DOMAIN_MAP: dict[str, str] = {


### PR DESCRIPTION
Closes #546

## Summary

- The F5XC API uses `/api/config/namespaces/{ns}/service_policys` for service_policy resources (not `service_policies`)
- `minimum_configs.yaml` already used the correct path — this brings `constraint_prober.py` in sync
- Discovered via the new autoresearch enrichment benchmark (`autoresearch-enrichment.sh`) which probes live API constraints and compares to the embedded terraform index

## Test plan
- [ ] Run `constraint_prober.py --resource service_policy` against staging — should no longer 404
- [ ] Run `autoresearch-enrichment.sh` — enrichment_score should remain 100.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)