### PR TITLE
feat(curl-validation): add prerequisite lifecycle support, fix tcp_loadbalancer

### DIFF
--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -612,7 +612,10 @@ resources:
     description: "TCP load balancer for non-HTTP protocols"
     domain: "virtual"
     resource_type: "loadbalancer"
-    skip_curl_test: true  # requires pre-existing origin pool; validate_curl_examples.py tests each resource independently
+    prerequisites:
+      origin_pool:
+        name_var: PREREQ_POOL
+        payload_template: '{"metadata":{"name":"{{prereq_name}}","namespace":"{{namespace}}"},"spec":{"origin_servers":[{"public_ip":{"ip":"10.0.0.1"},"labels":{}}],"port":80,"no_tls":{},"loadbalancer_algorithm":"LB_OVERRIDE","endpoint_selection":"LOCAL_PREFERRED"}}'
 
     # Minimum required fields (verified via live API)
     # The absolute minimum is: metadata.name + metadata.namespace + spec.listen_port
@@ -682,7 +685,7 @@ resources:
         "spec": {
           "listen_port": 80,
           "do_not_advertise": {},
-          "origin_pools_weights": [{"pool": {"namespace": "default", "name": "backend-pool"}}]
+          "origin_pools_weights": [{"pool": {"namespace": "{{PREREQ_POOL_NS}}", "name": "{{PREREQ_POOL}}"}, "weight": 1}]
         }
       }
 

--- a/scripts/utils/curl_validator.py
+++ b/scripts/utils/curl_validator.py
@@ -486,7 +486,7 @@ class CurlExampleValidator:
             duration_ms=(time.monotonic() - start) * 1000,
         )
 
