### PR TITLE
fix: correct active_enhanced_firewall_policies inner field and namespace for securemesh_site_v2

### DIFF
--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -1997,13 +1997,15 @@ resources:
         spec_override: {"no_network_policy": {}}
         description: "No network policy applied"
       active_enhanced_firewall_policies:
-        spec_override: {"active_enhanced_firewall_policies": {"active_enhanced_firewall_policies": [{"name": "POLICY_NAME", "namespace": "NAMESPACE"}]}}
-        description: "Apply enhanced firewall policy — reference by name+namespace"
+        # IMPORTANT: inner field is "enhanced_firewall_policies" (no "active_" prefix)
+        # IMPORTANT: policy MUST be in system namespace — cannot reference user namespace
+        spec_override: {"active_enhanced_firewall_policies": {"enhanced_firewall_policies": [{"name": "POLICY_NAME", "namespace": "system"}]}}
+        description: "Apply enhanced firewall policy — inner field is enhanced_firewall_policies, policy must be in system namespace"
         prerequisites:
           enhanced_firewall_policy:
             api_path: "enhanced_firewall_policys"
-            namespace: "user_namespace"
-            payload: '{"metadata":{"name":"{{name}}","namespace":"{{namespace}}"},"spec":{}}'
+            namespace: "system"
+            payload: '{"metadata":{"name":"{{name}}","namespace":"system"},"spec":{}}'
 
       # Group 4: forward_proxy
       no_forward_proxy:

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -2099,6 +2099,7 @@ resources:
         spec_override: {"enable_management_network": {}}
         description: "Enable management network"
 
+
   # ============================================================================
   # Identity - Namespace
   # ============================================================================


### PR DESCRIPTION
Closes #608

## Summary

- Fixes two incorrect API facts in `config/minimum_configs.yaml` under `securemesh_site_v2.option_examples.active_enhanced_firewall_policies`
- Inner spec field renamed from `active_enhanced_firewall_policies` to `enhanced_firewall_policies` (the outer wrapper key keeps the `active_` prefix; the inner list field does not)
- Prerequisite `enhanced_firewall_policy` namespace changed from `user_namespace` to `system` — SMSv2 sites live in the system namespace and the API rejects cross-namespace policy references with 400

## Verification

Verified live against SE tenant:
- `enhanced_firewall_policy` in `system` namespace + inner field `enhanced_firewall_policies` → **200 success**
- `active_enhanced_firewall_policies` as inner field → 400
- `user_namespace` as prerequisite namespace → 400

## Test plan

- [ ] Confirm `xcsh` generates SMSv2 payloads with `enhanced_firewall_policies` (not `active_enhanced_firewall_policies`) as the inner field
- [ ] Confirm prerequisite `enhanced_firewall_policy` is created in `system` namespace
- [ ] Run benchmark suite against SE tenant and verify `active_enhanced_firewall_policies` option returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)