### PR TITLE
feat: add server-default for disable_bot_defense and disable_ip_reputation

### DIFF
--- a/config/discovered_defaults.yaml
+++ b/config/discovered_defaults.yaml
@@ -631,6 +631,10 @@ resources:
       default_sensitive_data_policy: {}
       l7_ddos_protection: {}
       add_location: false
+      # Bot defense - disabled by default
+      disable_bot_defense: {}
+      # IP reputation - disabled by default
+      disable_ip_reputation: {}
     nested:
       https_auto_cert:
         defaults:


### PR DESCRIPTION
## Summary
Add `disable_bot_defense: {}` and `disable_ip_reputation: {}` to the http_loadbalancer top-level defaults in `discovered_defaults.yaml`. These are oneOf default variants that were missing `x-f5xc-server-default: true`, causing them to appear in VS Code extension minimal exports.

Closes #695
Related: #693 — nested defaults still need enricher fix for http_redirect, add_hsts, connection_idle_timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)