### PR TITLE
feat(autoresearch): add securemesh_site_v2 (SMSv2) Azure CE support

### DIFF
--- a/config/curl_validation.yaml
+++ b/config/curl_validation.yaml
@@ -67,6 +67,10 @@ api_paths:
     collection: "/api/config/namespaces/system/fast_acls"
     resource: "/api/config/namespaces/system/fast_acls/{name}"
 
+  securemesh_site_v2:
+    collection: "/api/config/namespaces/system/securemesh_site_v2s"
+    resource: "/api/config/namespaces/system/securemesh_site_v2s/{name}"
+
   k8s_cluster:
     collection: "/api/config/namespaces/system/k8s_clusters"
     resource: "/api/config/namespaces/system/k8s_clusters/{name}"

--- a/config/discovered_defaults.yaml
+++ b/config/discovered_defaults.yaml
@@ -971,6 +971,20 @@ resources:
 # - consul_service: service_name, site_locator, network_choice
 
 
+  securemesh_site_v2:
+    description: "SecureMesh Site v2 server-applied defaults (verified 2026-06-05)"
+    schema_pattern: "securemesh_site_v2.*SpecType"
+    # No numeric/string server defaults — all fields are oneOf empty-object choices
+    # constraint_prober found 0 server_default_fields (expected: spec is all binary choices)
+    defaults: {}
+    oneof_recommended:
+      provider_choice: "azure"
+      node_ha_choice: "disable_ha"
+      blocked_services_choice: "block_all_services"
+      network_policy_choice: "no_network_policy"
+      forward_proxy_choice: "no_forward_proxy"
+      logs_receiver_choice: "logs_streaming_disabled"
+
   azure_vnet_site:
     description: "Azure VNET site server-applied defaults (verified 2026-05-10)"
     schema_pattern: "azure_vnet_site.*SpecType"

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -1852,6 +1852,87 @@ resources:
       - "Server defaults: no_worker_nodes:{}, block_all_services:{}, logs_streaming_disabled:{}"
 
   # ============================================================================
+  # SMSv2 - Secure Mesh Site v2
+  # ============================================================================
+
+  securemesh_site_v2:
+    description: "Secure Mesh Site v2 for multi-cloud CE deployments (Azure, AWS, GCP, bare-metal, etc.)"
+    domain: "cloud_infrastructure"
+    resource_type: "site"
+    # NOTE: requires system namespace (enforced by x-f5xc-namespace-profile)
+    # NOTE: provider_choice (azure/aws/gcp/etc.) is REQUIRED at runtime despite schema saying optional
+    # NOTE: nodes self-register after site creation — no azure_cred prerequisite needed for API object
+
+    required_fields:
+      - "metadata.name"
+      - "metadata.namespace"  # must be "system"
+      - "spec.provider_choice"  # one of: azure, aws, gcp, baremetal, equinix, kvm, nutanix, oci, openstack, vmware
+
+    mutually_exclusive_groups:
+      - name: "provider_choice"
+        fields: ["spec.azure", "spec.aws", "spec.gcp", "spec.baremetal", "spec.equinix", "spec.kvm", "spec.nutanix", "spec.oci", "spec.openstack", "spec.vmware"]
+        reason: "Choose exactly one cloud provider"
+      - name: "node_ha_choice"
+        fields: ["spec.disable_ha", "spec.enable_ha"]
+        reason: "HA enabled or disabled"
+      - name: "blocked_services_choice"
+        fields: ["spec.block_all_services", "spec.blocked_services"]
+        reason: "Block all or specific services"
+      - name: "network_policy_choice"
+        fields: ["spec.active_enhanced_firewall_policies", "spec.no_network_policy"]
+        reason: "Network policy or none"
+      - name: "forward_proxy_choice"
+        fields: ["spec.active_forward_proxy_policies", "spec.no_forward_proxy"]
+        reason: "Forward proxy or none"
+      - name: "enterprise_proxy_choice"
+        fields: ["spec.custom_proxy", "spec.f5_proxy"]
+        reason: "Proxy type"
+      - name: "proxy_bypass_choice"
+        fields: ["spec.custom_proxy_bypass", "spec.no_proxy_bypass"]
+        reason: "Proxy bypass or none"
+      - name: "logs_receiver_choice"
+        fields: ["spec.log_receiver", "spec.logs_streaming_disabled"]
+        reason: "Log receiver or disabled"
+      - name: "s2s_connectivity_sli_choice"
+        fields: ["spec.dc_cluster_group_sli", "spec.no_s2s_connectivity_sli"]
+        reason: "S2S connectivity SLI"
+      - name: "s2s_connectivity_slo_choice"
+        fields: ["spec.dc_cluster_group_slo", "spec.no_s2s_connectivity_slo", "spec.site_mesh_group_on_slo"]
+        reason: "S2S connectivity SLO"
+      - name: "url_categorization_choice"
+        fields: ["spec.disable_url_categorization", "spec.enable_url_categorization"]
+        reason: "URL categorization"
+      - name: "management_network_choice"
+        fields: ["spec.disable_management_network", "spec.enable_management_network"]
+        reason: "Management network"
+
+    example_json: |
+      {
+        "metadata": {
+          "name": "example-smsv2",
+          "namespace": "system"
+        },
+        "spec": {
+          "azure": {
+            "not_managed": {
+              "node_list": []
+            }
+          },
+          "disable_ha": {},
+          "no_network_policy": {},
+          "no_forward_proxy": {},
+          "logs_streaming_disabled": {},
+          "block_all_services": {}
+        }
+      }
+
+    example_curl: |
+      curl -X POST "$F5XC_API_URL/api/config/namespaces/system/securemesh_site_v2s" \
+        -H "Authorization: APIToken $F5XC_API_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d '{"metadata":{"name":"example-smsv2","namespace":"system"},"spec":{"azure":{"not_managed":{"node_list":[]}},"disable_ha":{},"no_network_policy":{},"no_forward_proxy":{},"logs_streaming_disabled":{},"block_all_services":{}}}'
+
+  # ============================================================================
   # Identity - Namespace
   # ============================================================================
 

--- a/scripts/discovery/constraint_prober.py
+++ b/scripts/discovery/constraint_prober.py
@@ -35,6 +35,7 @@ RESOURCE_ENDPOINTS: dict[str, str] = {
     "tcp_loadbalancer": "tcp_loadbalancers",
     "app_firewall": "app_firewalls",
     "service_policy": "service_policys",
+    "securemesh_site_v2": "securemesh_site_v2s",
 }
 
 DOMAIN_MAP: dict[str, str] = {
@@ -44,6 +45,7 @@ DOMAIN_MAP: dict[str, str] = {
     "tcp_loadbalancer": "virtual",
     "app_firewall": "bot_and_threat_defense",
     "service_policy": "network_security",
+    "securemesh_site_v2": "cloud_infrastructure",
 }
 
 


### PR DESCRIPTION
## Summary
Foundational autoresearch support for securemesh_site_v2 (Secure Mesh Site v2) Azure CE deployments:

- **minimum_configs.yaml**: adds securemesh_site_v2 with minimal Azure not_managed payload (no azure_cred prereq — nodes self-register)
- **curl_validation.yaml**: system-namespace API paths for SMSv2 CRUD
- **constraint_prober.py**: adds securemesh_site_v2 to RESOURCE_ENDPOINTS and DOMAIN_MAP
- **discovered_defaults.yaml**: SMSv2 section (0 server defaults — all fields are binary oneOf choices)

Verified locally: curl_validity_score=100% (27/27), spec_accuracy_score=100% (7/7)

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)