### PR TITLE
chore: use example- prefix for sample resource names in config examples

### DIFF
--- a/config/field_metadata.yaml
+++ b/config/field_metadata.yaml
@@ -22,7 +22,7 @@ field_patterns:
     x-f5xc-examples:
       - value: 'example-resource'
         context: 'Basic alphanumeric name'
-      - value: 'my-app-prod'
+      - value: 'example-app-prod'
         context: 'Environment-specific naming'
     x-f5xc-completion:
       type: 'string-value'

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -1756,7 +1756,7 @@ resources:
         type: "array"
         description: |
           Kubernetes-style label selector expressions. Common patterns:
-          - Match by site name: "ves.io/siteName in (my-ce-site-1, my-ce-site-2)"
+          - Match by site name: "ves.io/siteName in (example-ce-site-1, example-ce-site-2)"
           - Match by label: "environment=production,tier=frontend"
           - All CE sites in a region: "ves.io/region in (us-east-1)"
 
@@ -1778,7 +1778,7 @@ resources:
 
     example_yaml: |
       metadata:
-        name: my-virtual-site
+        name: example-virtual-site
         namespace: default
       spec:
         site_type: REGIONAL_EDGE
@@ -2056,13 +2056,13 @@ resources:
         namespace: system
       spec:
         azure_region: eastus2
-        resource_group: my-resource-group
+        resource_group: example-resource-group
         azure_cred:
-          name: my-azure-cred
+          name: example-azure-cred
           namespace: system
         vnet:
           new_vnet:
-            name: my-vnet
+            name: example-vnet
             primary_ipv4: "10.0.0.0/16"
         ingress_gw:
           azure_certified_hw: azure-byol-voltmesh
@@ -2081,9 +2081,9 @@ resources:
         },
         "spec": {
           "azure_region": "eastus2",
-          "resource_group": "my-resource-group",
-          "azure_cred": {"name": "my-azure-cred", "namespace": "system"},
-          "vnet": {"new_vnet": {"name": "my-vnet", "primary_ipv4": "10.0.0.0/16"}},
+          "resource_group": "example-resource-group",
+          "azure_cred": {"name": "example-azure-cred", "namespace": "system"},
+          "vnet": {"new_vnet": {"name": "example-vnet", "primary_ipv4": "10.0.0.0/16"}},
           "ingress_gw": {
             "azure_certified_hw": "azure-byol-voltmesh",
             "az_nodes": [{"azure_az": "1", "local_subnet": {"subnet_param": {"ipv4": "10.0.1.0/24"}}}]
@@ -2424,7 +2424,7 @@ resources:
 
     example_yaml: |
       metadata:
-        name: my-log-receiver
+        name: example-log-receiver
         namespace: system
       spec:
         request_logs: {}
@@ -2433,7 +2433,7 @@ resources:
 
     example_json: |
       {
-        "metadata": {"name": "my-log-receiver", "namespace": "system"},
+        "metadata": {"name": "example-log-receiver", "namespace": "system"},
         "spec": {
           "request_logs": {},
           "http_receiver": {"uri": "http://logs.example.com/ingest"}
@@ -2468,7 +2468,7 @@ resources:
 
     example_yaml: |
       metadata:
-        name: my-alert-receiver
+        name: example-alert-receiver
         namespace: system
       spec:
         email:
@@ -2476,7 +2476,7 @@ resources:
 
     example_json: |
       {
-        "metadata": {"name": "my-alert-receiver", "namespace": "system"},
+        "metadata": {"name": "example-alert-receiver", "namespace": "system"},
         "spec": {
           "email": {"email_address": "alerts@example.com"}
         }
@@ -2503,14 +2503,14 @@ resources:
 
     example_yaml: |
       metadata:
-        name: my-k8s-cluster
+        name: example-k8s-cluster
         namespace: system
       spec: {}
 
     example_json: |
       {
         "metadata": {
-          "name": "my-k8s-cluster",
+          "name": "example-k8s-cluster",
           "namespace": "system"
         },
         "spec": {}
@@ -2544,14 +2544,14 @@ resources:
 
     example_yaml: |
       metadata:
-        name: my-network-firewall
+        name: example-network-firewall
         namespace: system
       spec: {}
 
     example_json: |
       {
         "metadata": {
-          "name": "my-network-firewall",
+          "name": "example-network-firewall",
           "namespace": "system"
         },
         "spec": {}
@@ -2584,14 +2584,14 @@ resources:
 
     example_yaml: |
       metadata:
-        name: my-efp
+        name: example-efp
         namespace: default
       spec: {}
 
     example_json: |
       {
         "metadata": {
-          "name": "my-efp",
+          "name": "example-efp",
           "namespace": "default"
         },
         "spec": {}
@@ -2635,7 +2635,7 @@ resources:
       apiVersion: v1
       kind: fast_acl
       metadata:
-        name: my-fast-acl
+        name: example-fast-acl
         namespace: system
       spec:
         re_acl: {}
@@ -2643,7 +2643,7 @@ resources:
     example_json: |
       {
         "metadata": {
-          "name": "my-fast-acl",
+          "name": "example-fast-acl",
           "namespace": "system"
         },
         "spec": {

--- a/config/resource_examples.yaml
+++ b/config/resource_examples.yaml
@@ -25,7 +25,7 @@ domains:
         use_case: "Development environments, quick validation"
         yaml: |
           metadata:
-            name: my-lb
+            name: example-lb
             namespace: default
           spec:
             domains:
@@ -34,7 +34,7 @@ domains:
               port: 80
             default_route_pools:
               - pool:
-                  name: my-origin-pool
+                  name: example-origin-pool
                   namespace: default
 
       production:

--- a/config/server_variables.yaml
+++ b/config/server_variables.yaml
@@ -17,11 +17,11 @@ variables:
   # Tenant variable: Explicit tenant identifier
   tenant:
     default: "example-corp"
-    description: "F5 Distributed Cloud tenant identifier (e.g., my-company, acme-inc)"
+    description: "F5 Distributed Cloud tenant identifier (e.g., example-company, acme-inc)"
     examples:
       - "example-corp"
       - "acme-inc"
-      - "my-company"
+      - "example-company"
     env_var: "F5XC_TENANT"
     notes: |
       Default comes from F5XC_TENANT environment variable if set.


### PR DESCRIPTION
Standardizes sample resource names on the ecosystem `example-` convention in the config example payloads.

- `config/minimum_configs.yaml`, `config/resource_examples.yaml`, `config/field_metadata.yaml`, `config/server_variables.yaml`: `my-*` -> `example-*` (26 values)

The enrichment branding transform only rewrites text fields (description/summary/title/x-displayname), so example payload values are fixed at the source. Enriched specs under `docs/specifications/api/` are regenerated by `sync-and-enrich` on merge; the contract-diff gate regenerates fresh and is unaffected.

Left unchanged: `config/enrichment.yaml` transform rules, and the RFC 5737 `TEST-NET-1` documentation range in field_descriptions.yaml.

Closes #747