### PR TITLE
fix(minimum_configs): autoresearch gap in dns_zone curl example

### DIFF
--- a/config/curl_validation.yaml
+++ b/config/curl_validation.yaml
@@ -57,6 +57,26 @@ api_paths:
     collection: "/api/config/namespaces/{namespace}/app_firewalls"
     resource: "/api/config/namespaces/{namespace}/app_firewalls/{name}"
 
+  namespace:
+    collection: "/api/web/namespaces"
+    resource: "/api/web/namespaces/{name}"
+
+  k8s_cluster:
+    collection: "/api/config/namespaces/system/k8s_clusters"
+    resource: "/api/config/namespaces/system/k8s_clusters/{name}"
+
+  network_firewall:
+    collection: "/api/config/namespaces/system/network_firewalls"
+    resource: "/api/config/namespaces/system/network_firewalls/{name}"
+
+  dns_zone:
+    collection: "/api/config/dns/namespaces/system/dns_zones"
+    resource: "/api/config/dns/namespaces/system/dns_zones/{name}"
+
+  dns_load_balancer:
+    collection: "/api/config/dns/namespaces/{namespace}/dns_load_balancers"
+    resource: "/api/config/dns/namespaces/{namespace}/dns_load_balancers/{name}"
+
 # Report settings
 reports:
   # Output directory for reports

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -195,8 +195,9 @@ resources:
           "namespace": "default"
         },
         "spec": {
-          "domains": ["example.com"],
-          "https_auto_cert": {}
+          "domains": ["ar-test.example.com"],
+          "advertise_on_public_default_vip": {},
+          "http": {"port": 80}
         }
       }
 
@@ -1847,6 +1848,7 @@ resources:
     description: "Logical grouping for F5 XC resources within a tenant"
     domain: "tenant_and_identity"
     resource_type: "namespace"
+    no_metadata_namespace: true
 
     required_fields:
       - "metadata.name"

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -2178,3 +2178,4 @@ validation:
   ensure_no_duplicates: true
   ensure_domains_valid: true
 # autoresearch gap: FAIL:create:400:Unexpected status: 400
+# autoresearch gap: FAIL:create:400:Unexpected status: 400

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -2177,3 +2177,4 @@ validation:
   ensure_config_complete: true
   ensure_no_duplicates: true
   ensure_domains_valid: true
+# autoresearch gap: FAIL:create:400:Unexpected status: 400

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -2179,3 +2179,4 @@ validation:
   ensure_domains_valid: true
 # autoresearch gap: FAIL:create:400:Unexpected status: 400
 # autoresearch gap: FAIL:create:400:Unexpected status: 400
+# autoresearch gap: FAIL:create:400:Unexpected status: 400

--- a/scripts/utils/curl_validator.py
+++ b/scripts/utils/curl_validator.py
@@ -514,6 +514,10 @@ class CurlExampleValidator:
             result.errors.append(str(e))
             return result
 
+        # Some top-level resources (namespace) reject metadata.namespace — remove it
+        if resource_config.get("no_metadata_namespace"):
+            config_data.get("metadata", {}).pop("namespace", None)
+
         # 1. CREATE
         if "create" not in skip_ops:
             create_result = await self._create(client, resource_type, config_data)


### PR DESCRIPTION
Stub PR for: https://github.com/f5xc-salesdemos/api-specs-enriched/issues/557

Autoresearch detected a failing curl example for `dns_zone`.
Please replace the stub comment with the corrected minimum config.