-    async def validate_resource(
+    async def validate_resource(  # noqa: PLR0911
         self,
         client: httpx.AsyncClient,
         resource_type: str,
@@ -536,22 +536,30 @@ class CurlExampleValidator:
             prereq_ns = prereq_config.get("namespace", self.namespace)
             raw_payload = prereq_config.get("payload_template", "{}")
             prereq_payload = json.loads(
-                raw_payload.replace("{{prereq_name}}", prereq_name).replace("{{namespace}}", prereq_ns)
+                raw_payload.replace("{{prereq_name}}", prereq_name).replace(
+                    "{{namespace}}", prereq_ns
+                )
             )
             api_paths_cfg = self.config.get("api_paths", {})
             prereq_path_cfg = api_paths_cfg.get(prereq_type, {})
             if prereq_path_cfg.get("collection"):
-                prereq_collection = prereq_path_cfg["collection"].format(namespace=prereq_ns, name="")
+                prereq_collection = prereq_path_cfg["collection"].format(
+                    namespace=prereq_ns, name=""
+                )
             else:
                 prereq_collection = f"/api/config/namespaces/{prereq_ns}/{prereq_type}s"
             prereq_url = f"{self.api_url}{prereq_collection}"
             status, _, _ = await self._execute_request(client, "POST", prereq_url, prereq_payload)
             if status not in [200, 201]:
                 result.errors.append(f"Prerequisite {prereq_type} creation failed: status {status}")
-                result.duration_ms = (time.monotonic() - start) * 1000
-                return result
-            prereq_names[prereq_config.get("name_var", prereq_type)] = prereq_name
-            prereq_cleanup.append(f"{prereq_url}/{prereq_name}")
+            else:
+                prereq_names[prereq_config.get("name_var", prereq_type)] = prereq_name
+                prereq_cleanup.append(f"{prereq_url}/{prereq_name}")
+
+        # Abort if any prerequisite failed
+        if result.errors:
+            result.duration_ms = (time.monotonic() - start) * 1000
+            return result
 
         # Substitute {{VAR_NAME}} placeholders in config_data with prerequisite names
         if prereq_names:

--- a/scripts/utils/curl_validator.py
+++ b/scripts/utils/curl_validator.py
@@ -531,7 +531,7 @@ class CurlExampleValidator:
         prereq_cleanup: list[str] = []
         prerequisites = resource_config.get("prerequisites", {})
         for prereq_type, prereq_config in prerequisites.items():
-            prereq_uuid = self._generate_test_name().split("-")[-1]
+            prereq_uuid = self._generate_test_name().rsplit("-", maxsplit=1)[-1]
             prereq_name = f"{self.test_prefix}-pre-{prereq_type[:8]}-{prereq_uuid}"
             prereq_ns = prereq_config.get("namespace", self.namespace)
             raw_payload = prereq_config.get("payload_template", "{}")

--- a/scripts/utils/curl_validator.py
+++ b/scripts/utils/curl_validator.py
@@ -525,6 +525,42 @@ class CurlExampleValidator:
         if resource_config.get("no_metadata_namespace"):
             config_data.get("metadata", {}).pop("namespace", None)
 
+        # Create prerequisite resources (e.g. origin_pool for tcp_loadbalancer)
+        # prereq_cleanup maps prereq_type -> (delete_url)
+        prereq_names: dict[str, str] = {}
+        prereq_cleanup: list[str] = []
+        prerequisites = resource_config.get("prerequisites", {})
+        for prereq_type, prereq_config in prerequisites.items():
+            prereq_uuid = self._generate_test_name().split("-")[-1]
+            prereq_name = f"{self.test_prefix}-pre-{prereq_type[:8]}-{prereq_uuid}"
+            prereq_ns = prereq_config.get("namespace", self.namespace)
+            raw_payload = prereq_config.get("payload_template", "{}")
+            prereq_payload = json.loads(
+                raw_payload.replace("{{prereq_name}}", prereq_name).replace("{{namespace}}", prereq_ns)
+            )
+            api_paths_cfg = self.config.get("api_paths", {})
+            prereq_path_cfg = api_paths_cfg.get(prereq_type, {})
+            if prereq_path_cfg.get("collection"):
+                prereq_collection = prereq_path_cfg["collection"].format(namespace=prereq_ns, name="")
+            else:
+                prereq_collection = f"/api/config/namespaces/{prereq_ns}/{prereq_type}s"
+            prereq_url = f"{self.api_url}{prereq_collection}"
+            status, _, _ = await self._execute_request(client, "POST", prereq_url, prereq_payload)
+            if status not in [200, 201]:
+                result.errors.append(f"Prerequisite {prereq_type} creation failed: status {status}")
+                result.duration_ms = (time.monotonic() - start) * 1000
+                return result
+            prereq_names[prereq_config.get("name_var", prereq_type)] = prereq_name
+            prereq_cleanup.append(f"{prereq_url}/{prereq_name}")
+
+        # Substitute {{VAR_NAME}} placeholders in config_data with prerequisite names
+        if prereq_names:
+            config_str = json.dumps(config_data)
+            for var_name, pname in prereq_names.items():
+                config_str = config_str.replace("{{" + var_name + "}}", pname)
+                config_str = config_str.replace("{{" + var_name + "_NS}}", self.namespace)
+            config_data = json.loads(config_str)
+
         # 1. CREATE
         if "create" not in skip_ops:
             create_result = await self._create(client, resource_type, config_data)
@@ -585,6 +621,10 @@ class CurlExampleValidator:
 
                 if not verify_result.success:
                     result.errors.append(f"VERIFY DELETE failed: {verify_result.error}")
+
+        # Clean up prerequisite resources (best-effort, regardless of test outcome)
+        for delete_url in prereq_cleanup:
+            await self._execute_request(client, "DELETE", delete_url)
 
         result.duration_ms = (time.monotonic() - start) * 1000
         return result


### PR DESCRIPTION
## Summary
- curl_validator.py: before CRUD lifecycle, create prerequisite resources specified in minimum_configs.yaml `prerequisites` dict; substitute `{{VAR_NAME}}` placeholders in example_json; delete prerequisites in cleanup regardless of test outcome
- minimum_configs.yaml: tcp_loadbalancer gets `prerequisites.origin_pool` with payload_template + name_var=PREREQ_POOL; example_json references `{{PREREQ_POOL}}`; `skip_curl_test` removed

Result: curl_resources_tested 24 → 25, curl_validity_score remains 100%.

Closes #572

🤖 Generated with [Claude Code](https://claude.com/claude-code)