### PR TITLE
chore: refresh stale translations for extensions/catalog.md

### DIFF
--- a/docs/ar/extensions/catalog.md
+++ b/docs/ar/extensions/catalog.md
@@ -1,35 +1,35 @@
 ---
-title: كتالوج امتدادات الإثراء
-description: مرجع موثوق لكل امتداد x-* في مواصفات OpenAPI المحسّنة
+title: كتالوج امتداد الإثراء
+description: المرجع الأساسي لكل امتداد x-* في مواصفات OpenAPI المحسّنة
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
-# كتالوج امتدادات الإثراء
+# كتالوج امتداد الإثراء
 
-مرجع موثوق لكل امتداد `x-*` يظهر في
-`docs/specifications/api/*.json`. يُفرض التوافق مع
+المرجع الأساسي لكل امتداد `x-*` يظهر في
+`docs/specifications/api/*.json`. يتم فرض التوافق مع
 `scripts/utils/extension_constants.py` بواسطة
 `tests/test_extension_catalog.py`.
 
 ثلاث فئات من الامتدادات موثقة هنا:
 
-- **مُحقنة هنا** — امتدادات يضيفها مُثريونا (`x-f5xc-*` و
+- **مُضخَّة هنا** — امتدادات يضيفها مُثريونا (`x-f5xc-*` و
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / متغيرات
-  الاكتشاف). وهي الامتدادات التي يجب أن تستهلكها الأدوات اللاحقة.
-- **مُمرَّرة من المنبع** — امتدادات تُصدرها F5 في مواصفات المصدر
-  ونحافظ عليها دون تغيير (`x-ves-proto-*`، `x-displayname`، إلخ).
-  موثقة للشفافية لكنها غير مُتحكَّم بها من هذا المستودع.
-- **مُحقنة مستقبلاً** — لم تُصدَر بعد؛ توثَّق هنا في اللحظة التي يبدأ
-  فيها مُثري ما بإنتاجها (غير قابل للتطبيق عند التعبئة الأولية).
+  الاكتشاف). هذه هي الامتدادات التي يجب أن تستهلكها الأدوات الداخلية.
+- **مُمرَّرة من الأصل** — امتدادات تُصدرها F5 في المواصفات المصدر
+  ونحتفظ بها دون تغيير (`x-ves-proto-*`، `x-displayname`، إلخ).
+  موثقة للشفافية لكن هذا المستودع لا يتحكم بها.
+- **مُضخَّة مستقبلاً** — لم تُصدَر بعد؛ توثق هنا في اللحظة التي
+  يبدأ فيها مُثري ما بإنتاجها (غير منطبقة عند التعبئة الأولية).
 
-## مخطط المدخل
+## مخطط الإدخال
 
-لكل مدخل أدناه هذا الشكل تحديداً. يتسامح اختبار التوافق في
-`tests/test_extension_catalog.py` مع كون جسم القسم موجزاً طالما أن
-رأس `### x-name` موجود وعلامة `Pass-through from upstream:` حاضرة
-بقيمة `yes` أو `no`.
+كل إدخال أدناه له هذا الشكل بالضبط. اختبار التوافق في
+`tests/test_extension_catalog.py` يتسامح مع كون جسم القسم مختصراً
+طالما أن الرأس `### x-name` موجود وعلامة
+`Pass-through from upstream:` حاضرة بقيمة `yes` أو `no`.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -42,12 +42,12 @@ i18n:
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## مُحقنة — على مستوى المواصفة (قسم info)
+## مُضخَّة — على مستوى المواصفة (قسم info)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** يُحدِّد slug نطاق واجهة سطر الأوامر (مثل `http_loadbalancer`) لمواصفة مُثراة.
+- **Purpose:** يحدد slug نطاق CLI (مثل `http_loadbalancer`) لمواصفة مُثراة.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -59,7 +59,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** كتلة بيانات وصفية شاملة لواجهة سطر الأوامر (اسم الأداة، تلميحات الإصدار، تجميع النطاق).
+- **Purpose:** كتلة بيانات وصفية خاصة بـ CLI على مستوى الأداة (اسم الأداة، تلميحات الإصدار، تجميع النطاق).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -71,7 +71,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** طابع زمني لمواصفة المصدر الأولية التي بُني منها الملف المُثرى.
+- **Purpose:** الطابع الزمني للمواصفة المصدر الأصلية التي بُني منها الملف المُثرى.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -83,7 +83,7 @@ i18n:
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag لأصل إصدار مواصفة المصدر الأولية.
+- **Purpose:** ETag لأصل مواصفة المصدر الأصلية.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -95,7 +95,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** إصدار دلالي يُختم على المواصفة المُثراة من قِبل خط الأنابيب.
+- **Purpose:** إصدار دلالي مختوم على المواصفة المُثراة بواسطة خط الأنابيب.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -107,7 +107,7 @@ i18n:
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** كتلة مسرد العلامة التجارية والمصطلحات المُطبَّقة على كل مواصفة نطاق.
+- **Purpose:** كتلة مسرد مصطلحات العلامة التجارية/المصطلحات التقنية المطبقة على كل مواصفة نطاق.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -119,7 +119,7 @@ i18n:
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** الطابع الزمني لوقت تنفيذ مرحلة اكتشاف الواجهة البرمجية الحية.
+- **Purpose:** الطابع الزمني لتنفيذ مرحلة اكتشاف API المباشر.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -131,7 +131,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** URL الأساسي للواجهة البرمجية الحية التي جرى استطلاعها أثناء الاكتشاف.
+- **Purpose:** عنوان URL الأساسي لـ API المباشر الذي جرى فحصه أثناء الاكتشاف.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -143,7 +143,7 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL صفحة توثيق مرجع الواجهة البرمجية المستضافة لهذا النطاق.
+- **Purpose:** عنوان URL لصفحة توثيق مرجع API المستضافة لهذا النطاق.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -155,7 +155,7 @@ i18n:
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** وقت الاستجابة الملاحَظ (بالميلي ثانية) للواجهة البرمجية المُستطلَعة أثناء الاكتشاف.
+- **Purpose:** وقت الاستجابة الملاحظ (بالمللي ثانية) لـ API الذي تم فحصه أثناء الاكتشاف.
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -167,7 +167,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** إرشادات أفضل الممارسات المنتقاة لنطاق ما.
+- **Purpose:** إرشادات أفضل الممارسات المنتقاة لأحد النطاقات.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -179,7 +179,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** سير عمل خطوة بخطوة مُسمَّاة لإنجاز المهام الشائعة في نطاق ما.
+- **Purpose:** سير عمل مسماة خطوة بخطوة لإنجاز المهام الشائعة في أحد النطاقات.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -191,7 +191,7 @@ i18n:
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** جدول توسيع الاختصارات الخاص بكل نطاق.
+- **Purpose:** جدول توسيع الاختصارات على مستوى النطاق.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -200,12 +200,24 @@ i18n:
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
-## مُحقنة — على مستوى المخطط (مخططات المكونات)
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** شجرة تنقل وحدة التحكم العامة — مساحة العمل والتسلسل الهرمي للقوائم.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
+## مُضخَّة — على مستوى المخطط (مخططات المكونات)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** الحد الأدنى من الحقول المطلوبة للنجاح في عملية POST/PUT لهذا المورد.
+- **Purpose:** الحد الأدنى من الحقول المطلوبة لنجاح عملية POST/PUT لهذا المورد.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -217,7 +229,7 @@ i18n:
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** يوفر قيود مساحة الاسم وبيانات التوصية والتصنيف الوصفية لمورد ما.
+- **Purpose:** يوفر بيانات تعريفية خاصة بقيد مساحة الأسماء والتوصية والتصنيف لأحد الموارد.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -229,7 +241,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** الترتيب المقترح للخصائص لعرضها في واجهة المستخدم أو واجهة سطر الأوامر.
+- **Purpose:** الترتيب المقترح للخصائص لعرضها في واجهة المستخدم/CLI.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -241,7 +253,7 @@ i18n:
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** اسم نوع مورد Terraform الذي يُعيَّن لهذا المخطط.
+- **Purpose:** اسم نوع مورد Terraform الذي يرتبط بهذا المخطط.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -253,7 +265,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** اسم عرض مقروء للإنسان لمخطط المورد (يتجاوز التوليد التلقائي).
+- **Purpose:** اسم عرض سهل القراءة لمخطط مورد (يُلغي التوليد التلقائي).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -262,12 +274,24 @@ i18n:
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
 - **Pass-through from upstream:** no
 
-## مُحقنة — على مستوى الخاصية
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** بيانات تنقل واجهة مستخدم وحدة التحكم والتوجيه وبنية النموذج لهذا المورد.
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
+- **Pass-through from upstream:** no
+
+## مُضخَّة — على مستوى الخاصية
 
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** وصف خاصية مُثرى يُكمل الـ `description` الأصلي من المنبع.
+- **Purpose:** وصف خاصية مُثرى يكمّل `description` الأصلي.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -279,7 +303,7 @@ i18n:
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** قواعد تحقق إعلانية مشتقة من `ves.io.schema.rules` لـ protobuf من المنبع.
+- **Purpose:** قواعد التحقق التعريفية المشتقة من `ves.io.schema.rules` في protobuf الأصلي.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -291,7 +315,7 @@ i18n:
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** قيم أمثلة توضيحية متعددة لخاصية ما.
+- **Purpose:** قيم أمثلة توضيحية متعددة لإحدى الخصائص.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -303,7 +327,7 @@ i18n:
 ### x-f5xc-example
 
 - **Applied at:** schema property
-- **Purpose:** قيمة مثال أساسية واحدة.
+- **Purpose:** قيمة مثال متعارف عليها واحدة.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -327,7 +351,7 @@ i18n:
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** القيمة الافتراضية التي تظهر في المستندات المُولَّدة وواجهات المستخدم.
+- **Purpose:** القيمة/القيم الافتراضية لعرضها في المستندات المُولَّدة وواجهات المستخدم.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -339,7 +363,7 @@ i18n:
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** يُدرج عمليات HTTP (POST/PUT/...) التي تتطلب هذه الخاصية.
+- **Purpose:** يسرد عمليات HTTP (POST/PUT/...) التي تستلزم هذه الخاصية.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -351,7 +375,7 @@ i18n:
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** يُدرج مجموعات الميزات المُسمَّاة التي تتطلب هذه الخاصية.
+- **Purpose:** يسرد تركيبات الميزات المسماة التي تستلزم هذه الخاصية.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -363,7 +387,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** المتطلبات الشرطية (مثل: مطلوب عندما يساوي حقل شقيق قيمة X).
+- **Purpose:** المتطلبات الشرطية (مثل: مطلوب عندما يساوي الحقل الشقيق X).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -375,7 +399,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** إشعار إهمال مع إرشادات حول البديل.
+- **Purpose:** إشعار إهمال مع إرشادات بديلة.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -387,7 +411,7 @@ i18n:
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** القيمة الافتراضية التي يُعيِّنها الخادم عندما يُغفل العميل الخاصية.
+- **Purpose:** القيمة الافتراضية التي يعيّنها الخادم عند حذف العميل للخاصية.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -399,7 +423,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** القيمة الإنتاجية الموصى بها لحقل تكون قيمته الافتراضية من الخادم دون المستوى الأمثل.
+- **Purpose:** القيمة الإنتاجية الموصى بها لحقل تكون فيه القيمة الافتراضية للخادم دون المستوى الأمثل.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -411,7 +435,7 @@ i18n:
 ### x-f5xc-recommended-oneof-variant
 
 - **Applied at:** schema property
-- **Purpose:** بالنسبة لكتل `oneOf`، يُشير إلى المتغير الموصى به.
+- **Purpose:** لكتل `oneOf`، يشير إلى المتغير الموصى به.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -423,7 +447,7 @@ i18n:
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** يُدرج الخصائص الشقيقة التي لا يمكن تعيينها جنباً إلى جنب مع هذه الخاصية.
+- **Purpose:** يسرد الخصائص الشقيقة التي لا يمكن تعيينها بجانب هذه الخاصية.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -435,7 +459,7 @@ i18n:
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** يوثق التبعيات عبر الحقول حيث يستلزم حقل ما تعيين حقل آخر.
+- **Purpose:** يوثق التبعيات عبر الحقول حيث يستلزم حقل واحد تعيين حقل آخر.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -447,7 +471,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** قيود رقمية / نصية مشتقة من الاستطلاع الحي للواجهة البرمجية أو الأنماط الثابتة.
+- **Purpose:** قيود رقمية/نصية مشتقة من فحص API المباشر أو الأنماط الثابتة.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -459,7 +483,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** يُعلن ما إذا كان يجب أن يكون الحقل فريداً ضمن نطاقه.
+- **Purpose:** يُعلن ما إذا كان الحقل يجب أن يكون فريداً ضمن نطاقه.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -468,12 +492,24 @@ i18n:
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
-## مُحقنة — على مستوى العملية
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** بيانات أداة نموذج وحدة التحكم لخاصية API هذه.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
+## مُضخَّة — على مستوى العملية
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** يُسمي حقول جسم العملية التي يجب توفيرها لتحقيق النجاح.
+- **Purpose:** يُسمّي حقول جسم العملية التي يجب تقديمها لتحقيق النجاح.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -485,7 +521,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** يُصنِّف نطاق التأثير لعملية ما (منخفض/متوسط/عالٍ/حرج).
+- **Purpose:** يصنّف نطاق تأثير العملية (منخفض/متوسط/عالٍ/حرج).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -497,7 +533,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** ما إذا كانت واجهة سطر الأوامر أو واجهة المستخدم يجب أن تطلب من المستخدم التأكيد قبل التنفيذ.
+- **Purpose:** ما إذا كان يجب على CLI/واجهة المستخدم مطالبة المستخدم بالتأكيد قبل التنفيذ.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -509,7 +545,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** يُدرج الآثار الجانبية الملاحَظة للعملية (إعادة تشغيل، إعادة تكوين، إلخ).
+- **Purpose:** يسرد الآثار الجانبية الملاحظة للعملية (إعادة تشغيل، إعادة تكوين، إلخ).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -533,7 +569,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** رؤوس حد المعدل / السلوك الملاحَظ المستخرج من الواجهة البرمجية الحية.
+- **Purpose:** رؤوس/سلوك حدود المعدل الملاحظة المستخرجة من API المباشر.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -545,7 +581,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** كتالوج استجابات الخطأ المُلاحَظة أثناء الاكتشاف الحي، مع عينات من البيانات.
+- **Purpose:** كتالوج استجابات الأخطاء الملاحظة أثناء الاكتشاف المباشر، مع نماذج من البيانات.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -554,12 +590,12 @@ i18n:
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## مُحقنة — على مستوى الفهرس (بيانات النطاق الوصفية)
+## مُضخَّة — على مستوى الفهرس (بيانات تعريف النطاق)
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** فئة التجميع الأعلى مستوى لواجهة سطر الأوامر / واجهة المستخدم / المستندات / Terraform لنطاق ما.
+- **Purpose:** فئة التجميع على المستوى الأعلى لـ CLI / واجهة المستخدم / المستندات / Terraform لأحد النطاقات.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -571,7 +607,7 @@ i18n:
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** قائمة أنواع الموارد الأساسية التي تُعرِّف النطاق.
+- **Purpose:** قائمة بأنواع الموارد الأساسية التي تُعرّف النطاق.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -583,7 +619,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** الموارد التي تتطلب عناية مرتفعة (حرجة في بيئة الإنتاج).
+- **Purpose:** الموارد التي تتطلب عناية متزايدة (حرجة في الإنتاج).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -595,7 +631,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** وصف قصير للنطاق (~60 حرفاً). ينطبق أيضاً على مستوى الخاصية للأوصاف الطويلة.
+- **Purpose:** وصف قصير للنطاق (حوالي 60 حرفاً). ينطبق أيضاً على مستوى الخاصية للأوصاف الطويلة.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -607,7 +643,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** وصف متوسط للنطاق (~150 حرفاً). ينطبق أيضاً على مستوى الخاصية.
+- **Purpose:** وصف متوسط للنطاق (حوالي 150 حرفاً). ينطبق أيضاً على مستوى الخاصية.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -619,7 +655,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** وصف طويل للنطاق (~500 حرف).
+- **Purpose:** وصف طويل للنطاق (حوالي 500 حرف).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -631,7 +667,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** مستوى التعقيد النسبي لإنشاء التكوينات في هذا النطاق.
+- **Purpose:** مستوى التعقيد النسبي لصياغة الإعدادات في هذا النطاق.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -655,7 +691,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** يُعلِّم نطاقاً ما باعتباره ميزة معاينة / تجريبية.
+- **Purpose:** يُعلّم نطاقاً ما على أنه ميزة معاينة/تجريبية.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -667,7 +703,7 @@ i18n:
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** حالات الاستخدام المُسمَّاة التي يدعمها هذا النطاق.
+- **Purpose:** حالات الاستخدام المسماة التي يدعمها هذا النطاق.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -679,7 +715,7 @@ i18n:
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** معرِّف الأيقونة المستخدم عند عرض هذا النطاق في واجهة المستخدم.
+- **Purpose:** معرّف الأيقونة المستخدم عند عرض هذا النطاق في واجهة المستخدم.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -691,7 +727,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** SVG مضمَّن (أو مسار) لشعار العلامة التجارية الذي يمثل النطاق.
+- **Purpose:** SVG مضمّن (أو مسار) لشعار علامة تجارية يمثل النطاق.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -703,7 +739,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** روابط تشعبية لنطاقات أخرى تُستخدم شائعاً جنباً إلى جنب مع هذا النطاق.
+- **Purpose:** روابط متقاطعة إلى نطاقات أخرى تُستخدم عادةً مع هذا النطاق.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -715,7 +751,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** قسم التوثيق / slug تجميع التنقل للمستندات المُعرضة.
+- **Purpose:** قسم التوثيق / slug تجميع التنقل للمستندات المُصيَّرة.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -724,12 +760,12 @@ i18n:
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## مُمرَّرة من المنبع
+## مُمرَّرة من المصدر الأصلي
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة المنبع F5.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -741,7 +777,7 @@ i18n:
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة المنبع F5.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -753,7 +789,7 @@ i18n:
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة المنبع F5.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -765,7 +801,7 @@ i18n:
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة المنبع F5.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -777,7 +813,7 @@ i18n:
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة المنبع F5.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -789,7 +825,7 @@ i18n:
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة المنبع F5.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -801,35 +837,35 @@ i18n:
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة المنبع F5.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** راجع وثائق المنبع F5.
+- **Example:** راجع وثائق F5 الأصلية.
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة المنبع F5.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** راجع وثائق المنبع F5.
+- **Example:** راجع وثائق F5 الأصلية.
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة المنبع F5.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** راجع وثائق المنبع F5.
+- **Example:** راجع وثائق F5 الأصلية.
 - **Pass-through from upstream:** yes

--- a/docs/de/extensions/catalog.md
+++ b/docs/de/extensions/catalog.md
@@ -1,37 +1,37 @@
 ---
 title: Erweiterungskatalog für Anreicherungen
 description: >-
-  Maßgebliche Referenz für alle x-*-Erweiterungen in den angereicherten
+  Maßgebliche Referenz für jede x-*-Erweiterung in den angereicherten
   OpenAPI-Spezifikationen
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
 # Erweiterungskatalog für Anreicherungen
 
-Maßgebliche Referenz für alle `x-*`-Erweiterungen, die in
-`docs/specifications/api/*.json` erscheinen. Die Übereinstimmung mit
+Maßgebliche Referenz für jede `x-*`-Erweiterung, die in
+`docs/specifications/api/*.json` vorkommt. Die Übereinstimmung mit
 `scripts/utils/extension_constants.py` wird durch
 `tests/test_extension_catalog.py` erzwungen.
 
 Drei Klassen von Erweiterungen sind hier dokumentiert:
 
-- **Hier eingefügt** — Erweiterungen, die unsere Anreicherungen hinzufügen (`x-f5xc-*` und
+- **Hier injiziert** — Erweiterungen, die unsere Anreicherungsskripte hinzufügen (`x-f5xc-*` und
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / Discovery-
   Varianten). Diese sollten von nachgelagerten Werkzeugen konsumiert werden.
 - **Upstream-Durchleitung** — Erweiterungen, die F5 in den Quellspezifikationen ausgibt
-  und die wir unverändert übernehmen (`x-ves-proto-*`, `x-displayname`, etc.).
+  und die wir unverändert übernehmen (`x-ves-proto-*`, `x-displayname` usw.).
   Aus Transparenzgründen dokumentiert, aber nicht von diesem Repository gesteuert.
-- **Zukünftig eingefügt** — noch nicht ausgegeben; wird hier dokumentiert, sobald
-  ein Anreicherungsprozess damit beginnt, sie zu erzeugen (beim ersten Befüllen nicht zutreffend).
+- **Zukünftig injiziert** — noch nicht ausgegeben; wird hier dokumentiert, sobald
+  ein Anreicherungsskript beginnt, sie zu erzeugen (bei der initialen Befüllung nicht anwendbar).
 
 ## Eintragsschema
 
-Jeder Eintrag unten hat genau diese Form. Der Paritätstest in
-`tests/test_extension_catalog.py` toleriert einen rudimentären Abschnittskörper,
+Jeder nachstehende Eintrag hat genau diese Form. Der Paritätstest in
+`tests/test_extension_catalog.py` toleriert, dass der Abschnittsinhalt kurz gehalten ist,
 solange der `### x-name`-Header vorhanden ist und das
-`Pass-through from upstream:`-Flag mit dem Wert `yes` oder `no` vorhanden ist.
+`Pass-through from upstream:`-Flag mit dem Wert `yes` oder `no` angegeben ist.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -44,12 +44,12 @@ solange der `### x-name`-Header vorhanden ist und das
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## Eingefügt — Spezifikationsebene (Info-Abschnitt)
+## Injiziert — Spezifikationsebene (Info-Abschnitt)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** Identifiziert den CLI-Domänen-Slug (z. B. `http_loadbalancer`) für eine angereicherte Spezifikation.
+- **Purpose:** Identifiziert den CLI-Domain-Slug (z. B. `http_loadbalancer`) für eine angereicherte Spezifikation.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -61,7 +61,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** CLI-weiter Metadatenblock (Werkzeugname, Versionshinweise, Domänengruppierung).
+- **Purpose:** CLI-weiter Metadatenblock (Werkzeugname, Versionshinweise, Domain-Gruppierung).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -97,7 +97,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** Semantische Version, die durch die Pipeline auf der angereicherten Spezifikation gestempelt wird.
+- **Purpose:** Semantische Version, die von der Pipeline auf die angereicherte Spezifikation gestempelt wird.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -109,7 +109,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** Marken-/Terminologieglossar-Block, der auf jede Domänenspezifikation angewendet wird.
+- **Purpose:** Branding-/Terminologieglossar-Block, der auf jede Domain-Spezifikation angewendet wird.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -121,7 +121,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** Zeitstempel, wann der Live-API-Discovery-Durchlauf ausgeführt wurde.
+- **Purpose:** Zeitstempel, zu dem der Live-API-Discovery-Durchlauf ausgeführt wurde.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -133,7 +133,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** Basis-URL der Live-API, die während der Discovery abgefragt wurde.
+- **Purpose:** Basis-URL der Live-API, die während der Discovery untersucht wurde.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -145,7 +145,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL zur gehosteten API-Referenzdokumentationsseite für diese Domäne.
+- **Purpose:** URL zur gehosteten API-Referenzdokumentationsseite für diese Domain.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -157,7 +157,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** Gemessene Antwortzeit (ms) für die abgefragte API während der Discovery.
+- **Purpose:** Gemessene Antwortzeit (ms) für die untersuchte API während der Discovery.
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -169,7 +169,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** Kuratierte Best-Practice-Leitlinien für eine Domäne.
+- **Purpose:** Kuratierte Best-Practice-Leitlinien für eine Domain.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -181,7 +181,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** Benannte schrittweise Arbeitsabläufe zur Ausführung häufiger Aufgaben in einer Domäne.
+- **Purpose:** Benannte schrittweise Workflows zur Erledigung häufiger Aufgaben in einer Domain.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -193,7 +193,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** Domänenspezifische Akronym-Erweiterungstabelle.
+- **Purpose:** Domänenspezifische Akronym-Auflösungstabelle.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -202,12 +202,24 @@ solange der `### x-name`-Header vorhanden ist und das
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
-## Eingefügt — Schemaebene (Komponentenschemata)
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** Globale Konsolen-Navigationsstruktur — Arbeitsbereich- und Menühierarchie.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
+## Injiziert — Schemaebene (Komponentenschemata)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** Mindest-Feldsatz, der für ein erfolgreiches POST/PUT dieser Ressource erforderlich ist.
+- **Purpose:** Minimale Feldmenge, die erforderlich ist, um diese Ressource erfolgreich per POST/PUT zu übermitteln.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -255,7 +267,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** Für Menschen lesbarer Anzeigename für ein Ressourcenschema (überschreibt die automatische Generierung).
+- **Purpose:** Menschenlesbarer Anzeigename für ein Ressourcenschema (überschreibt die automatische Generierung).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -264,7 +276,19 @@ solange der `### x-name`-Header vorhanden ist und das
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
 - **Pass-through from upstream:** no
 
-## Eingefügt — Eigenschaftsebene
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** Konsolen-UI-Navigation, Routing und Formularstruktur für diese Ressource.
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
+- **Pass-through from upstream:** no
+
+## Injiziert — Eigenschaftsebene
 
 ### x-f5xc-description
 
@@ -329,7 +353,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** Standardwert(e), die in generierten Dokumenten und Benutzeroberflächen angezeigt werden sollen.
+- **Purpose:** Standardwert(e), die in generierten Dokumentationen und Benutzeroberflächen angezeigt werden.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -353,7 +377,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** Listet benannte Funktionskombinationen auf, die diese Eigenschaft erfordern.
+- **Purpose:** Listet benannte Feature-Kombinationen auf, für die diese Eigenschaft erforderlich ist.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -377,7 +401,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** Veraltungshinweis mit Ersetzungsempfehlung.
+- **Purpose:** Veraltungshinweis mit Ersetzungshinweisen.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -437,7 +461,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** Dokumentiert feldübergreifende Abhängigkeiten, bei denen ein Feld das Setzen eines anderen erfordert.
+- **Purpose:** Dokumentiert feldübergreifende Abhängigkeiten, bei denen ein Feld ein anderes erfordert.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -449,7 +473,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Numerische / Zeichenfolgen-Einschränkungen, abgeleitet aus Live-API-Probing oder statischen Mustern.
+- **Purpose:** Numerische / Zeichenfolgen-Einschränkungen, die aus Live-API-Prüfungen oder statischen Mustern abgeleitet werden.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -461,7 +485,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** Gibt an, ob ein Feld innerhalb seines Geltungsbereichs eindeutig sein muss.
+- **Purpose:** Deklariert, ob ein Feld innerhalb seines Gültigkeitsbereichs eindeutig sein muss.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -470,12 +494,24 @@ solange der `### x-name`-Header vorhanden ist und das
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
-## Eingefügt — Operationsebene
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** Konsolen-Formular-Widget-Metadaten für diese API-Eigenschaft.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
+## Injiziert — Operationsebene
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** Benennt die Felder im Operationskörper, die für einen erfolgreichen Aufruf angegeben werden müssen.
+- **Purpose:** Benennt die Operationsanfrage-Felder, die für einen Erfolg angegeben werden müssen.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -499,7 +535,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Gibt an, ob CLI/UI den Benutzer zur Bestätigung auffordern soll, bevor die Ausführung erfolgt.
+- **Purpose:** Gibt an, ob CLI/UI den Benutzer vor der Ausführung zur Bestätigung auffordern soll.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -535,7 +571,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** Beobachtete Rate-Limit-Header / -Verhalten aus der Live-API.
+- **Purpose:** Beobachtete Rate-Limit-Header / -Verhalten, die von der Live-API erfasst wurden.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -556,12 +592,12 @@ solange der `### x-name`-Header vorhanden ist und das
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## Eingefügt — Indexebene (Domänenmetadaten)
+## Injiziert — Indexebene (Domain-Metadaten)
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** Übergeordnete CLI-/UI-/Dokumentations-/Terraform-Gruppierungskategorie für eine Domäne.
+- **Purpose:** Übergeordnete CLI-/UI-/Dokumentations-/Terraform-Gruppierungskategorie für eine Domain.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -573,7 +609,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** Liste der primären Ressourcentypen, die die Domäne definieren.
+- **Purpose:** Liste der primären Ressourcentypen, die die Domain definieren.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -597,7 +633,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** Kurze (~60 Zeichen) Domänenbeschreibung. Gilt auch auf Eigenschaftsebene für lange Beschreibungen.
+- **Purpose:** Kurze (~60 Zeichen) Domain-Beschreibung. Gilt auch auf Eigenschaftsebene für lange Beschreibungen.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -609,7 +645,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** Mittlere (~150 Zeichen) Domänenbeschreibung. Gilt auch auf Eigenschaftsebene.
+- **Purpose:** Mittellange (~150 Zeichen) Domain-Beschreibung. Gilt auch auf Eigenschaftsebene.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -621,7 +657,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** Lange (~500 Zeichen) Domänenbeschreibung.
+- **Purpose:** Lange (~500 Zeichen) Domain-Beschreibung.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -633,7 +669,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** Relative Komplexitätsstufe für das Erstellen von Konfigurationen in dieser Domäne.
+- **Purpose:** Relative Komplexitätsstufe für das Erstellen von Konfigurationen in dieser Domain.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -657,7 +693,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** Kennzeichnet eine Domäne als Vorschau-/Beta-Funktion.
+- **Purpose:** Kennzeichnet eine Domain als Vorschau-/Beta-Feature.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -669,7 +705,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** Benannte Anwendungsfälle, die diese Domäne unterstützt.
+- **Purpose:** Benannte Anwendungsfälle, die diese Domain unterstützt.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -681,7 +717,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** Symbol-Bezeichner, der beim Rendern dieser Domäne in einer Benutzeroberfläche verwendet werden soll.
+- **Purpose:** Symbol-Bezeichner, der beim Rendern dieser Domain in einer Benutzeroberfläche verwendet wird.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -693,7 +729,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** Inline-SVG (oder Pfad) für ein Markenlogo, das die Domäne repräsentiert.
+- **Purpose:** Eingebettetes SVG (oder Pfad) für ein Markenlogo, das die Domain repräsentiert.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -705,7 +741,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** Querverweise auf andere Domänen, die häufig zusammen mit dieser verwendet werden.
+- **Purpose:** Querverweise auf andere Domains, die häufig zusammen mit dieser verwendet werden.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -717,7 +753,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** Dokumentationsbereich / Navigationsgruppierungs-Slug für gerenderte Dokumentation.
+- **Purpose:** Dokumentationsabschnitt / Navigationsgruppen-Slug für gerenderte Dokumentation.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`

--- a/docs/es/extensions/catalog.md
+++ b/docs/es/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Fuente de verdad para cada extensión x-* en las especificaciones OpenAPI
   enriquecidas
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
@@ -17,20 +17,20 @@ Fuente de verdad para cada extensión `x-*` que aparece en
 
 Aquí se documentan tres clases de extensiones:
 
-- **Inyectadas aquí** — extensiones que agregan nuestros enriquecedores (`x-f5xc-*` y
+- **Inyectadas aquí** — extensiones que nuestros enriquecedores agregan (`x-f5xc-*` y
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / variantes de
-  descubrimiento). Estas son las que deben consumir las herramientas posteriores.
-- **Paso a través desde upstream** — extensiones que F5 emite en las especificaciones fuente
-  y que preservamos sin cambios (`x-ves-proto-*`, `x-displayname`, etc.).
-  Documentadas por transparencia, pero no controladas por este repositorio.
-- **Inyectadas en el futuro** — aún no emitidas; documentadas aquí en el momento
-  en que un enriquecedor comienza a producirlas (no aplica en la población inicial).
+  descubrimiento). Estas son las que las herramientas downstream deben consumir.
+- **Transferidas desde upstream** — extensiones que F5 emite en las especificaciones
+  fuente y que preservamos sin cambios (`x-ves-proto-*`, `x-displayname`, etc.).
+  Documentadas por transparencia pero no controladas por este repositorio.
+- **Inyección futura** — aún no emitidas; documentadas aquí en el momento en que
+  un enriquecedor comienza a producirlas (no aplica en la población inicial).
 
 ## Esquema de entrada
 
 Cada entrada a continuación tiene exactamente esta forma. La prueba de paridad en
-`tests/test_extension_catalog.py` tolera que el cuerpo de la sección sea
-básico, siempre que exista el encabezado `### x-nombre` y que el indicador
+`tests/test_extension_catalog.py` tolera que el cuerpo de la sección sea escueto,
+siempre que exista el encabezado `### x-name` y el indicador
 `Pass-through from upstream:` esté presente con el valor `yes` o `no`.
 
     ### x-<name>
@@ -61,7 +61,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** Bloque de metadatos para toda la CLI (nombre de herramienta, indicaciones de versión, agrupación por dominio).
+- **Purpose:** Bloque de metadatos globales de CLI (nombre de herramienta, sugerencias de versión, agrupación de dominio).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -202,12 +202,24 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** Árbol de navegación global de la consola — jerarquía de espacios de trabajo y menús.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
 ## Inyectadas — nivel de esquema (esquemas de componentes)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** Conjunto mínimo de campos viable requerido para hacer POST/PUT correctamente en este recurso.
+- **Purpose:** Conjunto mínimo de campos requerido para realizar con éxito una solicitud POST/PUT de este recurso.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -243,7 +255,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** Nombre del tipo de recurso de Terraform que se asigna a este esquema.
+- **Purpose:** Nombre del tipo de recurso de Terraform que se corresponde con este esquema.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -255,13 +267,25 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** Nombre de presentación legible por humanos para un esquema de recurso (reemplaza la generación automática).
+- **Purpose:** Nombre para mostrar legible por humanos para un esquema de recurso (reemplaza la generación automática).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
 - **Injected by:** scripts/utils/field_metadata_enricher.py
 - **Driven by config:** config/field_metadata.yaml
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
+- **Pass-through from upstream:** no
+
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** Navegación de la UI de consola, enrutamiento y estructura de formularios para este recurso.
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
 - **Pass-through from upstream:** no
 
 ## Inyectadas — nivel de propiedad
@@ -281,7 +305,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** Reglas de validación declarativas derivadas de `ves.io.schema.rules` de protobuf upstream.
+- **Purpose:** Reglas de validación declarativas derivadas de las `ves.io.schema.rules` de protobuf upstream.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -317,7 +341,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** Sugerencias de autocompletado de shell (enumeración estática o comando dinámico).
+- **Purpose:** Sugerencias de completado de shell (enumeración estática o comando dinámico).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -329,7 +353,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** Valor(es) predeterminado(s) para mostrar en documentación y UI generadas.
+- **Purpose:** Valor(es) predeterminado(s) para mostrar en documentación generada e interfaces de usuario.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -353,7 +377,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** Lista combinaciones de características nombradas que requieren esta propiedad.
+- **Purpose:** Lista las combinaciones de características con nombre que requieren esta propiedad.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -401,7 +425,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** Valor de producción recomendado para un campo donde el valor predeterminado del servidor es subóptimo.
+- **Purpose:** Valor recomendado para producción de un campo donde el valor predeterminado del servidor es subóptimo.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -437,7 +461,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** Documenta dependencias entre campos donde un campo requiere que otro esté establecido.
+- **Purpose:** Documenta las dependencias entre campos donde un campo requiere que otro esté establecido.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -449,7 +473,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Restricciones numéricas / de cadena derivadas de sondeo de API en vivo o patrones estáticos.
+- **Purpose:** Restricciones numéricas/de cadena derivadas del sondeo de la API en vivo o de patrones estáticos.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -468,6 +492,18 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 - **Injected by:** scripts/utils/uniqueness_enricher.py
 - **Driven by config:** hardcoded
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
+- **Pass-through from upstream:** no
+
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** Metadatos del widget de formulario de consola para esta propiedad de API.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
 - **Pass-through from upstream:** no
 
 ## Inyectadas — nivel de operación
@@ -499,7 +535,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Indica si la CLI/UI debe solicitar confirmación al usuario antes de ejecutar.
+- **Purpose:** Indica si la CLI/UI debe solicitar al usuario confirmación antes de ejecutar.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -535,7 +571,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** Encabezados / comportamiento de límite de tasa observados en la API en vivo.
+- **Purpose:** Encabezados/comportamiento de límite de tasa observados y expuestos desde la API en vivo.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -561,7 +597,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** Categoría de agrupación de nivel superior para CLI / UI / documentación / Terraform de un dominio.
+- **Purpose:** Categoría de agrupación de nivel superior de CLI / UI / documentación / Terraform para un dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -585,7 +621,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** Recursos que requieren especial cuidado (críticos para producción).
+- **Purpose:** Recursos que requieren mayor cuidado (críticos para producción).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -597,7 +633,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** Descripción corta del dominio (~60 caracteres). También aplica a nivel de propiedad para descripciones largas.
+- **Purpose:** Descripción breve (~60 caracteres) del dominio. También aplica a nivel de propiedad para descripciones largas.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -609,7 +645,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** Descripción media del dominio (~150 caracteres). También aplica a nivel de propiedad.
+- **Purpose:** Descripción media (~150 caracteres) del dominio. También aplica a nivel de propiedad.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -621,7 +657,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** Descripción larga del dominio (~500 caracteres).
+- **Purpose:** Descripción larga (~500 caracteres) del dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -633,7 +669,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** Nivel de complejidad relativa para la creación de configuraciones en este dominio.
+- **Purpose:** Nivel de complejidad relativa para crear configuraciones en este dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -645,7 +681,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** Nivel mínimo de suscripción a F5 XC requerido.
+- **Purpose:** Nivel mínimo de suscripción de F5 XC requerido.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -657,7 +693,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** Marca un dominio como funcionalidad en vista previa / beta.
+- **Purpose:** Marca un dominio como característica en vista previa / beta.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -669,7 +705,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** Casos de uso nombrados que admite este dominio.
+- **Purpose:** Casos de uso con nombre que este dominio soporta.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -681,7 +717,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** Identificador de icono a usar al renderizar este dominio en una UI.
+- **Purpose:** Identificador de icono a usar al renderizar este dominio en una interfaz de usuario.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -693,7 +729,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** SVG en línea (o ruta) para un logotipo de marca que representa el dominio.
+- **Purpose:** SVG en línea (o ruta) de un logotipo de marca que representa el dominio.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -705,7 +741,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** Vínculos cruzados a otros dominios que se usan comúnmente junto con este.
+- **Purpose:** Referencias cruzadas a otros dominios que se usan comúnmente junto con este.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -717,7 +753,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** Slug de sección de documentación / agrupación de navegación para documentación renderizada.
+- **Purpose:** Sección de documentación / slug de agrupación de navegación para los documentos renderizados.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -726,12 +762,12 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## Paso a través desde upstream
+## Transferidas desde upstream
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservada sin cambios desde la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -743,7 +779,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservada sin cambios desde la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -755,7 +791,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservada sin cambios desde la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -767,7 +803,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservada sin cambios desde la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -779,7 +815,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservada sin cambios desde la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -791,7 +827,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservada sin cambios desde la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -803,7 +839,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservada sin cambios desde la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -815,7 +851,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservada sin cambios desde la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -827,7 +863,7 @@ básico, siempre que exista el encabezado `### x-nombre` y que el indicador
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservada sin cambios desde la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A

--- a/docs/fr/extensions/catalog.md
+++ b/docs/fr/extensions/catalog.md
@@ -4,15 +4,15 @@ description: >-
   Source de vérité pour chaque extension x-* dans les spécifications OpenAPI
   enrichies
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
 # Catalogue des extensions d'enrichissement
 
-Source de vérité pour chaque extension `x-*` présente dans
+Source de vérité pour chaque extension `x-*` qui apparaît dans
 `docs/specifications/api/*.json`. La parité avec
-`scripts/utils/extension_constants.py` est imposée par
+`scripts/utils/extension_constants.py` est vérifiée par
 `tests/test_extension_catalog.py`.
 
 Trois classes d'extensions sont documentées ici :
@@ -20,18 +20,18 @@ Trois classes d'extensions sont documentées ici :
 - **Injectées ici** — extensions ajoutées par nos enrichisseurs (`x-f5xc-*` et
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / variantes de
   découverte). Ce sont celles que les outils en aval doivent consommer.
-- **Transmission en amont** — extensions émises par F5 dans les spécifications
-  sources et que nous préservons telles quelles (`x-ves-proto-*`, `x-displayname`, etc.).
-  Documentées par souci de transparence mais non contrôlées par ce dépôt.
-- **Injectées ultérieurement** — pas encore émises ; documentées dès qu'un
+- **Transmises depuis l'amont** — extensions émises par F5 dans les spécifications sources
+  et préservées à l'identique (`x-ves-proto-*`, `x-displayname`, etc.).
+  Documentées par souci de transparence, mais non contrôlées par ce dépôt.
+- **Injectées à l'avenir** — pas encore émises ; documentées ici dès qu'un
   enrichisseur commence à les produire (non applicable lors de la population initiale).
 
 ## Schéma d'entrée
 
-Chaque entrée ci-dessous possède exactement cette structure. Le test de parité dans
-`tests/test_extension_catalog.py` tolère que le corps de la section soit sommaire,
-à condition que l'en-tête `### x-name` existe et que le
-flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
+Chaque entrée ci-dessous a exactement cette forme. Le test de parité dans
+`tests/test_extension_catalog.py` tolère que le corps de la section soit
+succinct, à condition que l'en-tête `### x-name` existe et que
+l'indicateur `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -61,7 +61,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** Bloc de métadonnées CLI globales (nom de l'outil, indications de version, regroupement de domaine).
+- **Purpose:** Bloc de métadonnées CLI global (nom de l'outil, indices de version, regroupement par domaine).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -85,7 +85,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag de l'actif de version de la spec source amont.
+- **Purpose:** ETag de la ressource de publication de la spec source amont.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -145,7 +145,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL vers la page de documentation de référence de l'API hébergée pour ce domaine.
+- **Purpose:** URL de la page de documentation de référence de l'API hébergée pour ce domaine.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -169,7 +169,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** Recommandations de bonnes pratiques organisées pour un domaine.
+- **Purpose:** Guide de bonnes pratiques sélectionnées pour un domaine.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -181,7 +181,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** Flux de travail nommés pas à pas pour accomplir les tâches courantes dans un domaine.
+- **Purpose:** Flux de travail guidés étape par étape pour accomplir des tâches courantes dans un domaine.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -200,6 +200,18 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 - **Injected by:** scripts/utils/acronym_enricher.py
 - **Driven by config:** config/acronyms.yaml
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
+- **Pass-through from upstream:** no
+
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** Arbre de navigation global de la console — hiérarchie des espaces de travail et des menus.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
 - **Pass-through from upstream:** no
 
 ## Injectées — niveau schéma (schémas de composants)
@@ -231,7 +243,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** Ordre suggéré des propriétés pour la présentation dans l'interface utilisateur/CLI.
+- **Purpose:** Ordre suggéré des propriétés pour la présentation dans l'interface CLI/UI.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -255,13 +267,25 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** Nom d'affichage lisible par l'utilisateur pour un schéma de ressource (remplace la génération automatique).
+- **Purpose:** Nom d'affichage lisible par un humain pour un schéma de ressource (remplace la génération automatique).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
 - **Injected by:** scripts/utils/field_metadata_enricher.py
 - **Driven by config:** config/field_metadata.yaml
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
+- **Pass-through from upstream:** no
+
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** Navigation dans l'interface console, routage et structure de formulaire pour cette ressource.
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
 - **Pass-through from upstream:** no
 
 ## Injectées — niveau propriété
@@ -317,7 +341,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** Indications de complétion shell (enum statique ou commande dynamique).
+- **Purpose:** Indices de complétion shell (énumération statique ou commande dynamique).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -329,7 +353,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** Valeur(s) par défaut à afficher dans la documentation générée et les interfaces utilisateur.
+- **Purpose:** Valeur(s) par défaut à afficher dans la documentation générée et les interfaces.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -365,7 +389,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** Exigences conditionnelles (ex. requis lorsqu'un champ frère est égal à X).
+- **Purpose:** Exigences conditionnelles (ex. requis lorsqu'un champ voisin est égal à X).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -377,7 +401,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** Avis de dépréciation avec des indications de remplacement.
+- **Purpose:** Avis de dépréciation avec des conseils de remplacement.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -425,7 +449,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** Liste les propriétés sœurs qui ne peuvent pas être définies en même temps que celle-ci.
+- **Purpose:** Liste les propriétés voisines qui ne peuvent pas être définies en même temps que celle-ci.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -437,7 +461,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** Documente les dépendances inter-champs où un champ en requiert un autre.
+- **Purpose:** Documente les dépendances inter-champs où un champ en requiert un autre d'être défini.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -449,7 +473,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Contraintes numériques/de chaîne dérivées du sondage de l'API en direct ou de motifs statiques.
+- **Purpose:** Contraintes numériques/de chaîne dérivées du sondage de l'API en direct ou de patterns statiques.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -470,6 +494,18 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** Métadonnées du widget de formulaire console pour cette propriété d'API.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
 ## Injectées — niveau opération
 
 ### x-f5xc-required-fields
@@ -487,7 +523,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** Classifie le rayon de souffle d'une opération (low/medium/high/critical).
+- **Purpose:** Classifie le rayon d'action d'une opération (faible/moyen/élevé/critique).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -499,7 +535,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Indique si l'interface CLI/UI doit demander à l'utilisateur de confirmer avant d'exécuter.
+- **Purpose:** Indique si le CLI/UI doit inviter l'utilisateur à confirmer avant d'exécuter.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -535,7 +571,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** En-têtes de limitation de débit / comportement observés depuis l'API en direct.
+- **Purpose:** En-têtes/comportements de limitation de débit observés depuis l'API en direct.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -561,7 +597,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** Catégorie de regroupement de niveau supérieur CLI / UI / docs / Terraform pour un domaine.
+- **Purpose:** Catégorie de regroupement de premier niveau CLI / UI / docs / Terraform pour un domaine.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -597,7 +633,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** Description courte de domaine (~60 caractères). S'applique également au niveau propriété pour les descriptions longues.
+- **Purpose:** Description courte (~60 caractères) du domaine. S'applique également au niveau propriété pour les descriptions longues.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -609,7 +645,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** Description de domaine moyenne (~150 caractères). S'applique également au niveau propriété.
+- **Purpose:** Description moyenne (~150 caractères) du domaine. S'applique également au niveau propriété.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -621,7 +657,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** Description longue de domaine (~500 caractères).
+- **Purpose:** Description longue (~500 caractères) du domaine.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -657,7 +693,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** Marque un domaine comme fonctionnalité en aperçu / bêta.
+- **Purpose:** Marque un domaine comme fonctionnalité en préversion / bêta.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -669,7 +705,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** Cas d'utilisation nommés que ce domaine prend en charge.
+- **Purpose:** Cas d'usage nommés pris en charge par ce domaine.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -681,7 +717,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** Identifiant d'icône à utiliser lors du rendu de ce domaine dans une interface utilisateur.
+- **Purpose:** Identifiant d'icône à utiliser lors du rendu de ce domaine dans une interface.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -693,7 +729,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** SVG en ligne (ou chemin) pour un logo de marque représentant le domaine.
+- **Purpose:** SVG inline (ou chemin) pour un logo de marque représentant le domaine.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -726,12 +762,12 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## Transmission en amont
+## Transmises depuis l'amont
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** Préservé tel quel depuis la spec F5 amont.
+- **Purpose:** Préservée à l'identique depuis la spec amont F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -743,7 +779,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** Préservé tel quel depuis la spec F5 amont.
+- **Purpose:** Préservée à l'identique depuis la spec amont F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -755,7 +791,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** Préservé tel quel depuis la spec F5 amont.
+- **Purpose:** Préservée à l'identique depuis la spec amont F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -767,7 +803,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** Préservé tel quel depuis la spec F5 amont.
+- **Purpose:** Préservée à l'identique depuis la spec amont F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -779,7 +815,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** Préservé tel quel depuis la spec F5 amont.
+- **Purpose:** Préservée à l'identique depuis la spec amont F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -791,7 +827,7 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** Préservé tel quel depuis la spec F5 amont.
+- **Purpose:** Préservée à l'identique depuis la spec amont F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -803,35 +839,35 @@ flag `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** Préservé tel quel depuis la spec F5 amont.
+- **Purpose:** Préservée à l'identique depuis la spec amont F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** Voir la documentation F5 amont.
+- **Example:** Voir la documentation amont F5.
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** Préservé tel quel depuis la spec F5 amont.
+- **Purpose:** Préservée à l'identique depuis la spec amont F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** Voir la documentation F5 amont.
+- **Example:** Voir la documentation amont F5.
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** Préservé tel quel depuis la spec F5 amont.
+- **Purpose:** Préservée à l'identique depuis la spec amont F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** Voir la documentation F5 amont.
+- **Example:** Voir la documentation amont F5.
 - **Pass-through from upstream:** yes

--- a/docs/hi/extensions/catalog.md
+++ b/docs/hi/extensions/catalog.md
@@ -2,41 +2,41 @@
 title: संवर्धन एक्सटेंशन कैटालॉग
 description: संवर्धित OpenAPI विनिर्देशों में प्रत्येक x-* एक्सटेंशन के लिए सत्य का स्रोत
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
 # संवर्धन एक्सटेंशन कैटालॉग
 
-`docs/specifications/api/*.json` में प्रकट होने वाले प्रत्येक `x-*` एक्सटेंशन के लिए सत्य का स्रोत। `scripts/utils/extension_constants.py` के साथ समानता `tests/test_extension_catalog.py` द्वारा लागू की जाती है।
+`docs/specifications/api/*.json` में दिखाई देने वाले प्रत्येक `x-*` एक्सटेंशन के लिए सत्य का स्रोत। `scripts/utils/extension_constants.py` के साथ समानता `tests/test_extension_catalog.py` द्वारा लागू की जाती है।
 
-यहाँ तीन श्रेणियों के एक्सटेंशन प्रलेखित हैं:
+यहाँ तीन प्रकार के एक्सटेंशन दस्तावेज़ीकृत हैं:
 
-- **यहाँ इंजेक्ट किए गए** — वे एक्सटेंशन जो हमारे एन्रिचर जोड़ते हैं (`x-f5xc-*` और `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / डिस्कवरी वेरिएंट)। ये वे हैं जिन्हें डाउनस्ट्रीम उपकरणों को उपभोग करना चाहिए।
-- **अपस्ट्रीम पास-थ्रू** — वे एक्सटेंशन जो F5 स्रोत विनिर्देशों में उत्सर्जित करता है और हम अपरिवर्तित संरक्षित रखते हैं (`x-ves-proto-*`, `x-displayname`, आदि)। पारदर्शिता के लिए प्रलेखित किए गए हैं लेकिन इस रेपो द्वारा नियंत्रित नहीं।
-- **भविष्य-इंजेक्ट** — अभी तक उत्सर्जित नहीं; उस क्षण यहाँ प्रलेखित जब एक एन्रिचर इन्हें उत्पन्न करना शुरू करता है (प्रारंभिक जनसंख्या पर लागू नहीं)।
+- **यहाँ इंजेक्ट किए गए** — वे एक्सटेंशन जो हमारे एनरिचर जोड़ते हैं (`x-f5xc-*` और `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / डिस्कवरी वेरिएंट)। ये वे हैं जिन्हें डाउनस्ट्रीम उपकरण उपभोग करें।
+- **अपस्ट्रीम पास-थ्रू** — वे एक्सटेंशन जो F5 स्रोत विनिर्देशों में उत्सर्जित करता है और हम अपरिवर्तित संरक्षित रखते हैं (`x-ves-proto-*`, `x-displayname`, आदि)। पारदर्शिता के लिए दस्तावेज़ीकृत लेकिन इस रेपो द्वारा नियंत्रित नहीं।
+- **भविष्य में इंजेक्ट किए जाने वाले** — अभी तक उत्सर्जित नहीं; जैसे ही कोई एनरिचर इन्हें उत्पन्न करना शुरू करे, यहाँ दस्तावेज़ीकृत किए जाएंगे (प्रारंभिक पॉपुलेशन पर लागू नहीं)।
 
 ## एंट्री स्कीमा
 
-नीचे प्रत्येक एंट्री का ठीक यही आकार है। `tests/test_extension_catalog.py` में पैरिटी टेस्ट सेक्शन बॉडी को स्टबी होने की अनुमति देता है जब तक कि `### x-name` हेडर मौजूद हो और `Pass-through from upstream:` फ्लैग `yes` या `no` मान के साथ उपस्थित हो।
+नीचे दी गई प्रत्येक एंट्री का ठीक यही रूप है। `tests/test_extension_catalog.py` में पैरिटी टेस्ट सेक्शन बॉडी के स्टब्बी होने को तब तक सहन करता है जब तक `### x-name` हेडर मौजूद हो और `Pass-through from upstream:` फ्लैग `yes` या `no` मान के साथ उपस्थित हो।
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
-    - **Purpose:** <one sentence>
+    - **Purpose:** <एक वाक्य>
     - **Consumers:** <CLI | VSCode | Terraform | Web UI | multiple | N/A>
     - **Value type:** <string | number | boolean | object | array>
-    - **Value schema:** <JSON Schema snippet, or N/A>
-    - **Injected by:** <scripts/utils/<enricher>.py, or "upstream">
-    - **Driven by config:** <config/<file>.yaml, or "hardcoded", or "upstream">
-    - **Example:** <short snippet>
+    - **Value schema:** <JSON Schema स्निपेट, या N/A>
+    - **Injected by:** <scripts/utils/<enricher>.py, या "upstream">
+    - **Driven by config:** <config/<file>.yaml, या "hardcoded", या "upstream">
+    - **Example:** <छोटा स्निपेट>
     - **Pass-through from upstream:** <yes/no>
 
-## इंजेक्ट किए गए — विनिर्देश-स्तर (info अनुभाग)
+## इंजेक्ट किए गए — स्पेक-स्तर (info सेक्शन)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** एक समृद्ध विनिर्देश के लिए CLI डोमेन स्लग (जैसे `http_loadbalancer`) की पहचान करता है।
+- **Purpose:** एनरिच्ड स्पेक के लिए CLI डोमेन स्लग (जैसे `http_loadbalancer`) की पहचान करता है।
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -48,7 +48,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** CLI-व्यापी मेटाडेटा ब्लॉक (टूल नाम, संस्करण संकेत, डोमेन समूहन)।
+- **Purpose:** CLI-व्यापी मेटाडेटा ब्लॉक (टूल नाम, संस्करण संकेत, डोमेन ग्रुपिंग)।
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -60,7 +60,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** अपस्ट्रीम स्रोत विनिर्देश का टाइमस्टैम्प जिससे समृद्ध फ़ाइल बनाई गई थी।
+- **Purpose:** अपस्ट्रीम स्रोत स्पेक का टाइमस्टैम्प जिससे एनरिच्ड फ़ाइल बनाई गई थी।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -72,7 +72,7 @@ i18n:
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** अपस्ट्रीम स्रोत विनिर्देश रिलीज़ असेट का ETag।
+- **Purpose:** अपस्ट्रीम स्रोत स्पेक रिलीज़ एसेट का ETag।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -84,7 +84,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** पाइपलाइन द्वारा समृद्ध विनिर्देश पर अंकित सिमेंटिक संस्करण।
+- **Purpose:** पाइपलाइन द्वारा एनरिच्ड स्पेक पर स्टैम्प किया गया सेमेंटिक संस्करण।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -96,7 +96,7 @@ i18n:
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** प्रत्येक डोमेन विनिर्देश पर लागू ब्रांडिंग/शब्दावली ग्लॉसरी ब्लॉक।
+- **Purpose:** प्रत्येक डोमेन स्पेक पर लागू ब्रांडिंग/शब्दावली ग्लॉसरी ब्लॉक।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -108,7 +108,7 @@ i18n:
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** टाइमस्टैम्प जब लाइव-API डिस्कवरी पास निष्पादित की गई थी।
+- **Purpose:** वह टाइमस्टैम्प जब लाइव-API डिस्कवरी पास निष्पादित किया गया था।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -120,7 +120,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** लाइव API का बेस URL जिसे डिस्कवरी के दौरान प्रोब किया गया था।
+- **Purpose:** डिस्कवरी के दौरान जांची गई लाइव API का बेस URL।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -132,19 +132,19 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** इस डोमेन के लिए होस्ट किए गए API संदर्भ दस्तावेज़ीकरण पृष्ठ का URL।
+- **Purpose:** इस डोमेन के लिए होस्टेड API रेफरेंस दस्तावेज़ीकरण पृष्ठ का URL।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
 - **Injected by:** scripts/utils/external_docs_enricher.py
-- **Driven by config:** none (derived from domain name)
+- **Driven by config:** none (डोमेन नाम से व्युत्पन्न)
 - **Example:** `"x-f5xc-api-reference-url": "https://f5xc-salesdemos.github.io/api-specs-enriched/api-reference/sites/"`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** डिस्कवरी के दौरान प्रोब किए गए API के लिए देखा गया प्रतिक्रिया समय (ms)।
+- **Purpose:** डिस्कवरी के दौरान जांची गई API के लिए देखा गया प्रतिक्रिया समय (ms)।
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -156,7 +156,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** एक डोमेन के लिए क्यूरेटेड सर्वोत्तम-अभ्यास मार्गदर्शन।
+- **Purpose:** किसी डोमेन के लिए क्यूरेटेड सर्वोत्तम-प्रथा मार्गदर्शन।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -168,7 +168,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** एक डोमेन में सामान्य कार्यों को पूरा करने के लिए नामित चरण-दर-चरण वर्कफ़्लो।
+- **Purpose:** किसी डोमेन में सामान्य कार्यों को पूरा करने के लिए नामित चरण-दर-चरण वर्कफ़्लो।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -189,12 +189,24 @@ i18n:
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
-## इंजेक्ट किए गए — स्कीमा-स्तर (कॉम्पोनेंट स्कीमा)
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** ग्लोबल कंसोल नेविगेशन ट्री — वर्कस्पेस और मेनू पदानुक्रम।
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
+## इंजेक्ट किए गए — स्कीमा-स्तर (component schemas)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** न्यूनतम व्यवहार्य फ़ील्ड सेट जो इस रिसोर्स को सफलतापूर्वक POST/PUT करने के लिए आवश्यक है।
+- **Purpose:** इस संसाधन को सफलतापूर्वक POST/PUT करने के लिए आवश्यक न्यूनतम व्यावहारिक फ़ील्ड सेट।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -206,7 +218,7 @@ i18n:
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** किसी रिसोर्स के लिए नेमस्पेस बाधा, अनुशंसा और वर्गीकरण मेटाडेटा प्रदान करता है।
+- **Purpose:** किसी संसाधन के लिए नेमस्पेस बाधा, अनुशंसा और वर्गीकरण मेटाडेटा प्रदान करता है।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -218,7 +230,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** UI/CLI प्रस्तुति के लिए प्रॉपर्टीज़ का सुझावित क्रम।
+- **Purpose:** UI/CLI प्रस्तुति के लिए गुणों का सुझाया गया क्रम।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -230,7 +242,7 @@ i18n:
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** Terraform रिसोर्स प्रकार का नाम जो इस स्कीमा से मैप होता है।
+- **Purpose:** Terraform संसाधन प्रकार का नाम जो इस स्कीमा से मैप होता है।
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -242,7 +254,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** किसी रिसोर्स स्कीमा के लिए मानव-पठनीय प्रदर्शन नाम (ऑटो-जनरेशन को ओवरराइड करता है)।
+- **Purpose:** संसाधन स्कीमा के लिए मानव-पठनीय प्रदर्शन नाम (ऑटो-जनरेशन को ओवरराइड करता है)।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -251,12 +263,24 @@ i18n:
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** इस संसाधन के लिए कंसोल UI नेविगेशन, रूटिंग और फ़ॉर्म संरचना।
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
+- **Pass-through from upstream:** no
+
 ## इंजेक्ट किए गए — प्रॉपर्टी-स्तर
 
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** समृद्ध प्रॉपर्टी विवरण जो अपस्ट्रीम `description` को पूरक बनाता है।
+- **Purpose:** एनरिच्ड प्रॉपर्टी विवरण जो अपस्ट्रीम `description` को पूरक करता है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -292,7 +316,7 @@ i18n:
 ### x-f5xc-example
 
 - **Applied at:** schema property
-- **Purpose:** एकल कैनोनिकल उदाहरण मान।
+- **Purpose:** एक एकल विहित उदाहरण मान।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -304,7 +328,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** शेल कम्पलीशन संकेत (स्टेटिक enum या डायनामिक कमांड)।
+- **Purpose:** शेल कम्पलीशन संकेत (स्थिर enum या गतिशील कमांड)।
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -316,7 +340,7 @@ i18n:
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** जनरेट किए गए दस्तावेज़ों और UI में प्रदर्शित करने के लिए डिफ़ॉल्ट मान।
+- **Purpose:** जनरेट किए गए दस्तावेज़ों और UIs में प्रदर्शित करने के लिए डिफ़ॉल्ट मान।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -340,7 +364,7 @@ i18n:
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** नामित फ़ीचर संयोजनों को सूचीबद्ध करता है जिनके लिए यह प्रॉपर्टी आवश्यक है।
+- **Purpose:** नामित फ़ीचर संयोजनों की सूची बनाता है जिनके लिए यह प्रॉपर्टी आवश्यक है।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -352,7 +376,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** सशर्त आवश्यकताएं (जैसे जब सिब्लिंग फ़ील्ड X के बराबर हो तब आवश्यक)।
+- **Purpose:** सशर्त आवश्यकताएं (जैसे जब सिब्लिंग फ़ील्ड X के बराबर हो तो आवश्यक)।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -364,7 +388,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** प्रतिस्थापन मार्गदर्शन के साथ अप्रचलन सूचना।
+- **Purpose:** प्रतिस्थापन मार्गदर्शन के साथ अवमूल्यन सूचना।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -376,7 +400,7 @@ i18n:
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** डिफ़ॉल्ट मान जो सर्वर तब असाइन करता है जब क्लाइंट प्रॉपर्टी को छोड़ देता है।
+- **Purpose:** वह डिफ़ॉल्ट मान जो सर्वर तब असाइन करता है जब क्लाइंट प्रॉपर्टी छोड़ देता है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -388,7 +412,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** किसी फ़ील्ड के लिए अनुशंसित प्रोडक्शन मान जहाँ सर्वर डिफ़ॉल्ट सबऑप्टिमल है।
+- **Purpose:** किसी फ़ील्ड के लिए अनुशंसित प्रोडक्शन मान जहाँ सर्वर डिफ़ॉल्ट इष्टतम नहीं है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -412,7 +436,7 @@ i18n:
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** सिब्लिंग प्रॉपर्टीज़ सूचीबद्ध करता है जिन्हें इसके साथ सेट नहीं किया जा सकता।
+- **Purpose:** उन सिब्लिंग प्रॉपर्टीज़ की सूची बनाता है जो इसके साथ सेट नहीं की जा सकतीं।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -424,7 +448,7 @@ i18n:
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** क्रॉस-फ़ील्ड निर्भरताओं को प्रलेखित करता है जहाँ एक फ़ील्ड को दूसरे को सेट करने की आवश्यकता होती है।
+- **Purpose:** क्रॉस-फ़ील्ड निर्भरताओं को दस्तावेज़ीकृत करता है जहाँ एक फ़ील्ड को दूसरे के सेट होने की आवश्यकता होती है।
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -436,7 +460,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** लाइव-API प्रोबिंग या स्टेटिक पैटर्न से व्युत्पन्न संख्यात्मक/स्ट्रिंग बाधाएं।
+- **Purpose:** लाइव-API प्रोबिंग या स्थिर पैटर्न से व्युत्पन्न संख्यात्मक / स्ट्रिंग बाधाएं।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -448,7 +472,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** घोषित करता है कि कोई फ़ील्ड अपने दायरे में अद्वितीय होनी चाहिए या नहीं।
+- **Purpose:** घोषित करता है कि कोई फ़ील्ड अपने दायरे के भीतर अद्वितीय होनी चाहिए या नहीं।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -457,12 +481,24 @@ i18n:
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** इस API प्रॉपर्टी के लिए कंसोल फ़ॉर्म विजेट मेटाडेटा।
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
 ## इंजेक्ट किए गए — ऑपरेशन-स्तर
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** ऑपरेशन-बॉडी फ़ील्ड के नाम जो सफलता के लिए प्रदान किए जाने चाहिए।
+- **Purpose:** ऑपरेशन-बॉडी फ़ील्ड के नाम बताता है जो सफलता के लिए प्रदान किए जाने चाहिए।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -474,7 +510,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** किसी ऑपरेशन के विस्फोट त्रिज्या को वर्गीकृत करता है (low/medium/high/critical)।
+- **Purpose:** किसी ऑपरेशन के ब्लास्ट रेडियस को वर्गीकृत करता है (low/medium/high/critical)।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -486,7 +522,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** क्या CLI/UI को निष्पादन से पहले उपयोगकर्ता से पुष्टि के लिए संकेत देना चाहिए।
+- **Purpose:** क्या CLI/UI को निष्पादन से पहले उपयोगकर्ता से पुष्टि मांगनी चाहिए।
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -498,7 +534,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** ऑपरेशन के अवलोकनीय साइड इफेक्ट्स सूचीबद्ध करता है (रीस्टार्ट, रीकॉन्फ़िगर, आदि)।
+- **Purpose:** ऑपरेशन के अवलोकन योग्य साइड इफेक्ट्स सूचीबद्ध करता है (restart, reconfigure, आदि)।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -522,7 +558,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** लाइव API से सामने आई देखी गई रेट-लिमिट हेडर / व्यवहार।
+- **Purpose:** लाइव API से सर्फेस किए गए देखे गए रेट-लिमिट हेडर / व्यवहार।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -534,7 +570,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** लाइव डिस्कवरी के दौरान देखी गई त्रुटि प्रतिक्रियाओं का कैटालॉग, नमूना पेलोड के साथ।
+- **Purpose:** लाइव डिस्कवरी के दौरान देखी गई त्रुटि प्रतिक्रियाओं का कैटालॉग, नमूना पेलोड सहित।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -548,7 +584,7 @@ i18n:
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** किसी डोमेन के लिए शीर्ष-स्तरीय CLI / UI / दस्तावेज़ / Terraform समूहन श्रेणी।
+- **Purpose:** किसी डोमेन के लिए शीर्ष-स्तरीय CLI / UI / docs / Terraform ग्रुपिंग श्रेणी।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -560,7 +596,7 @@ i18n:
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** प्राथमिक रिसोर्स प्रकारों की सूची जो डोमेन को परिभाषित करते हैं।
+- **Purpose:** प्राथमिक संसाधन प्रकारों की सूची जो डोमेन को परिभाषित करते हैं।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -572,7 +608,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** वे रिसोर्स जिन्हें उन्नत देखभाल की आवश्यकता है (प्रोडक्शन-क्रिटिकल)।
+- **Purpose:** वे संसाधन जिन्हें उच्च सतर्कता की आवश्यकता है (प्रोडक्शन-क्रिटिकल)।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -584,7 +620,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** संक्षिप्त (~60 अक्षर) डोमेन विवरण। लंबे विवरणों के लिए प्रॉपर्टी स्तर पर भी लागू होता है।
+- **Purpose:** संक्षिप्त (~60 char) डोमेन विवरण। लंबे विवरणों के लिए प्रॉपर्टी स्तर पर भी लागू होता है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -596,7 +632,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** मध्यम (~150 अक्षर) डोमेन विवरण। प्रॉपर्टी स्तर पर भी लागू होता है।
+- **Purpose:** मध्यम (~150 char) डोमेन विवरण। प्रॉपर्टी स्तर पर भी लागू होता है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -608,7 +644,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** लंबा (~500 अक्षर) डोमेन विवरण।
+- **Purpose:** लंबा (~500 char) डोमेन विवरण।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -620,7 +656,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** इस डोमेन में कॉन्फ़िगरेशन बनाने के लिए सापेक्ष जटिलता स्तर।
+- **Purpose:** इस डोमेन में कॉन्फ़िगरेशन बनाने की सापेक्ष जटिलता स्तर।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -632,7 +668,7 @@ i18n:
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** न्यूनतम F5 XC सब्सक्रिप्शन टियर जो आवश्यक है।
+- **Purpose:** आवश्यक न्यूनतम F5 XC सब्सक्रिप्शन टियर।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -644,7 +680,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** किसी डोमेन को प्रीव्यू / बीटा फ़ीचर के रूप में चिह्नित करता है।
+- **Purpose:** किसी डोमेन को प्रीव्यू / बीटा फ़ीचर के रूप में फ्लैग करता है।
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -656,7 +692,7 @@ i18n:
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** नामित उपयोग मामले जिनका यह डोमेन समर्थन करता है।
+- **Purpose:** नामित उपयोग-मामले जो यह डोमेन समर्थित करता है।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -668,7 +704,7 @@ i18n:
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** UI में इस डोमेन को रेंडर करते समय उपयोग किया जाने वाला आइकन पहचानकर्ता।
+- **Purpose:** UI में इस डोमेन को रेंडर करते समय उपयोग करने के लिए आइकन पहचानकर्ता।
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -692,7 +728,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** अन्य डोमेन के क्रॉस-लिंक जो आमतौर पर इसके साथ मिलकर उपयोग किए जाते हैं।
+- **Purpose:** अन्य डोमेन के क्रॉस-लिंक जो आमतौर पर इसके साथ उपयोग किए जाते हैं।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -704,7 +740,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** रेंडर किए गए दस्तावेज़ों के लिए दस्तावेज़ीकरण अनुभाग / नेव ग्रुपिंग स्लग।
+- **Purpose:** रेंडर किए गए दस्तावेज़ों के लिए दस्तावेज़ीकरण सेक्शन / नेव ग्रुपिंग स्लग।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -718,7 +754,7 @@ i18n:
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** F5 अपस्ट्रीम विनिर्देश से अपरिवर्तित संरक्षित।
+- **Purpose:** F5 अपस्ट्रीम स्पेक से अपरिवर्तित संरक्षित।
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -730,7 +766,7 @@ i18n:
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** F5 अपस्ट्रीम विनिर्देश से अपरिवर्तित संरक्षित।
+- **Purpose:** F5 अपस्ट्रीम स्पेक से अपरिवर्तित संरक्षित।
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -742,7 +778,7 @@ i18n:
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** F5 अपस्ट्रीम विनिर्देश से अपरिवर्तित संरक्षित।
+- **Purpose:** F5 अपस्ट्रीम स्पेक से अपरिवर्तित संरक्षित।
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -754,7 +790,7 @@ i18n:
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** F5 अपस्ट्रीम विनिर्देश से अपरिवर्तित संरक्षित।
+- **Purpose:** F5 अपस्ट्रीम स्पेक से अपरिवर्तित संरक्षित।
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -766,7 +802,7 @@ i18n:
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** F5 अपस्ट्रीम विनिर्देश से अपरिवर्तित संरक्षित।
+- **Purpose:** F5 अपस्ट्रीम स्पेक से अपरिवर्तित संरक्षित।
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -778,7 +814,7 @@ i18n:
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** F5 अपस्ट्रीम विनिर्देश से अपरिवर्तित संरक्षित।
+- **Purpose:** F5 अपस्ट्रीम स्पेक से अपरिवर्तित संरक्षित।
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -790,7 +826,7 @@ i18n:
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** F5 अपस्ट्रीम विनिर्देश से अपरिवर्तित संरक्षित।
+- **Purpose:** F5 अपस्ट्रीम स्पेक से अपरिवर्तित संरक्षित।
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -802,7 +838,7 @@ i18n:
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** F5 अपस्ट्रीम विनिर्देश से अपरिवर्तित संरक्षित।
+- **Purpose:** F5 अपस्ट्रीम स्पेक से अपरिवर्तित संरक्षित।
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -814,7 +850,7 @@ i18n:
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** F5 अपस्ट्रीम विनिर्देश से अपरिवर्तित संरक्षित।
+- **Purpose:** F5 अपस्ट्रीम स्पेक से अपरिवर्तित संरक्षित।
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A

--- a/docs/it/extensions/catalog.md
+++ b/docs/it/extensions/catalog.md
@@ -1,55 +1,55 @@
 ---
-title: Catalogo delle Estensioni di Arricchimento
+title: Catalogo delle estensioni di arricchimento
 description: >-
-  Fonte di riferimento per ogni estensione x-* nelle specifiche OpenAPI
-  arricchite
+  Fonte ufficiale di riferimento per ogni estensione x-* nelle specifiche
+  OpenAPI arricchite
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
-# Catalogo delle Estensioni di Arricchimento
+# Catalogo delle estensioni di arricchimento
 
-Fonte di riferimento per ogni estensione `x-*` che compare in
-`docs/specifications/api/*.json`. La parità con
+Fonte ufficiale di riferimento per ogni estensione `x-*` che compare in
+`docs/specifications/api/*.json`. La corrispondenza con
 `scripts/utils/extension_constants.py` è verificata da
 `tests/test_extension_catalog.py`.
 
-In questo documento sono documentate tre classi di estensioni:
+Qui sono documentate tre classi di estensioni:
 
 - **Iniettate qui** — estensioni aggiunte dai nostri enricher (`x-f5xc-*` e
-  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / varianti di discovery).
-  Queste sono quelle che gli strumenti a valle dovrebbero consumare.
+  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / varianti di
+  discovery). Queste sono quelle che gli strumenti a valle dovrebbero consumare.
 - **Pass-through upstream** — estensioni emesse da F5 nelle specifiche sorgente
   e preservate invariate (`x-ves-proto-*`, `x-displayname`, ecc.).
   Documentate per trasparenza ma non controllate da questo repository.
-- **Future-injected** — non ancora emesse; documentate nel momento in cui
+- **Iniettate in futuro** — non ancora emesse; documentate nel momento in cui
   un enricher inizia a produrle (non applicabile alla popolazione iniziale).
 
 ## Schema delle voci
 
-Ogni voce di seguito ha esattamente questa struttura. Il test di parità in
+Ogni voce di seguito ha esattamente questa forma. Il test di corrispondenza in
 `tests/test_extension_catalog.py` tollera che il corpo della sezione sia
-essenziale, purché l'intestazione `### x-name` esista e il
-flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
+minimale purché esista l'intestazione `### x-name` e il flag
+`Pass-through from upstream:` sia presente con valore `yes` o `no`.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
-    - **Purpose:** <una frase>
+    - **Purpose:** <one sentence>
     - **Consumers:** <CLI | VSCode | Terraform | Web UI | multiple | N/A>
     - **Value type:** <string | number | boolean | object | array>
-    - **Value schema:** <frammento JSON Schema, o N/A>
-    - **Injected by:** <scripts/utils/<enricher>.py, o "upstream">
-    - **Driven by config:** <config/<file>.yaml, o "hardcoded", o "upstream">
-    - **Example:** <breve frammento>
+    - **Value schema:** <JSON Schema snippet, or N/A>
+    - **Injected by:** <scripts/utils/<enricher>.py, or "upstream">
+    - **Driven by config:** <config/<file>.yaml, or "hardcoded", or "upstream">
+    - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## Iniettate — livello spec (sezione info)
+## Iniettate — a livello di specifica (sezione info)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** Identifica lo slug del dominio CLI (es. `http_loadbalancer`) per una spec arricchita.
+- **Purpose:** Identifica lo slug del dominio CLI (es. `http_loadbalancer`) per una specifica arricchita.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -73,7 +73,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** Timestamp della spec sorgente upstream da cui è stato costruito il file arricchito.
+- **Purpose:** Timestamp della specifica sorgente upstream da cui è stato costruito il file arricchito.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -85,7 +85,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag dell'asset di rilascio della spec sorgente upstream.
+- **Purpose:** ETag dell'asset di rilascio della specifica sorgente upstream.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -97,7 +97,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** Versione semantica apposta sulla spec arricchita dalla pipeline.
+- **Purpose:** Versione semantica applicata alla specifica arricchita dalla pipeline.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -109,7 +109,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** Blocco glossario di branding/terminologia applicato a ciascuna spec di dominio.
+- **Purpose:** Blocco glossario di branding/terminologia applicato a ogni specifica di dominio.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -133,7 +133,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** URL di base dell'API live che è stata esaminata durante la discovery.
+- **Purpose:** URL base dell'API live analizzata durante la discovery.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -145,19 +145,19 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL della pagina di documentazione di riferimento API ospitata per questo dominio.
+- **Purpose:** URL alla pagina della documentazione di riferimento API ospitata per questo dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
 - **Injected by:** scripts/utils/external_docs_enricher.py
-- **Driven by config:** none (derivato dal nome del dominio)
+- **Driven by config:** none (derived from domain name)
 - **Example:** `"x-f5xc-api-reference-url": "https://f5xc-salesdemos.github.io/api-specs-enriched/api-reference/sites/"`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** Tempo di risposta osservato (ms) per l'API esaminata durante la discovery.
+- **Purpose:** Tempo di risposta osservato (ms) per l'API analizzata durante la discovery.
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -169,7 +169,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** Guida curata alle best practice per un dominio.
+- **Purpose:** Guida alle best practice curata per un dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -181,7 +181,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** Workflow passo-passo nominati per svolgere attività comuni in un dominio.
+- **Purpose:** Flussi di lavoro guidati passo-passo per svolgere attività comuni in un dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -202,12 +202,24 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
-## Iniettate — livello schema (component schemas)
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** Albero di navigazione globale della console — gerarchia di workspace e menu.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
+## Iniettate — a livello di schema (schemi dei componenti)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** Insieme minimo di campi necessari per eseguire con successo un POST/PUT di questa risorsa.
+- **Purpose:** Set minimo di campi necessari per eseguire con successo un POST/PUT di questa risorsa.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -231,7 +243,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** Ordinamento suggerito delle proprietà per la presentazione in UI/CLI.
+- **Purpose:** Ordinamento suggerito delle proprietà per la presentazione nell'interfaccia utente/CLI.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -243,7 +255,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** Nome del tipo di risorsa Terraform che si mappa su questo schema.
+- **Purpose:** Nome del tipo di risorsa Terraform che corrisponde a questo schema.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -255,7 +267,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** Nome visualizzato leggibile dall'utente per uno schema di risorsa (sostituisce la generazione automatica).
+- **Purpose:** Nome visualizzato leggibile dall'uomo per uno schema di risorsa (sostituisce la generazione automatica).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -264,7 +276,19 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
 - **Pass-through from upstream:** no
 
-## Iniettate — livello proprietà
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** Navigazione nell'interfaccia utente della console, routing e struttura del form per questa risorsa.
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
+- **Pass-through from upstream:** no
+
+## Iniettate — a livello di proprietà
 
 ### x-f5xc-description
 
@@ -317,7 +341,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** Suggerimenti per il completamento shell (enum statico o comando dinamico).
+- **Purpose:** Suggerimenti per il completamento della shell (enum statico o comando dinamico).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -329,7 +353,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** Valore/i predefinito/i da mostrare nei documenti e nelle UI generati.
+- **Purpose:** Valore/i predefinito/i da mostrare nella documentazione generata e nelle interfacce utente.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -353,7 +377,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** Elenca le combinazioni di funzionalità nominate che richiedono questa proprietà.
+- **Purpose:** Elenca le combinazioni di funzionalità denominate che richiedono questa proprietà.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -365,7 +389,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** Requisiti condizionali (es. richiesto quando un campo fratello è uguale a X).
+- **Purpose:** Requisiti condizionali (es. obbligatorio quando il campo fratello è uguale a X).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -401,7 +425,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** Valore di produzione raccomandato per un campo dove il valore predefinito del server è subottimale.
+- **Purpose:** Valore di produzione raccomandato per un campo in cui il valore predefinito del server non è ottimale.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -437,19 +461,19 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** Documenta le dipendenze tra campi in cui un campo ne richiede un altro impostato.
+- **Purpose:** Documenta le dipendenze tra campi in cui un campo richiede che un altro sia impostato.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
 - **Injected by:** scripts/utils/dependency_enricher.py
-- **Driven by config:** config/minimum_configs.yaml (sezione dependencies)
+- **Driven by config:** config/minimum_configs.yaml (dependencies section)
 - **Example:** `"x-f5xc-requires": [{"field": "tls_config", "required": true, "reason": "use_tls requires tls_config sub-field"}]`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Vincoli numerici / stringa derivati da sondaggi sull'API live o da pattern statici.
+- **Purpose:** Vincoli numerici/stringa derivati dalla probing dell'API live o da pattern statici.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -470,12 +494,24 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
-## Iniettate — livello operazione
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** Metadati del widget del form della console per questa proprietà API.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
+## Iniettate — a livello di operazione
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** Denomina i campi del corpo dell'operazione che devono essere forniti per il successo.
+- **Purpose:** Nomina i campi del corpo dell'operazione che devono essere forniti per il successo.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -487,7 +523,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** Classifica il raggio d'impatto di un'operazione (low/medium/high/critical).
+- **Purpose:** Classifica il raggio d'azione di un'operazione (low/medium/high/critical).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -499,7 +535,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Indica se CLI/UI deve richiedere conferma all'utente prima dell'esecuzione.
+- **Purpose:** Indica se CLI/interfaccia utente deve richiedere all'utente conferma prima dell'esecuzione.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -535,7 +571,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** Header di rate-limit osservati / comportamento emerso dall'API live.
+- **Purpose:** Intestazioni/comportamento di rate-limit osservati dall'API live.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -556,12 +592,12 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## Iniettate — livello indice (metadati di dominio)
+## Iniettate — a livello di indice (metadati del dominio)
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** Categoria di raggruppamento di primo livello per CLI / UI / documentazione / Terraform di un dominio.
+- **Purpose:** Categoria di raggruppamento di primo livello per CLI / interfaccia utente / documentazione / Terraform di un dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -573,7 +609,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** Elenco dei tipi di risorsa primari che definiscono il dominio.
+- **Purpose:** Elenco dei tipi di risorse primarie che definiscono il dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -585,7 +621,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** Risorse che richiedono particolare attenzione (critiche per la produzione).
+- **Purpose:** Risorse che richiedono attenzione elevata (critiche in produzione).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -633,7 +669,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** Livello di complessità relativo per la creazione di configurazioni in questo dominio.
+- **Purpose:** Livello di complessità relativa per la creazione di configurazioni in questo dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -657,7 +693,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** Contrassegna un dominio come funzionalità in anteprima / beta.
+- **Purpose:** Contrassegna un dominio come funzionalità in anteprima/beta.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -669,7 +705,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** Casi d'uso nominati supportati da questo dominio.
+- **Purpose:** Casi d'uso denominati supportati da questo dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -681,7 +717,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** Identificatore dell'icona da utilizzare per il rendering di questo dominio in una UI.
+- **Purpose:** Identificatore dell'icona da utilizzare per il rendering di questo dominio nell'interfaccia utente.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -705,7 +741,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** Riferimenti incrociati ad altri domini comunemente usati insieme a questo.
+- **Purpose:** Riferimenti incrociati ad altri domini comunemente utilizzati insieme a questo.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -717,7 +753,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** Slug di sezione della documentazione / raggruppamento di navigazione per i documenti renderizzati.
+- **Purpose:** Sezione della documentazione / slug di raggruppamento di navigazione per la documentazione renderizzata.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -731,7 +767,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla spec upstream F5.
+- **Purpose:** Preservato invariato dalla specifica upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -743,7 +779,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla spec upstream F5.
+- **Purpose:** Preservato invariato dalla specifica upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -755,7 +791,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla spec upstream F5.
+- **Purpose:** Preservato invariato dalla specifica upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -767,7 +803,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla spec upstream F5.
+- **Purpose:** Preservato invariato dalla specifica upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -779,7 +815,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla spec upstream F5.
+- **Purpose:** Preservato invariato dalla specifica upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -791,7 +827,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla spec upstream F5.
+- **Purpose:** Preservato invariato dalla specifica upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -803,7 +839,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla spec upstream F5.
+- **Purpose:** Preservato invariato dalla specifica upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -815,7 +851,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla spec upstream F5.
+- **Purpose:** Preservato invariato dalla specifica upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -827,7 +863,7 @@ flag `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla spec upstream F5.
+- **Purpose:** Preservato invariato dalla specifica upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A

--- a/docs/ja/extensions/catalog.md
+++ b/docs/ja/extensions/catalog.md
@@ -1,24 +1,27 @@
 ---
-title: エンリッチメント拡張機能カタログ
-description: エンリッチされた OpenAPI 仕様における全 x-* 拡張機能の信頼できる情報源
+title: 拡充拡張機能カタログ
+description: 拡充 OpenAPI 仕様に含まれるすべての x-* 拡張機能の信頼できる情報源
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
-# エンリッチメント拡張機能カタログ
+# 拡充拡張機能カタログ
 
-`docs/specifications/api/*.json` に記載されているすべての `x-*` 拡張機能の信頼できる情報源です。`scripts/utils/extension_constants.py` との整合性は `tests/test_extension_catalog.py` によって保証されています。
+`docs/specifications/api/*.json` に含まれるすべての `x-*` 拡張機能の信頼できる情報源です。`scripts/utils/extension_constants.py` との整合性は `tests/test_extension_catalog.py` によって検証されます。
 
-ここでは3種類の拡張機能を記載しています:
+ここでは 3 種類の拡張機能を説明しています。
 
-- **ここで注入** — エンリッチャーが追加する拡張機能（`x-f5xc-*` および `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / ディスカバリーバリアント）。下流ツールが使用するべき拡張機能です。
-- **アップストリームパススルー** — F5 がソーススペックで出力し、そのまま保持される拡張機能（`x-ves-proto-*`、`x-displayname` など）。透明性のために記載していますが、このリポジトリでは制御しません。
-- **将来注入予定** — 現時点では未出力。エンリッチャーが生成を開始した時点でここに記載されます（初回作成時は該当なし）。
+- **ここで注入** — エンリッチャーが追加する拡張機能（`x-f5xc-*` および
+  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / ディスカバリー
+  バリアント）。これらはダウンストリームのツールが利用する対象です。
+- **上流パススルー** — F5 がソース仕様に含めて発行し、変更せず保持する拡張機能（`x-ves-proto-*`、`x-displayname` など）。
+  透明性のために記載しますが、このリポジトリでは制御しません。
+- **将来注入予定** — まだ出力されていません。エンリッチャーが生成を開始した時点でここに記載します（初回投入時点では該当なし）。
 
 ## エントリースキーマ
 
-以下の各エントリーは正確にこの形式を持ちます。`tests/test_extension_catalog.py` のパリティテストは、`### x-name` ヘッダーが存在し、`Pass-through from upstream:` フラグが `yes` または `no` の値で存在する限り、セクション本文が簡潔でも許容します。
+以下の各エントリーは、厳密にこの形式に従います。`tests/test_extension_catalog.py` のパリティテストでは、`### x-name` ヘッダーが存在し、`Pass-through from upstream:` フラグが `yes` または `no` の値で存在する限り、セクション本文が簡略化されていても許容します。
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -31,12 +34,12 @@ i18n:
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## 注入済み — スペックレベル（info セクション）
+## 注入済み — 仕様レベル（info セクション）
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** エンリッチされたスペックの CLI ドメインスラッグ（例: `http_loadbalancer`）を識別します。
+- **Purpose:** 拡充仕様の CLI ドメインスラッグ（例：`http_loadbalancer`）を識別します。
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -48,7 +51,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** CLI 全体のメタデータブロック（ツール名、バージョンヒント、ドメイングルーピング）。
+- **Purpose:** CLI 全体のメタデータブロック（ツール名、バージョンヒント、ドメイングループ）。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -60,7 +63,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** エンリッチされたファイルのビルド元となったアップストリームソーススペックのタイムスタンプ。
+- **Purpose:** 拡充ファイルのビルド元となった上流ソース仕様のタイムスタンプ。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -72,7 +75,7 @@ i18n:
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** アップストリームソーススペックのリリースアセットの ETag。
+- **Purpose:** 上流ソース仕様リリースアセットの ETag。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -84,7 +87,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** パイプラインによってエンリッチされたスペックに付与されるセマンティックバージョン。
+- **Purpose:** パイプラインによって拡充仕様にスタンプされるセマンティックバージョン。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -96,7 +99,7 @@ i18n:
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** 各ドメインスペックに適用されるブランディング／用語集ブロック。
+- **Purpose:** 各ドメイン仕様に適用されるブランディング／用語集ブロック。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -120,7 +123,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** ディスカバリー時にプローブされたライブ API のベース URL。
+- **Purpose:** ディスカバリー中にプローブされたライブ API のベース URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -132,7 +135,7 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** このドメインのホストされた API リファレンスドキュメントページの URL。
+- **Purpose:** このドメインのホスト型 API リファレンスドキュメントページの URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -144,7 +147,7 @@ i18n:
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** ディスカバリー時にプローブされた API の観測応答時間（ミリ秒）。
+- **Purpose:** ディスカバリー中にプローブされた API の観測応答時間（ミリ秒）。
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -168,7 +171,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** ドメイン内の一般的なタスクを実行するための名前付きステップバイステップワークフロー。
+- **Purpose:** ドメインにおける一般的なタスクを達成するための名前付きステップバイステップワークフロー。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -189,12 +192,24 @@ i18n:
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** グローバルコンソールナビゲーションツリー — ワークスペースとメニュー階層。
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
 ## 注入済み — スキーマレベル（コンポーネントスキーマ）
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** このリソースへの POST/PUT を成功させるために必要な最小限のフィールドセット。
+- **Purpose:** このリソースへの POST/PUT を正常に実行するために必要な最小限のフィールドセット。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -206,7 +221,7 @@ i18n:
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** リソースの名前空間制約、推奨事項、および分類メタデータを提供します。
+- **Purpose:** リソースのネームスペース制約、推奨事項、および分類メタデータを提供します。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -218,7 +233,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** UI/CLI 表示のためのプロパティの推奨順序。
+- **Purpose:** UI/CLI での表示用のプロパティ推奨順序。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -242,7 +257,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** リソーススキーマの人間が読めるディスプレイ名（自動生成をオーバーライド）。
+- **Purpose:** リソーススキーマの人間が読みやすい表示名（自動生成を上書きします）。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -251,12 +266,24 @@ i18n:
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** このリソースのコンソール UI ナビゲーション、ルーティング、およびフォーム構造。
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
+- **Pass-through from upstream:** no
+
 ## 注入済み — プロパティレベル
 
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** アップストリームの `description` を補足するエンリッチされたプロパティ説明。
+- **Purpose:** 上流の `description` を補完する拡充プロパティ説明。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -268,7 +295,7 @@ i18n:
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** アップストリームの protobuf `ves.io.schema.rules` から導出された宣言的バリデーションルール。
+- **Purpose:** 上流の protobuf `ves.io.schema.rules` から派生した宣言的バリデーションルール。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -280,7 +307,7 @@ i18n:
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** プロパティに対する複数の例示値。
+- **Purpose:** プロパティの複数の例示値。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -304,7 +331,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** シェル補完ヒント（静的な列挙型または動的コマンド）。
+- **Purpose:** シェル補完ヒント（静的な列挙または動的なコマンド）。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -328,7 +355,7 @@ i18n:
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** このプロパティを必要とする HTTP 操作（POST/PUT/...）のリスト。
+- **Purpose:** このプロパティが必須となる HTTP オペレーション（POST/PUT/...）の一覧。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -340,7 +367,7 @@ i18n:
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** このプロパティを必要とする名前付き機能の組み合わせのリスト。
+- **Purpose:** このプロパティが必須となる名前付きフィーチャーの組み合わせの一覧。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -352,7 +379,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** 条件付き要件（例: 兄弟フィールドが X に等しい場合に必要）。
+- **Purpose:** 条件付き要件（例：兄弟フィールドが X と等しい場合に必須）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -364,7 +391,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** 代替ガイダンスを含む非推奨通知。
+- **Purpose:** 代替手段のガイダンスを含む非推奨通知。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -400,7 +427,7 @@ i18n:
 ### x-f5xc-recommended-oneof-variant
 
 - **Applied at:** schema property
-- **Purpose:** `oneOf` ブロックに対して、推奨されるバリアントを示します。
+- **Purpose:** `oneOf` ブロックにおいて、推奨されるバリアントを示します。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -412,7 +439,7 @@ i18n:
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** このプロパティと同時に設定できない兄弟プロパティのリスト。
+- **Purpose:** このプロパティと同時に設定できない兄弟プロパティの一覧。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -436,7 +463,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** ライブ API プローブまたは静的パターンから導出された数値／文字列制約。
+- **Purpose:** ライブ API プローブまたは静的パターンから派生した数値／文字列制約。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -448,7 +475,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** フィールドがそのスコープ内で一意でなければならないかどうかを宣言します。
+- **Purpose:** フィールドがそのスコープ内で一意である必要があるかどうかを宣言します。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -457,12 +484,24 @@ i18n:
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** この API プロパティのコンソールフォームウィジェットメタデータ。
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
 ## 注入済み — オペレーションレベル
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** 成功のために提供しなければならないオペレーションボディフィールドの名前。
+- **Purpose:** 成功のために提供する必要があるオペレーションボディフィールドの名前。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -486,7 +525,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** CLI/UI が実行前にユーザーへ確認プロンプトを表示すべきかどうか。
+- **Purpose:** 実行前に CLI/UI がユーザーに確認を求める必要があるかどうか。
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -498,7 +537,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** オペレーションの観測可能な副作用（再起動、再設定など）のリスト。
+- **Purpose:** オペレーションの観測可能な副作用の一覧（再起動、再設定など）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -510,7 +549,7 @@ i18n:
 ### x-f5xc-discovered-response-time
 
 - **Applied at:** operation
-- **Purpose:** ディスカバリー時にこのオペレーションで実測された応答時間。
+- **Purpose:** ディスカバリー中にこのオペレーションに対して実測された応答時間。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -522,7 +561,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** ライブ API から表面化した観測済みレート制限ヘッダー／動作。
+- **Purpose:** ライブ API から確認されたレート制限ヘッダー／動作。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -534,7 +573,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** ライブディスカバリー中に観測されたエラーレスポンスのカタログ（サンプルペイロードを含む）。
+- **Purpose:** ライブディスカバリー中に観測されたエラーレスポンスのカタログ（サンプルペイロード付き）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -548,7 +587,7 @@ i18n:
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** ドメインの CLI / UI / ドキュメント / Terraform の最上位グルーピングカテゴリ。
+- **Purpose:** ドメインのトップレベル CLI / UI / ドキュメント / Terraform グループ化カテゴリ。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -560,7 +599,7 @@ i18n:
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** ドメインを定義する主要リソースタイプのリスト。
+- **Purpose:** ドメインを定義するプライマリリソースタイプの一覧。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -572,7 +611,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** 高い注意を要するリソース（本番クリティカル）。
+- **Purpose:** 高い注意が必要なリソース（プロダクションクリティカル）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -584,7 +623,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** 短い（約60文字）ドメイン説明。プロパティレベルの長い説明にも適用されます。
+- **Purpose:** 短い（約 60 文字）ドメイン説明。プロパティレベルの長い説明にも適用されます。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -596,7 +635,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** 中程度（約150文字）のドメイン説明。プロパティレベルにも適用されます。
+- **Purpose:** 中程度（約 150 文字）のドメイン説明。プロパティレベルにも適用されます。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -608,7 +647,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** 長い（約500文字）ドメイン説明。
+- **Purpose:** 長い（約 500 文字）ドメイン説明。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -620,7 +659,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** このドメインで設定をオーサリングする際の相対的な複雑度ティア。
+- **Purpose:** このドメインで設定を作成する際の相対的な複雑さのティア。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -644,7 +683,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** ドメインをプレビュー／ベータ機能としてフラグ付けします。
+- **Purpose:** ドメインをプレビュー／ベータフィーチャーとしてフラグを立てます。
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -692,7 +731,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** このドメインとよく一緒に使用される他のドメインへのクロスリンク。
+- **Purpose:** このドメインとともに一般的に使用される他のドメインへのクロスリンク。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -704,7 +743,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** レンダリングされたドキュメントのドキュメントセクション／ナビゲーショングルーピングスラッグ。
+- **Purpose:** レンダリングされたドキュメントのドキュメントセクション／ナビゲーショングループスラッグ。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -713,12 +752,12 @@ i18n:
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## アップストリームパススルー
+## 上流パススルー
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** F5 アップストリームスペックからそのまま保持されます。
+- **Purpose:** F5 上流仕様から変更せずに保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -730,7 +769,7 @@ i18n:
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** F5 アップストリームスペックからそのまま保持されます。
+- **Purpose:** F5 上流仕様から変更せずに保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -742,7 +781,7 @@ i18n:
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** F5 アップストリームスペックからそのまま保持されます。
+- **Purpose:** F5 上流仕様から変更せずに保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -754,7 +793,7 @@ i18n:
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** F5 アップストリームスペックからそのまま保持されます。
+- **Purpose:** F5 上流仕様から変更せずに保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -766,7 +805,7 @@ i18n:
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** F5 アップストリームスペックからそのまま保持されます。
+- **Purpose:** F5 上流仕様から変更せずに保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -778,7 +817,7 @@ i18n:
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** F5 アップストリームスペックからそのまま保持されます。
+- **Purpose:** F5 上流仕様から変更せずに保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -790,35 +829,35 @@ i18n:
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** F5 アップストリームスペックからそのまま保持されます。
+- **Purpose:** F5 上流仕様から変更せずに保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** F5 アップストリームドキュメントを参照してください。
+- **Example:** F5 上流ドキュメントを参照してください。
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** F5 アップストリームスペックからそのまま保持されます。
+- **Purpose:** F5 上流仕様から変更せずに保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** F5 アップストリームドキュメントを参照してください。
+- **Example:** F5 上流ドキュメントを参照してください。
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** F5 アップストリームスペックからそのまま保持されます。
+- **Purpose:** F5 上流仕様から変更せずに保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** F5 アップストリームドキュメントを参照してください。
+- **Example:** F5 上流ドキュメントを参照してください。
 - **Pass-through from upstream:** yes

--- a/docs/ko/extensions/catalog.md
+++ b/docs/ko/extensions/catalog.md
@@ -1,24 +1,24 @@
 ---
 title: 강화 확장 카탈로그
-description: 강화된 OpenAPI 사양에 있는 모든 x-* 확장에 대한 단일 진실 공급원
+description: 강화된 OpenAPI 사양의 모든 x-* 확장에 대한 단일 진실 공급원
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
 # 강화 확장 카탈로그
 
-`docs/specifications/api/*.json`에 나타나는 모든 `x-*` 확장에 대한 단일 진실 공급원입니다. `scripts/utils/extension_constants.py`와의 일치는 `tests/test_extension_catalog.py`에 의해 강제됩니다.
+`docs/specifications/api/*.json`에 나타나는 모든 `x-*` 확장의 단일 진실 공급원입니다. `scripts/utils/extension_constants.py`와의 동등성은 `tests/test_extension_catalog.py`에 의해 적용됩니다.
 
-여기에 세 가지 종류의 확장이 문서화되어 있습니다:
+여기에는 세 가지 클래스의 확장이 문서화되어 있습니다:
 
-- **여기서 주입됨** — 인리처가 추가하는 확장 (`x-f5xc-*` 및 `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / 디스커버리 변형). 다운스트림 도구에서 소비해야 하는 확장입니다.
-- **업스트림 패스스루** — F5가 소스 사양에서 내보내고 변경 없이 보존하는 확장 (`x-ves-proto-*`, `x-displayname` 등). 투명성을 위해 문서화되었지만 이 저장소에서 제어되지 않습니다.
-- **향후 주입 예정** — 아직 내보내지 않음; 인리처가 생성하기 시작하는 즉시 문서화됩니다 (초기 배포 시에는 해당 없음).
+- **여기서 주입됨** — 강화기(enricher)가 추가하는 확장 (`x-f5xc-*` 및 `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / 디스커버리 변형). 이것들이 다운스트림 도구가 사용해야 하는 항목입니다.
+- **업스트림 통과** — F5가 소스 사양에서 방출하고 우리가 변경 없이 보존하는 확장 (`x-ves-proto-*`, `x-displayname` 등). 투명성을 위해 문서화되었지만 이 레포지토리에서 제어하지 않습니다.
+- **향후 주입 예정** — 아직 방출되지 않음; 강화기가 생성하기 시작하는 순간 여기에 문서화됩니다 (초기 작성 시에는 해당 없음).
 
 ## 항목 스키마
 
-아래의 모든 항목은 정확히 이 형태를 가집니다. `tests/test_extension_catalog.py`의 일치 테스트는 `### x-name` 헤더가 존재하고 `Pass-through from upstream:` 플래그가 `yes` 또는 `no` 값과 함께 있는 한 섹션 본문이 간략해도 허용합니다.
+아래의 모든 항목은 정확히 이 형태를 가집니다. `tests/test_extension_catalog.py`의 동등성 테스트는 `### x-name` 헤더가 존재하고 `Pass-through from upstream:` 플래그가 `yes` 또는 `no` 값으로 존재하는 한 섹션 본문이 간략한 것을 허용합니다.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -36,7 +36,7 @@ i18n:
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** 강화된 사양에 대한 CLI 도메인 슬러그(예: `http_loadbalancer`)를 식별합니다.
+- **Purpose:** 강화된 사양의 CLI 도메인 슬러그 (예: `http_loadbalancer`)를 식별합니다.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -84,7 +84,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** 파이프라인에 의해 강화된 사양에 스탬프된 시맨틱 버전.
+- **Purpose:** 파이프라인에 의해 강화된 사양에 찍힌 시맨틱 버전.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -96,7 +96,7 @@ i18n:
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** 각 도메인 사양에 적용되는 브랜딩/용어 용어집 블록.
+- **Purpose:** 각 도메인 사양에 적용된 브랜딩/용어 용어집 블록.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -120,7 +120,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** 디스커버리 중에 탐색된 라이브 API의 기본 URL.
+- **Purpose:** 디스커버리 중에 조사된 라이브 API의 기본 URL.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -132,7 +132,7 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** 이 도메인에 대해 호스팅된 API 참조 문서 페이지의 URL.
+- **Purpose:** 이 도메인에 대한 호스팅된 API 참조 문서 페이지의 URL.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -144,7 +144,7 @@ i18n:
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** 디스커버리 중에 탐색된 API에 대해 관측된 응답 시간 (ms).
+- **Purpose:** 디스커버리 중에 조사된 API에 대해 관측된 응답 시간 (ms).
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -156,7 +156,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** 도메인에 대해 엄선된 모범 사례 안내.
+- **Purpose:** 도메인에 대한 선별된 모범 사례 지침.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -168,7 +168,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** 도메인에서 일반적인 작업을 수행하기 위한 이름이 지정된 단계별 워크플로.
+- **Purpose:** 도메인에서 일반적인 작업을 수행하기 위한 명명된 단계별 워크플로우.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -187,6 +187,18 @@ i18n:
 - **Injected by:** scripts/utils/acronym_enricher.py
 - **Driven by config:** config/acronyms.yaml
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
+- **Pass-through from upstream:** no
+
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** 전역 콘솔 탐색 트리 — 워크스페이스 및 메뉴 계층 구조.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
 - **Pass-through from upstream:** no
 
 ## 주입됨 — 스키마 수준 (구성 요소 스키마)
@@ -218,7 +230,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** UI/CLI 표시를 위한 속성의 권장 순서.
+- **Purpose:** UI/CLI 표시를 위한 속성의 제안된 순서.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -242,13 +254,25 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** 리소스 스키마에 대한 사람이 읽을 수 있는 표시 이름 (자동 생성을 재정의).
+- **Purpose:** 리소스 스키마에 대한 사람이 읽을 수 있는 표시 이름 (자동 생성 재정의).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
 - **Injected by:** scripts/utils/field_metadata_enricher.py
 - **Driven by config:** config/field_metadata.yaml
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
+- **Pass-through from upstream:** no
+
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** 이 리소스에 대한 콘솔 UI 탐색, 라우팅 및 폼 구조.
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
 - **Pass-through from upstream:** no
 
 ## 주입됨 — 속성 수준
@@ -328,7 +352,7 @@ i18n:
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** 이 속성을 필요로 하는 HTTP 작업 (POST/PUT/...)을 나열합니다.
+- **Purpose:** 이 속성이 필요한 HTTP 작업 (POST/PUT/...)을 나열합니다.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -340,7 +364,7 @@ i18n:
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** 이 속성을 필요로 하는 명명된 기능 조합을 나열합니다.
+- **Purpose:** 이 속성이 필요한 명명된 기능 조합을 나열합니다.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -352,7 +376,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** 조건부 요구 사항 (예: 형제 필드가 X와 같을 때 필수).
+- **Purpose:** 조건부 요구사항 (예: 형제 필드가 X와 같을 때 필요).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -364,7 +388,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** 대체 안내가 포함된 사용 중단 알림.
+- **Purpose:** 대체 지침이 포함된 사용 중단 공지.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -400,7 +424,7 @@ i18n:
 ### x-f5xc-recommended-oneof-variant
 
 - **Applied at:** schema property
-- **Purpose:** `oneOf` 블록의 경우 권장 변형을 나타냅니다.
+- **Purpose:** `oneOf` 블록의 경우 권장되는 변형을 나타냅니다.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -424,7 +448,7 @@ i18n:
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** 한 필드가 다른 필드를 필요로 하는 교차 필드 종속성을 문서화합니다.
+- **Purpose:** 한 필드가 다른 필드의 설정을 필요로 하는 교차 필드 의존성을 문서화합니다.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -436,7 +460,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** 라이브 API 탐색 또는 정적 패턴에서 파생된 숫자/문자열 제약.
+- **Purpose:** 라이브 API 탐지 또는 정적 패턴에서 파생된 숫자/문자열 제약.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -457,12 +481,24 @@ i18n:
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** 이 API 속성에 대한 콘솔 폼 위젯 메타데이터.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
 ## 주입됨 — 작업 수준
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** 성공을 위해 제공해야 하는 작업 본문 필드의 이름을 지정합니다.
+- **Purpose:** 성공을 위해 제공되어야 하는 작업 본문 필드를 명명합니다.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -474,7 +510,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** 작업의 영향 범위를 분류합니다 (low/medium/high/critical).
+- **Purpose:** 작업의 영향 범위를 분류합니다 (낮음/중간/높음/위험).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -486,7 +522,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** CLI/UI가 실행 전에 사용자에게 확인을 요청해야 하는지 여부.
+- **Purpose:** 실행 전에 CLI/UI가 사용자에게 확인을 요청해야 하는지 여부.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -498,7 +534,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** 작업의 관측 가능한 부작용을 나열합니다 (재시작, 재구성 등).
+- **Purpose:** 작업의 관측 가능한 부작용 목록 (재시작, 재구성 등).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -534,7 +570,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** 라이브 디스커버리 중에 관측된 오류 응답 카탈로그 (샘플 페이로드 포함).
+- **Purpose:** 샘플 페이로드와 함께 라이브 디스커버리 중에 관측된 오류 응답 카탈로그.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -572,7 +608,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** 높은 주의가 필요한 리소스 (프로덕션 중요).
+- **Purpose:** 높은 주의가 필요한 리소스 (프로덕션 크리티컬).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -584,7 +620,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** 짧은 (~60자) 도메인 설명. 긴 설명의 속성 수준에도 적용됩니다.
+- **Purpose:** 짧은 (~60자) 도메인 설명. 긴 설명의 경우 속성 수준에도 적용됩니다.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -620,7 +656,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** 이 도메인에서 구성을 작성하는 상대적 복잡도 등급.
+- **Purpose:** 이 도메인에서 구성을 작성하기 위한 상대적 복잡도 수준.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -632,7 +668,7 @@ i18n:
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** 필요한 최소 F5 XC 구독 등급.
+- **Purpose:** 필요한 최소 F5 XC 구독 티어.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -644,7 +680,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** 도메인을 미리보기/베타 기능으로 표시합니다.
+- **Purpose:** 도메인을 프리뷰/베타 기능으로 표시합니다.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -680,7 +716,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** 도메인을 나타내는 브랜드 로고에 대한 인라인 SVG (또는 경로).
+- **Purpose:** 도메인을 나타내는 브랜드 로고의 인라인 SVG (또는 경로).
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -704,7 +740,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** 렌더링된 문서에 대한 문서 섹션 / 탐색 그룹화 슬러그.
+- **Purpose:** 렌더링된 문서의 문서 섹션/탐색 그룹화 슬러그.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -713,7 +749,7 @@ i18n:
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## 업스트림 패스스루
+## 업스트림 통과
 
 ### x-ves-proto-package
 

--- a/docs/pt-br/extensions/catalog.md
+++ b/docs/pt-br/extensions/catalog.md
@@ -1,29 +1,29 @@
 ---
 title: Catálogo de Extensões de Enriquecimento
 description: >-
-  Fonte de verdade para cada extensão x-* nas especificações OpenAPI
+  Fonte oficial de todas as extensões x-* nas especificações OpenAPI
   enriquecidas
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
 # Catálogo de Extensões de Enriquecimento
 
-Fonte de verdade para cada extensão `x-*` que aparece em
+Fonte oficial de todas as extensões `x-*` que aparecem em
 `docs/specifications/api/*.json`. A paridade com
 `scripts/utils/extension_constants.py` é verificada por
 `tests/test_extension_catalog.py`.
 
 Três classes de extensões estão documentadas aqui:
 
-- **Injetadas aqui** — extensões que nossos enriquecedores adicionam (`x-f5xc-*` e
+- **Injetadas aqui** — extensões adicionadas pelos nossos enriquecedores (`x-f5xc-*` e
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / variantes de
-  descoberta). São estas que as ferramentas downstream devem consumir.
-- **Passagem upstream** — extensões que a F5 emite nas especificações de origem
-  e que preservamos sem alteração (`x-ves-proto-*`, `x-displayname`, etc.).
-  Documentadas por transparência, mas não controladas por este repositório.
-- **Injetadas futuramente** — ainda não emitidas; documentadas aqui no momento
+  descoberta). Estas são as que ferramentas downstream devem consumir.
+- **Passagem upstream** — extensões emitidas pela F5 nas especificações-fonte
+  e preservadas sem alteração (`x-ves-proto-*`, `x-displayname`, etc.).
+  Documentadas para transparência, mas não controladas por este repositório.
+- **Futuras injetadas** — ainda não emitidas; documentadas aqui no momento
   em que um enriquecedor começar a produzi-las (não aplicável na população inicial).
 
 ## Esquema de entrada
@@ -44,12 +44,12 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## Injetadas — nível de spec (seção info)
+## Injetadas — nível de especificação (seção info)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** Identifica o slug de domínio CLI (ex.: `http_loadbalancer`) para uma spec enriquecida.
+- **Purpose:** Identifica o slug de domínio da CLI (ex.: `http_loadbalancer`) para uma especificação enriquecida.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -61,7 +61,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** Bloco de metadados de toda a CLI (nome da ferramenta, dicas de versão, agrupamento de domínio).
+- **Purpose:** Bloco de metadados global da CLI (nome da ferramenta, dicas de versão, agrupamento de domínio).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -73,7 +73,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** Timestamp da spec de origem upstream a partir da qual o arquivo enriquecido foi construído.
+- **Purpose:** Timestamp da especificação-fonte upstream a partir da qual o arquivo enriquecido foi gerado.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -85,7 +85,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag do ativo de lançamento da spec de origem upstream.
+- **Purpose:** ETag do ativo de lançamento da especificação-fonte upstream.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -97,7 +97,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** Versão semântica carimbada na spec enriquecida pelo pipeline.
+- **Purpose:** Versão semântica carimbada na especificação enriquecida pelo pipeline.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -109,7 +109,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** Bloco de glossário de marca/terminologia aplicado a cada spec de domínio.
+- **Purpose:** Bloco de glossário de marca/terminologia aplicado a cada especificação de domínio.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -121,7 +121,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** Timestamp de quando a etapa de descoberta da API ao vivo foi executada.
+- **Purpose:** Timestamp de quando a passagem de descoberta da API ao vivo foi executada.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -145,7 +145,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL da página de documentação de referência de API hospedada para este domínio.
+- **Purpose:** URL para a página de documentação de referência da API hospedada para este domínio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -181,7 +181,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** Fluxos de trabalho nomeados, passo a passo, para realizar tarefas comuns em um domínio.
+- **Purpose:** Fluxos de trabalho nomeados com etapas para realizar tarefas comuns em um domínio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -202,12 +202,24 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
-## Injetadas — nível de esquema (schemas de componentes)
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** Árvore de navegação global do console — hierarquia de espaços de trabalho e menus.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
+## Injetadas — nível de esquema (esquemas de componentes)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** Conjunto mínimo de campos necessários para realizar com êxito POST/PUT deste recurso.
+- **Purpose:** Conjunto mínimo de campos necessários para realizar com êxito um POST/PUT deste recurso.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -219,7 +231,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** Fornece metadados de restrição, recomendação e classificação de namespace para um recurso.
+- **Purpose:** Fornece metadados de restrição de namespace, recomendação e classificação para um recurso.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -243,7 +255,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** Nome do tipo de recurso Terraform que mapeia para este esquema.
+- **Purpose:** Nome do tipo de recurso Terraform que corresponde a este esquema.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -262,6 +274,18 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 - **Injected by:** scripts/utils/field_metadata_enricher.py
 - **Driven by config:** config/field_metadata.yaml
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
+- **Pass-through from upstream:** no
+
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** Navegação da UI do console, roteamento e estrutura de formulário para este recurso.
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
 - **Pass-through from upstream:** no
 
 ## Injetadas — nível de propriedade
@@ -317,7 +341,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** Dicas de completamento de shell (enum estático ou comando dinâmico).
+- **Purpose:** Dicas de autocompletar para shell (enum estático ou comando dinâmico).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -329,7 +353,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** Valor(es) padrão a serem exibidos em documentações e interfaces geradas.
+- **Purpose:** Valor(es) padrão a serem exibidos em documentações e UIs geradas.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -353,7 +377,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** Lista combinações de recursos nomeados que exigem esta propriedade.
+- **Purpose:** Lista combinações de funcionalidades nomeadas que exigem esta propriedade.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -377,7 +401,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** Aviso de depreciação com orientação de substituição.
+- **Purpose:** Aviso de descontinuação com orientação sobre substituição.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -401,7 +425,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** Valor recomendado para produção de um campo onde o padrão do servidor é subótimo.
+- **Purpose:** Valor recomendado para produção em um campo cujo padrão do servidor não é ideal.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -425,7 +449,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** Lista propriedades irmãs que não podem ser definidas junto com esta.
+- **Purpose:** Lista propriedades irmãs que não podem ser definidas juntamente com esta.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -437,7 +461,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** Documenta dependências entre campos, onde um campo exige que outro esteja definido.
+- **Purpose:** Documenta dependências entre campos em que um campo exige que outro esteja definido.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -449,7 +473,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Restrições numéricas/de string derivadas de sondagem de API ao vivo ou padrões estáticos.
+- **Purpose:** Restrições numéricas/de string derivadas de sondagem da API ao vivo ou padrões estáticos.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -470,6 +494,18 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** Metadados do widget de formulário do console para esta propriedade da API.
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
 ## Injetadas — nível de operação
 
 ### x-f5xc-required-fields
@@ -487,7 +523,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** Classifica o raio de impacto de uma operação (low/medium/high/critical).
+- **Purpose:** Classifica o raio de impacto de uma operação (baixo/médio/alto/crítico).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -499,7 +535,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Indica se a CLI/UI deve solicitar confirmação do usuário antes de executar.
+- **Purpose:** Indica se a CLI/UI deve solicitar confirmação ao usuário antes de executar.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -535,7 +571,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** Cabeçalhos/comportamento de limite de taxa observados na API ao vivo.
+- **Purpose:** Cabeçalhos/comportamento de limitação de taxa observados na API ao vivo.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -547,7 +583,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** Catálogo de respostas de erro observadas durante a descoberta ao vivo, com payloads de amostra.
+- **Purpose:** Catálogo de respostas de erro observadas durante a descoberta ao vivo, com payloads de exemplo.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -585,7 +621,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** Recursos que requerem cuidado elevado (críticos para produção).
+- **Purpose:** Recursos que exigem atenção elevada (críticos para produção).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -597,7 +633,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** Descrição curta (~60 caracteres) do domínio. Também se aplica no nível de propriedade para descrições longas.
+- **Purpose:** Descrição curta do domínio (~60 caracteres). Também se aplica no nível de propriedade para descrições longas.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -609,7 +645,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** Descrição média (~150 caracteres) do domínio. Também se aplica no nível de propriedade.
+- **Purpose:** Descrição média do domínio (~150 caracteres). Também se aplica no nível de propriedade.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -621,7 +657,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** Descrição longa (~500 caracteres) do domínio.
+- **Purpose:** Descrição longa do domínio (~500 caracteres).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -633,7 +669,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** Nível relativo de complexidade para criação de configurações neste domínio.
+- **Purpose:** Nível de complexidade relativa para criação de configurações neste domínio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -657,7 +693,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** Sinaliza um domínio como recurso em pré-visualização / beta.
+- **Purpose:** Sinaliza um domínio como funcionalidade em pré-visualização / beta.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -669,7 +705,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** Casos de uso nomeados que este domínio suporta.
+- **Purpose:** Casos de uso nomeados suportados por este domínio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -681,7 +717,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** Identificador de ícone a ser usado na renderização deste domínio em uma interface.
+- **Purpose:** Identificador de ícone a ser usado ao renderizar este domínio em uma UI.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -693,7 +729,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** SVG inline (ou caminho) para um logotipo de marca representando o domínio.
+- **Purpose:** SVG embutido (ou caminho) para um logotipo de marca representando o domínio.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -705,7 +741,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** Links cruzados para outros domínios frequentemente usados em conjunto com este.
+- **Purpose:** Links cruzados para outros domínios comumente utilizados em conjunto com este.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -717,7 +753,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** Slug de seção de documentação / agrupamento de navegação para docs renderizadas.
+- **Purpose:** Slug de seção de documentação / agrupamento de navegação para docs renderizados.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -731,7 +767,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alteração da spec upstream da F5.
+- **Purpose:** Preservado sem alteração a partir da especificação upstream da F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -743,7 +779,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alteração da spec upstream da F5.
+- **Purpose:** Preservado sem alteração a partir da especificação upstream da F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -755,7 +791,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alteração da spec upstream da F5.
+- **Purpose:** Preservado sem alteração a partir da especificação upstream da F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -767,7 +803,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alteração da spec upstream da F5.
+- **Purpose:** Preservado sem alteração a partir da especificação upstream da F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -779,7 +815,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alteração da spec upstream da F5.
+- **Purpose:** Preservado sem alteração a partir da especificação upstream da F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -791,7 +827,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alteração da spec upstream da F5.
+- **Purpose:** Preservado sem alteração a partir da especificação upstream da F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -803,7 +839,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alteração da spec upstream da F5.
+- **Purpose:** Preservado sem alteração a partir da especificação upstream da F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -815,7 +851,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alteração da spec upstream da F5.
+- **Purpose:** Preservado sem alteração a partir da especificação upstream da F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -827,7 +863,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alteração da spec upstream da F5.
+- **Purpose:** Preservado sem alteração a partir da especificação upstream da F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A

--- a/docs/th/extensions/catalog.md
+++ b/docs/th/extensions/catalog.md
@@ -1,54 +1,55 @@
 ---
-title: แคตตาล็อกส่วนขยายการเพิ่มประสิทธิภาพ
+title: แคตตาล็อก Extension การเพิ่มประสิทธิภาพ
 description: >-
-  แหล่งข้อมูลหลักสำหรับส่วนขยาย x-* ทุกรายการในข้อกำหนด OpenAPI
-  ที่เพิ่มประสิทธิภาพแล้ว
+  แหล่งข้อมูลอ้างอิงหลักสำหรับ x-* extension ทุกรายการในข้อกำหนด OpenAPI
+  ที่เพิ่มประสิทธิภาพ
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
-# แคตตาล็อกส่วนขยายการเพิ่มประสิทธิภาพ
+# แคตตาล็อก Extension การเพิ่มประสิทธิภาพ
 
-แหล่งข้อมูลหลักสำหรับส่วนขยาย `x-*` ทุกรายการที่ปรากฏใน
+แหล่งข้อมูลอ้างอิงหลักสำหรับ `x-*` extension ทุกรายการที่ปรากฏใน
 `docs/specifications/api/*.json` ความสอดคล้องกับ
 `scripts/utils/extension_constants.py` ถูกบังคับใช้โดย
 `tests/test_extension_catalog.py`
 
-ส่วนขยายสามประเภทได้รับการจัดทำเอกสารไว้ที่นี่:
+มี extension สามประเภทที่บันทึกไว้ที่นี่:
 
-- **ฉีดเข้าที่นี่** — ส่วนขยายที่ตัวเพิ่มประสิทธิภาพของเราเพิ่มเข้าไป (`x-f5xc-*` และ
-  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / ตัวแปรการค้นพบ)
-  เหล่านี้คือส่วนขยายที่เครื่องมือปลายทางควรนำไปใช้
-- **ส่งผ่านจากต้นทาง** — ส่วนขยายที่ F5 ส่งออกในข้อกำหนดต้นทางและเราเก็บรักษาไว้โดยไม่เปลี่ยนแปลง (`x-ves-proto-*`, `x-displayname` ฯลฯ)
-  จัดทำเอกสารไว้เพื่อความโปร่งใสแต่ไม่ได้ควบคุมโดย repo นี้
-- **จะฉีดในอนาคต** — ยังไม่ได้ส่งออก จะจัดทำเอกสารทันทีที่
-  ตัวเพิ่มประสิทธิภาพเริ่มสร้าง (ไม่มีผลในการเติมข้อมูลครั้งแรก)
+- **ฉีดเข้าที่นี่** — extensions ที่ enricher ของเราเพิ่มเข้าไป (`x-f5xc-*` และ
+  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / discovery
+  variants) นี่คือรายการที่เครื่องมือปลายทางควรใช้
+- **ส่งผ่านจาก upstream** — extensions ที่ F5 ปล่อยออกมาในสเปกต้นทาง
+  และเราเก็บรักษาไว้โดยไม่เปลี่ยนแปลง (`x-ves-proto-*`, `x-displayname`, ฯลฯ)
+  บันทึกไว้เพื่อความโปร่งใสแต่ไม่ได้ถูกควบคุมโดย repo นี้
+- **จะฉีดในอนาคต** — ยังไม่ได้ปล่อยออกมา; บันทึกไว้ทันทีที่
+  enricher เริ่มผลิตออกมา (ไม่มีผลในการเติมข้อมูลเริ่มต้น)
 
-## รูปแบบรายการ
+## โครงสร้างของแต่ละรายการ
 
-ทุกรายการด้านล่างมีรูปแบบดังนี้ การทดสอบความสอดคล้องใน
-`tests/test_extension_catalog.py` ยอมรับให้เนื้อหาส่วนนี้สั้นได้
-ตราบใดที่หัวข้อ `### x-name` มีอยู่และ
+ทุกรายการด้านล่างมีรูปแบบนี้อย่างแน่นอน การทดสอบ parity ใน
+`tests/test_extension_catalog.py` ยอมรับให้เนื้อหาของส่วนมีรายละเอียดน้อย
+ตราบใดที่ส่วนหัว `### x-name` มีอยู่และ
 แฟล็ก `Pass-through from upstream:` ระบุค่าเป็น `yes` หรือ `no`
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
-    - **Purpose:** <one sentence>
+    - **Purpose:** <ประโยคเดียว>
     - **Consumers:** <CLI | VSCode | Terraform | Web UI | multiple | N/A>
     - **Value type:** <string | number | boolean | object | array>
     - **Value schema:** <JSON Schema snippet, or N/A>
     - **Injected by:** <scripts/utils/<enricher>.py, or "upstream">
     - **Driven by config:** <config/<file>.yaml, or "hardcoded", or "upstream">
-    - **Example:** <short snippet>
+    - **Example:** <ตัวอย่างสั้น>
     - **Pass-through from upstream:** <yes/no>
 
-## ฉีดเข้า — ระดับสเปค (ส่วน info)
+## ฉีดเข้า — ระดับสเปก (ส่วน info)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** ระบุสลัก CLI domain (เช่น `http_loadbalancer`) สำหรับสเปคที่เพิ่มประสิทธิภาพแล้ว
+- **Purpose:** ระบุ slug ของ CLI domain (เช่น `http_loadbalancer`) สำหรับสเปกที่เพิ่มประสิทธิภาพ
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -60,7 +61,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** บล็อกข้อมูลเมตาสำหรับ CLI ทั้งระบบ (ชื่อเครื่องมือ, คำแนะนำเวอร์ชัน, การจัดกลุ่ม domain)
+- **Purpose:** บล็อก metadata สำหรับ CLI ทั้งหมด (ชื่อเครื่องมือ, คำแนะนำเวอร์ชัน, การจัดกลุ่ม domain)
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -72,7 +73,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** การประทับเวลาของสเปคต้นทางที่ใช้สร้างไฟล์ที่เพิ่มประสิทธิภาพแล้ว
+- **Purpose:** Timestamp ของสเปกต้นทาง upstream ที่ใช้สร้างไฟล์ที่เพิ่มประสิทธิภาพ
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -84,7 +85,7 @@ i18n:
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag ของ asset รีลีสสเปคต้นทาง
+- **Purpose:** ETag ของ release asset สเปกต้นทาง upstream
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -96,7 +97,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** เวอร์ชัน Semantic ที่ประทับไว้บนสเปคที่เพิ่มประสิทธิภาพแล้วโดย pipeline
+- **Purpose:** Semantic version ที่ประทับตราบนสเปกที่เพิ่มประสิทธิภาพโดย pipeline
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -108,7 +109,7 @@ i18n:
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** บล็อกคำศัพท์การสร้างแบรนด์/คำศัพท์เทคนิคที่ใช้กับแต่ละสเปค domain
+- **Purpose:** บล็อก glossary สำหรับ branding/คำศัพท์ที่ใช้กับสเปกของแต่ละ domain
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -120,7 +121,7 @@ i18n:
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** การประทับเวลาเมื่อรันการค้นพบ live-API
+- **Purpose:** Timestamp เมื่อการรัน live-API discovery ถูกดำเนินการ
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -132,7 +133,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** URL พื้นฐานของ live API ที่ถูกตรวจสอบระหว่างการค้นพบ
+- **Purpose:** Base URL ของ live API ที่ถูกตรวจสอบในระหว่าง discovery
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -144,19 +145,19 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL ไปยังหน้าเอกสารอ้างอิง API ที่โฮสต์ไว้สำหรับ domain นี้
+- **Purpose:** URL ไปยังหน้าเอกสาร API reference ที่โฮสต์ไว้สำหรับ domain นี้
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
 - **Injected by:** scripts/utils/external_docs_enricher.py
-- **Driven by config:** none (derived from domain name)
+- **Driven by config:** none (ได้มาจากชื่อ domain)
 - **Example:** `"x-f5xc-api-reference-url": "https://f5xc-salesdemos.github.io/api-specs-enriched/api-reference/sites/"`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** เวลาตอบสนองที่สังเกตได้ (มิลลิวินาที) สำหรับ API ที่ถูกตรวจสอบระหว่างการค้นพบ
+- **Purpose:** เวลาตอบสนองที่สังเกตได้ (ms) สำหรับ API ที่ถูกตรวจสอบในระหว่าง discovery
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -168,7 +169,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** คำแนะนำแนวปฏิบัติที่ดีที่สุดสำหรับ domain
+- **Purpose:** คำแนะนำ best practice ที่คัดสรรสำหรับ domain
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -180,7 +181,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** เวิร์กโฟลว์แบบขั้นตอนที่มีชื่อสำหรับการดำเนินงานทั่วไปใน domain
+- **Purpose:** workflows ที่มีชื่อแบบ step-by-step เพื่อทำงานทั่วไปใน domain
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -192,7 +193,7 @@ i18n:
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** ตารางขยายคำย่อเฉพาะ domain
+- **Purpose:** ตารางขยายคำย่อตาม domain
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -201,12 +202,24 @@ i18n:
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** โครงสร้างการนำทางใน console ทั่วโลก — ลำดับชั้นของ workspace และเมนู
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
 ## ฉีดเข้า — ระดับ schema (component schemas)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** ชุดฟิลด์ขั้นต่ำที่จำเป็นสำหรับการ POST/PUT ทรัพยากรนี้ให้สำเร็จ
+- **Purpose:** ชุดฟิลด์ขั้นต่ำที่จำเป็นต้องใช้เพื่อ POST/PUT resource นี้ให้สำเร็จ
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -218,7 +231,7 @@ i18n:
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** ให้ข้อมูลเมตาเกี่ยวกับข้อจำกัด, คำแนะนำ และการจำแนกประเภท namespace สำหรับทรัพยากร
+- **Purpose:** ให้ข้อมูล metadata ด้านข้อจำกัด คำแนะนำ และการจัดประเภทของ namespace สำหรับ resource
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -242,7 +255,7 @@ i18n:
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** ชื่อประเภท Terraform resource ที่แมปกับ schema นี้
+- **Purpose:** ชื่อประเภท Terraform resource ที่จับคู่กับ schema นี้
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -254,7 +267,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** ชื่อที่แสดงอ่านได้สำหรับมนุษย์สำหรับ resource schema (แทนที่การสร้างอัตโนมัติ)
+- **Purpose:** ชื่อที่อ่านได้สำหรับมนุษย์ของ resource schema (แทนที่การสร้างอัตโนมัติ)
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -263,12 +276,24 @@ i18n:
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** การนำทาง Console UI, routing และโครงสร้างฟอร์มสำหรับ resource นี้
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
+- **Pass-through from upstream:** no
+
 ## ฉีดเข้า — ระดับ property
 
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** คำอธิบาย property ที่เพิ่มประสิทธิภาพซึ่งเสริม `description` จากต้นทาง
+- **Purpose:** คำอธิบาย property ที่เพิ่มประสิทธิภาพซึ่งเสริมจาก `description` ของ upstream
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -280,7 +305,7 @@ i18n:
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** กฎการตรวจสอบแบบ Declarative ที่ได้จาก `ves.io.schema.rules` ของ protobuf ต้นทาง
+- **Purpose:** กฎ validation แบบ declarative ที่ได้มาจาก `ves.io.schema.rules` ของ upstream protobuf
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -292,7 +317,7 @@ i18n:
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** ค่าตัวอย่างหลายรายการสำหรับ property
+- **Purpose:** ค่าตัวอย่างหลายรายการที่แสดงถึง property
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -304,7 +329,7 @@ i18n:
 ### x-f5xc-example
 
 - **Applied at:** schema property
-- **Purpose:** ค่าตัวอย่างมาตรฐานเดียว
+- **Purpose:** ค่าตัวอย่าง canonical เดี่ยว
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -316,7 +341,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** คำแนะนำสำหรับการเติมข้อความ shell (enum แบบ static หรือคำสั่งแบบ dynamic)
+- **Purpose:** คำแนะนำสำหรับ shell completion (enum แบบ static หรือคำสั่งแบบ dynamic)
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -328,7 +353,7 @@ i18n:
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** ค่าเริ่มต้นที่แสดงในเอกสารที่สร้างขึ้นและ UI
+- **Purpose:** ค่าเริ่มต้นที่จะแสดงในเอกสารที่สร้างขึ้นและ UI
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -352,7 +377,7 @@ i18n:
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** แสดงรายการชุดฟีเจอร์ที่มีชื่อซึ่งต้องการ property นี้
+- **Purpose:** แสดงรายการการรวมกันของฟีเจอร์ที่มีชื่อซึ่งต้องการ property นี้
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -364,7 +389,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** ข้อกำหนดแบบมีเงื่อนไข (เช่น จำเป็นเมื่อฟิลด์ข้างเคียงมีค่าเท่ากับ X)
+- **Purpose:** ข้อกำหนดแบบมีเงื่อนไข (เช่น required เมื่อฟิลด์ sibling มีค่าเท่ากับ X)
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -376,7 +401,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** ประกาศการเลิกใช้พร้อมคำแนะนำทางเลือกแทน
+- **Purpose:** ประกาศการเลิกใช้งานพร้อมคำแนะนำสำหรับสิ่งที่จะมาแทนที่
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -388,7 +413,7 @@ i18n:
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** ค่าเริ่มต้นที่เซิร์ฟเวอร์กำหนดเมื่อ client ละเว้น property
+- **Purpose:** ค่าเริ่มต้นที่ server กำหนดเมื่อ client ไม่ได้ระบุ property
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -400,7 +425,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** ค่าที่แนะนำสำหรับการใช้งานจริงสำหรับฟิลด์ที่ค่าเริ่มต้นของเซิร์ฟเวอร์ไม่เหมาะสม
+- **Purpose:** ค่าที่แนะนำสำหรับ production ของฟิลด์ที่ค่าเริ่มต้นของ server ไม่เหมาะสมที่สุด
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -412,7 +437,7 @@ i18n:
 ### x-f5xc-recommended-oneof-variant
 
 - **Applied at:** schema property
-- **Purpose:** สำหรับบล็อก `oneOf` ระบุว่าตัวแปรใดที่แนะนำ
+- **Purpose:** สำหรับบล็อก `oneOf` ระบุว่า variant ใดที่แนะนำ
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -424,7 +449,7 @@ i18n:
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** แสดงรายการ properties ข้างเคียงที่ไม่สามารถตั้งค่าพร้อมกับ property นี้ได้
+- **Purpose:** แสดงรายการ properties sibling ที่ไม่สามารถตั้งค่าพร้อมกับรายการนี้ได้
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -436,7 +461,7 @@ i18n:
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** จัดทำเอกสารการพึ่งพาข้ามฟิลด์ซึ่งฟิลด์หนึ่งต้องการให้อีกฟิลด์หนึ่งถูกตั้งค่า
+- **Purpose:** บันทึก cross-field dependencies ที่ฟิลด์หนึ่งต้องการให้ฟิลด์อื่นถูกตั้งค่าด้วย
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -448,7 +473,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** ข้อจำกัดตัวเลข / สตริงที่ได้จากการตรวจสอบ live-API หรือรูปแบบ static
+- **Purpose:** ข้อจำกัดด้านตัวเลข / string ที่ได้มาจากการตรวจสอบ live-API หรือรูปแบบ static
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -460,7 +485,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** ประกาศว่าฟิลด์ต้องมีค่าเฉพาะภายในขอบเขตของตัวหรือไม่
+- **Purpose:** ประกาศว่าฟิลด์ต้องมีความเป็นเอกลักษณ์ภายใน scope ของมันหรือไม่
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -469,12 +494,24 @@ i18n:
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** metadata ของ widget ในฟอร์ม Console สำหรับ API property นี้
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
 ## ฉีดเข้า — ระดับ operation
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** ระบุชื่อฟิลด์ใน operation body ที่ต้องระบุเพื่อให้สำเร็จ
+- **Purpose:** ระบุชื่อฟิลด์ในเนื้อหาของ operation ที่ต้องระบุเพื่อให้สำเร็จ
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -486,7 +523,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** จำแนกระดับผลกระทบของ operation (low/medium/high/critical)
+- **Purpose:** จัดประเภทขนาดผลกระทบของ operation (low/medium/high/critical)
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -498,7 +535,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** ระบุว่า CLI/UI ควรแจ้งให้ผู้ใช้ยืนยันก่อนดำเนินการหรือไม่
+- **Purpose:** CLI/UI ควรแจ้งให้ผู้ใช้ยืนยันก่อนดำเนินการหรือไม่
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -510,7 +547,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** แสดงรายการผลข้างเคียงที่สังเกตได้จาก operation (restart, reconfigure ฯลฯ)
+- **Purpose:** แสดงรายการผลข้างเคียงที่สังเกตได้ของ operation (restart, reconfigure, ฯลฯ)
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -522,7 +559,7 @@ i18n:
 ### x-f5xc-discovered-response-time
 
 - **Applied at:** operation
-- **Purpose:** เวลาตอบสนองที่วัดได้จากการทดลองจริงสำหรับ operation นี้ระหว่างการค้นพบ
+- **Purpose:** เวลาตอบสนองที่วัดได้จริงสำหรับ operation นี้ในระหว่าง discovery
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -546,7 +583,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** แคตตาล็อกของการตอบสนองข้อผิดพลาดที่สังเกตได้ระหว่างการค้นพบสด พร้อม payload ตัวอย่าง
+- **Purpose:** แคตตาล็อกของ error responses ที่สังเกตพบระหว่าง live discovery พร้อม sample payloads
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -555,12 +592,12 @@ i18n:
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## ฉีดเข้า — ระดับ index (ข้อมูลเมตา domain)
+## ฉีดเข้า — ระดับ index (domain metadata)
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** หมวดหมู่การจัดกลุ่มระดับสูงสุดสำหรับ CLI / UI / เอกสาร / Terraform ของ domain
+- **Purpose:** หมวดหมู่การจัดกลุ่มระดับบนสุดของ CLI / UI / docs / Terraform สำหรับ domain
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -572,7 +609,7 @@ i18n:
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** รายการประเภททรัพยากรหลักที่กำหนด domain
+- **Purpose:** รายการประเภท resource หลักที่กำหนด domain
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -584,7 +621,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** ทรัพยากรที่ต้องการความระมัดระวังสูง (สำคัญต่อการใช้งานจริง)
+- **Purpose:** ทรัพยากรที่ต้องการความระมัดระวังสูง (สำคัญต่อ production)
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -596,7 +633,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** คำอธิบาย domain สั้น (~60 ตัวอักษร) ใช้ได้ที่ระดับ property สำหรับคำอธิบายยาวด้วย
+- **Purpose:** คำอธิบาย domain สั้น (~60 ตัวอักษร) ใช้ได้กับระดับ property ด้วยสำหรับคำอธิบายที่ยาว
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -608,7 +645,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** คำอธิบาย domain ระดับกลาง (~150 ตัวอักษร) ใช้ได้ที่ระดับ property ด้วย
+- **Purpose:** คำอธิบาย domain ขนาดกลาง (~150 ตัวอักษร) ใช้ได้กับระดับ property ด้วย
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -620,7 +657,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** คำอธิบาย domain แบบยาว (~500 ตัวอักษร)
+- **Purpose:** คำอธิบาย domain ขนาดยาว (~500 ตัวอักษร)
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -632,7 +669,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** ระดับความซับซ้อนสัมพัทธ์สำหรับการเขียนการกำหนดค่าใน domain นี้
+- **Purpose:** ระดับความซับซ้อนสัมพัทธ์สำหรับการสร้าง configurations ใน domain นี้
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -644,7 +681,7 @@ i18n:
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** ระดับการสมัครใช้งาน F5 XC ขั้นต่ำที่ต้องการ
+- **Purpose:** ระดับการสมัครสมาชิก F5 XC ขั้นต่ำที่จำเป็น
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -668,7 +705,7 @@ i18n:
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** กรณีการใช้งานที่มีชื่อซึ่ง domain นี้รองรับ
+- **Purpose:** use cases ที่มีชื่อซึ่ง domain นี้รองรับ
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -680,7 +717,7 @@ i18n:
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** ตัวระบุไอคอนที่ใช้เมื่อแสดง domain นี้ใน UI
+- **Purpose:** ตัวระบุไอคอนที่จะใช้เมื่อแสดง domain นี้ใน UI
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -692,7 +729,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** SVG แบบ inline (หรือ path) สำหรับโลโก้แบรนด์ที่แสดงถึง domain
+- **Purpose:** SVG แบบ inline (หรือ path) สำหรับโลโก้แบรนด์ที่แทน domain
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -704,7 +741,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** ลิงก์ข้ามไปยัง domain อื่นที่มักใช้ร่วมกับ domain นี้
+- **Purpose:** cross-link ไปยัง domains อื่นที่มักใช้ร่วมกับ domain นี้
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -716,7 +753,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** สลักส่วนเอกสาร / การจัดกลุ่มนำทางสำหรับเอกสารที่แสดงผล
+- **Purpose:** slug ของส่วนเอกสาร / การจัดกลุ่ม nav สำหรับเอกสารที่แสดงผล
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -725,12 +762,12 @@ i18n:
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## ส่งผ่านจากต้นทาง
+## ส่งผ่านจาก upstream
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปคต้นทาง F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปก upstream ของ F5
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -742,7 +779,7 @@ i18n:
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปคต้นทาง F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปก upstream ของ F5
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -754,7 +791,7 @@ i18n:
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปคต้นทาง F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปก upstream ของ F5
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -766,7 +803,7 @@ i18n:
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปคต้นทาง F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปก upstream ของ F5
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -778,7 +815,7 @@ i18n:
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปคต้นทาง F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปก upstream ของ F5
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -790,7 +827,7 @@ i18n:
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปคต้นทาง F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปก upstream ของ F5
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -802,35 +839,35 @@ i18n:
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปคต้นทาง F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปก upstream ของ F5
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** ดูเอกสารต้นทาง F5
+- **Example:** ดูเอกสาร upstream ของ F5
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปคต้นทาง F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปก upstream ของ F5
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** ดูเอกสารต้นทาง F5
+- **Example:** ดูเอกสาร upstream ของ F5
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปคต้นทาง F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปก upstream ของ F5
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** ดูเอกสารต้นทาง F5
+- **Example:** ดูเอกสาร upstream ของ F5
 - **Pass-through from upstream:** yes

--- a/docs/zh-cn/extensions/catalog.md
+++ b/docs/zh-cn/extensions/catalog.md
@@ -1,49 +1,42 @@
 ---
-title: 增强扩展目录
-description: 增强型 OpenAPI 规范中每个 x-* 扩展的权威来源
+title: 扩展字段目录
+description: 富化 OpenAPI 规范中每个 x-* 扩展的权威来源
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
-# 增强扩展目录
+# 扩展字段目录
 
-`docs/specifications/api/*.json` 中每个 `x-*` 扩展的权威来源。与
-`scripts/utils/extension_constants.py` 的一致性由
-`tests/test_extension_catalog.py` 强制保证。
+本目录是 `docs/specifications/api/*.json` 中每个 `x-*` 扩展的权威来源。与 `scripts/utils/extension_constants.py` 的一致性由 `tests/test_extension_catalog.py` 强制保证。
 
 此处记录了三类扩展：
 
-- **此处注入** — 由我们的增强器添加的扩展（`x-f5xc-*` 以及
-  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / 发现
-  变体）。这些是下游工具应使用的扩展。
-- **上游透传** — F5 在源规范中生成并由我们原样保留的扩展（`x-ves-proto-*`、`x-displayname` 等）。
-  为透明起见而记录，但不受本仓库控制。
-- **待注入** — 尚未生成；一旦某个增强器开始产生它们，即在此记录（初始填充时不适用）。
+- **此处注入** — 由我们的富化器添加的扩展（`x-f5xc-*` 以及 `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / 发现变体）。这些是下游工具应使用的扩展。
+- **上游透传** — F5 在源规范中发出并由我们原样保留的扩展（`x-ves-proto-*`、`x-displayname` 等）。为透明起见而记录，但不由本仓库控制。
+- **未来注入** — 尚未发出；一旦富化器开始生成即在此记录（初始填充时不适用）。
 
 ## 条目结构
 
-以下每个条目的格式完全如下所示。`tests/test_extension_catalog.py`
-中的一致性测试允许章节内容较为简略，只要 `### x-name` 标头存在，且
-`Pass-through from upstream:` 标志的值为 `yes` 或 `no` 即可。
+以下每个条目具有完全相同的结构。`tests/test_extension_catalog.py` 中的一致性测试容忍章节正文简略，只要 `### x-name` 标题存在，且 `Pass-through from upstream:` 标志以 `yes` 或 `no` 为值即可。
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
-    - **Purpose:** <one sentence>
+    - **Purpose:** <一句话说明>
     - **Consumers:** <CLI | VSCode | Terraform | Web UI | multiple | N/A>
     - **Value type:** <string | number | boolean | object | array>
-    - **Value schema:** <JSON Schema snippet, or N/A>
-    - **Injected by:** <scripts/utils/<enricher>.py, or "upstream">
-    - **Driven by config:** <config/<file>.yaml, or "hardcoded", or "upstream">
-    - **Example:** <short snippet>
+    - **Value schema:** <JSON Schema 片段，或 N/A>
+    - **Injected by:** <scripts/utils/<enricher>.py，或 "upstream">
+    - **Driven by config:** <config/<file>.yaml，或 "hardcoded"，或 "upstream">
+    - **Example:** <简短示例>
     - **Pass-through from upstream:** <yes/no>
 
-## 注入 — 规范级别（info 部分）
+## 注入 — 规范级别（info 节）
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** 标识增强规范的 CLI 域名缩写（例如 `http_loadbalancer`）。
+- **Purpose:** 标识富化规范的 CLI 域名缩略词（例如 `http_loadbalancer`）。
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -55,7 +48,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** CLI 全局元数据块（工具名称、版本提示、域分组）。
+- **Purpose:** CLI 级别的元数据块（工具名称、版本提示、域分组）。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -67,7 +60,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** 增强文件所依据的上游源规范的时间戳。
+- **Purpose:** 构建富化文件所使用的上游源规范的时间戳。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -91,7 +84,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** 由流水线标记在增强规范上的语义版本号。
+- **Purpose:** 由流水线在富化规范上打印的语义版本。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -115,7 +108,7 @@ i18n:
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** 执行实时 API 发现流程时的时间戳。
+- **Purpose:** 执行实时 API 发现过程的时间戳。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -127,7 +120,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** 发现期间被探测的实时 API 的基础 URL。
+- **Purpose:** 发现过程中探测的实时 API 基础 URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -139,19 +132,19 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** 该域托管 API 参考文档页面的 URL。
+- **Purpose:** 该域的托管 API 参考文档页面 URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
 - **Injected by:** scripts/utils/external_docs_enricher.py
-- **Driven by config:** none (derived from domain name)
+- **Driven by config:** none（由域名派生）
 - **Example:** `"x-f5xc-api-reference-url": "https://f5xc-salesdemos.github.io/api-specs-enriched/api-reference/sites/"`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** 发现期间探测 API 时观测到的响应时间（毫秒）。
+- **Purpose:** 发现过程中探测 API 的观测响应时间（毫秒）。
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -163,7 +156,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** 针对某个域精心整理的最佳实践指南。
+- **Purpose:** 针对某域的精选最佳实践指导。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -175,7 +168,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** 用于完成某个域中常见任务的有名称的分步工作流。
+- **Purpose:** 用于完成域内常见任务的命名分步工作流。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -187,7 +180,7 @@ i18n:
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** 按域划分的首字母缩略词扩展表。
+- **Purpose:** 按域划分的首字母缩写词扩展表。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -196,7 +189,19 @@ i18n:
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
-## 注入 — 模式级别（组件 schemas）
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** 全局控制台导航树 — 工作区与菜单层级结构。
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
+## 注入 — 模式级别（组件模式）
 
 ### x-f5xc-minimum-configuration
 
@@ -213,7 +218,7 @@ i18n:
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** 为资源提供命名空间约束、建议及分类元数据。
+- **Purpose:** 为资源提供命名空间约束、建议和分类元数据。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -225,7 +230,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** 用于 UI/CLI 展示的属性建议排列顺序。
+- **Purpose:** 供 UI/CLI 展示时建议的属性排列顺序。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -237,7 +242,7 @@ i18n:
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** 映射到该 schema 的 Terraform 资源类型名称。
+- **Purpose:** 映射到此模式的 Terraform 资源类型名称。
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -249,7 +254,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** 资源 schema 的人类可读显示名称（覆盖自动生成的名称）。
+- **Purpose:** 资源模式的人类可读显示名称（覆盖自动生成）。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -258,12 +263,24 @@ i18n:
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** 该资源的控制台 UI 导航、路由及表单结构。
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
+- **Pass-through from upstream:** no
+
 ## 注入 — 属性级别
 
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** 补充上游 `description` 的增强属性描述。
+- **Purpose:** 富化的属性描述，补充上游 `description`。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -287,7 +304,7 @@ i18n:
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** 属性的多个示例说明值。
+- **Purpose:** 属性的多个示例值。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -311,7 +328,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** Shell 补全提示（静态枚举或动态命令）。
+- **Purpose:** Shell 自动补全提示（静态枚举或动态命令）。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -335,7 +352,7 @@ i18n:
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** 列出需要该属性的 HTTP 操作（POST/PUT/...）。
+- **Purpose:** 列出需要此属性的 HTTP 操作（POST/PUT/...）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -347,7 +364,7 @@ i18n:
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** 列出需要该属性的命名功能组合。
+- **Purpose:** 列出需要此属性的命名功能组合。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -359,7 +376,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** 条件性要求（例如当同级字段等于 X 时为必填项）。
+- **Purpose:** 条件要求（例如，当兄弟字段等于 X 时为必填项）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -371,7 +388,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** 包含替代指引的弃用通知。
+- **Purpose:** 包含替代建议的弃用通知。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -383,7 +400,7 @@ i18n:
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** 客户端省略该属性时服务端分配的默认值。
+- **Purpose:** 客户端省略该属性时服务器所赋予的默认值。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -395,7 +412,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** 当服务端默认值不够理想时，该字段在生产环境中的推荐值。
+- **Purpose:** 字段在服务器默认值次优时的推荐生产值。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -419,7 +436,7 @@ i18n:
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** 列出不能与该属性同时设置的同级属性。
+- **Purpose:** 列出不能与此属性同时设置的兄弟属性。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -431,12 +448,12 @@ i18n:
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** 记录跨字段依赖关系，即一个字段要求另一个字段已被设置。
+- **Purpose:** 记录跨字段依赖关系，即一个字段需要另一个字段被设置。
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
 - **Injected by:** scripts/utils/dependency_enricher.py
-- **Driven by config:** config/minimum_configs.yaml (dependencies section)
+- **Driven by config:** config/minimum_configs.yaml（dependencies 节）
 - **Example:** `"x-f5xc-requires": [{"field": "tls_config", "required": true, "reason": "use_tls requires tls_config sub-field"}]`
 - **Pass-through from upstream:** no
 
@@ -455,7 +472,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** 声明字段在其作用域内是否必须唯一。
+- **Purpose:** 声明某字段是否在其作用域内必须唯一。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -464,12 +481,24 @@ i18n:
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** 该 API 属性的控制台表单控件元数据。
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
 ## 注入 — 操作级别
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** 指定操作请求体中必须提供的字段名称以确保成功执行。
+- **Purpose:** 命名操作请求体中必须提供才能成功的字段。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -505,7 +534,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** 列出该操作可观测的副作用（重启、重新配置等）。
+- **Purpose:** 列出该操作的可观测副作用（重启、重新配置等）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -517,7 +546,7 @@ i18n:
 ### x-f5xc-discovered-response-time
 
 - **Applied at:** operation
-- **Purpose:** 发现期间针对该操作实测的响应时间。
+- **Purpose:** 发现过程中对该操作实测的响应时间。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -529,7 +558,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** 从实时 API 中采集到的观测速率限制标头/行为。
+- **Purpose:** 从实时 API 中观测到的速率限制标头/行为。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -541,7 +570,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** 实时发现期间观测到的错误响应目录，包含示例负载。
+- **Purpose:** 实时发现过程中观测到的错误响应目录（含示例载荷）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -579,7 +608,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** 需要格外谨慎处理的资源（生产关键型）。
+- **Purpose:** 需要特别谨慎处理的资源（生产关键型）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -591,7 +620,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** 简短的域描述（约 60 个字符）。也可应用于属性级别以处理较长的描述。
+- **Purpose:** 简短（约 60 字符）的域描述。也适用于属性级别的长描述。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -603,7 +632,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** 中等长度的域描述（约 150 个字符）。也可应用于属性级别。
+- **Purpose:** 中等长度（约 150 字符）的域描述。也适用于属性级别。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -615,7 +644,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** 长篇域描述（约 500 个字符）。
+- **Purpose:** 长篇（约 500 字符）域描述。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -627,7 +656,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** 在该域中编写配置的相对复杂度层级。
+- **Purpose:** 在该域中编写配置的相对复杂度等级。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -651,7 +680,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** 将域标记为预览/测试功能。
+- **Purpose:** 将某域标记为预览/测试版功能。
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -687,7 +716,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** 代表该域的品牌 Logo 的内联 SVG（或路径）。
+- **Purpose:** 代表该域的品牌 Logo 内联 SVG（或路径）。
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -699,7 +728,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** 指向通常与该域一起使用的其他域的交叉链接。
+- **Purpose:** 交叉链接到通常与该域一起使用的其他域。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -711,7 +740,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** 渲染文档时使用的文档章节/导航分组缩写。
+- **Purpose:** 渲染文档时的文档章节/导航分组缩略词。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`

--- a/docs/zh-tw/extensions/catalog.md
+++ b/docs/zh-tw/extensions/catalog.md
@@ -1,29 +1,29 @@
 ---
-title: 擴充功能擴展目錄
-description: 豐富化 OpenAPI 規範中每個 x-* 擴展的唯一真實來源
+title: 擴充功能擴充目錄
+description: 已豐富化 OpenAPI 規格中每個 x-* 擴充功能的真實來源
 i18n:
-  sourceHash: 7fde0afb4dac
+  sourceHash: 70e0912cf4b0
   translator: machine
 ---
 
-# 擴充功能擴展目錄
+# 擴充功能擴充目錄
 
-`docs/specifications/api/*.json` 中出現的每個 `x-*` 擴展的唯一真實來源。與
+`docs/specifications/api/*.json` 中每個 `x-*` 擴充功能的真實來源。與
 `scripts/utils/extension_constants.py` 的一致性由
 `tests/test_extension_catalog.py` 強制執行。
 
-此處記錄三類擴展：
+此處記錄了三類擴充功能：
 
-- **此處注入** — 我們的豐富化工具添加的擴展（`x-f5xc-*` 及
+- **此處注入** — 由我們的豐富化器新增的擴充功能（`x-f5xc-*` 以及
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / 探索
-  變體）。這些是下游工具應使用的擴展。
-- **上游直通** — F5 在來源規範中發出並由我們原樣保留的擴展（`x-ves-proto-*`、`x-displayname` 等）。
-  記錄於此以提高透明度，但不受本倉庫控制。
-- **未來注入** — 尚未發出；當豐富化工具開始生成時即記錄於此（初始填充時不適用）。
+  變體）。這些是下游工具應使用的擴充功能。
+- **上游直通** — F5 在來源規格中發出並由我們原樣保留的擴充功能（`x-ves-proto-*`、`x-displayname` 等）。
+  為透明度而記錄，但不受此儲存庫控制。
+- **未來注入** — 尚未發出；在豐富化器開始產生時立即記錄於此（初始填充時不適用）。
 
-## 條目結構
+## 項目結構
 
-以下每個條目均具有此確切結構。`tests/test_extension_catalog.py` 中的一致性測試允許章節內容簡略，只要 `### x-name` 標題存在，且 `Pass-through from upstream:` 標記的值為 `yes` 或 `no` 即可。
+以下每個項目均具有此精確格式。`tests/test_extension_catalog.py` 中的一致性測試允許章節主體為簡略形式，只要存在 `### x-name` 標頭，且 `Pass-through from upstream:` 旗標的值為 `yes` 或 `no` 即可。
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -36,12 +36,12 @@ i18n:
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## 注入 — 規範層級（info 區段）
+## 注入 — 規格層級（info 區段）
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** 識別豐富化規範的 CLI 網域 slug（例如 `http_loadbalancer`）。
+- **Purpose:** 識別豐富化規格的 CLI 網域代號（例如 `http_loadbalancer`）。
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -53,7 +53,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** CLI 層級的元資料區塊（工具名稱、版本提示、網域分組）。
+- **Purpose:** CLI 全域中繼資料區塊（工具名稱、版本提示、網域分組）。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -65,7 +65,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** 豐富化檔案建構所依據的上游來源規範的時間戳記。
+- **Purpose:** 豐富化檔案所建置之上游來源規格的時間戳記。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -77,7 +77,7 @@ i18n:
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** 上游來源規範發布資產的 ETag。
+- **Purpose:** 上游來源規格發行資產的 ETag。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -89,7 +89,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** 由流水線標記在豐富化規範上的語意版本號。
+- **Purpose:** 由管道標記於豐富化規格上的語意版本號。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -101,7 +101,7 @@ i18n:
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** 套用於每個網域規範的品牌／術語詞彙表區塊。
+- **Purpose:** 套用於每個網域規格的品牌/術語詞彙表區塊。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -113,7 +113,7 @@ i18n:
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** 執行即時 API 探索掃描的時間戳記。
+- **Purpose:** 執行即時 API 探索過程的時間戳記。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -125,7 +125,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** 探索期間所探測的即時 API 基底 URL。
+- **Purpose:** 探索期間所探測之即時 API 的基本 URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -142,14 +142,14 @@ i18n:
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
 - **Injected by:** scripts/utils/external_docs_enricher.py
-- **Driven by config:** none（衍生自網域名稱）
+- **Driven by config:** none（由網域名稱衍生）
 - **Example:** `"x-f5xc-api-reference-url": "https://f5xc-salesdemos.github.io/api-specs-enriched/api-reference/sites/"`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** 探索期間所探測的 API 觀測回應時間（毫秒）。
+- **Purpose:** 探索期間所探測 API 的觀測回應時間（毫秒）。
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -161,7 +161,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** 針對某個網域的精選最佳實踐指引。
+- **Purpose:** 針對某網域精心整理的最佳實踐指引。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -173,7 +173,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** 用於完成網域中常見任務的具名逐步工作流程。
+- **Purpose:** 以步驟方式說明如何在網域中完成常見工作的命名工作流程。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -185,7 +185,7 @@ i18n:
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** 每個網域的縮寫詞展開表。
+- **Purpose:** 每個網域的縮寫展開對照表。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -194,12 +194,24 @@ i18n:
 - **Example:** `"x-f5xc-acronyms": {"LB": "Load Balancer"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-navigation
+
+- **Applied at:** spec info
+- **Purpose:** 全域主控台導覽樹 — 工作區與選單層級。
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
+- **Pass-through from upstream:** no
+
 ## 注入 — 結構描述層級（元件結構描述）
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** 成功 POST/PUT 此資源所需的最小可行欄位集。
+- **Purpose:** 成功 POST/PUT 此資源所需的最低可用欄位集。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -211,7 +223,7 @@ i18n:
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** 為資源提供命名空間約束、建議及分類元資料。
+- **Purpose:** 提供資源的命名空間限制、建議及分類中繼資料。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -223,7 +235,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** 用於 UI／CLI 呈現的屬性建議排序。
+- **Purpose:** 建議的屬性排序，用於 UI/CLI 呈現。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -247,7 +259,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** 資源結構描述的人類可讀顯示名稱（覆蓋自動生成）。
+- **Purpose:** 資源結構描述的人類可讀顯示名稱（覆蓋自動產生的名稱）。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -256,12 +268,24 @@ i18n:
 - **Example:** `"x-f5xc-display-name": "HTTP Load Balancer"`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console
+
+- **Applied at:** schema
+- **Purpose:** 此資源的主控台 UI 導覽、路由及表單結構。
+- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_ui.yaml
+- **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
+- **Pass-through from upstream:** no
+
 ## 注入 — 屬性層級
 
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** 補充上游 `description` 的豐富化屬性描述。
+- **Purpose:** 豐富化的屬性描述，補充上游 `description`。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -309,7 +333,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** Shell 補全提示（靜態列舉或動態指令）。
+- **Purpose:** Shell 補全提示（靜態列舉或動態命令）。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -321,7 +345,7 @@ i18n:
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** 在生成的文件和 UI 中呈現的預設值。
+- **Purpose:** 在產生的文件和 UI 中顯示的預設值。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -357,7 +381,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** 條件性需求（例如當兄弟欄位等於 X 時為必填）。
+- **Purpose:** 條件式需求（例如：當同層欄位等於 X 時為必填）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -369,7 +393,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** 棄用通知及替換指引。
+- **Purpose:** 包含替換指引的棄用通知。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -381,7 +405,7 @@ i18n:
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** 用戶端省略屬性時伺服器指派的預設值。
+- **Purpose:** 用戶端省略屬性時，伺服器指定的預設值。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -393,7 +417,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** 當伺服器預設值並非最佳時，欄位的建議生產環境值。
+- **Purpose:** 伺服器預設值未達最佳時，欄位的建議生產環境值。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -417,7 +441,7 @@ i18n:
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** 列出不能與此屬性同時設定的兄弟屬性。
+- **Purpose:** 列出不能與此屬性同時設定的同層屬性。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -429,7 +453,7 @@ i18n:
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** 記錄跨欄位相依性，其中一個欄位需要另一個欄位被設定。
+- **Purpose:** 記錄跨欄位依賴關係，其中一個欄位需要另一個欄位被設定。
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -441,7 +465,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** 衍生自即時 API 探測或靜態模式的數值／字串約束。
+- **Purpose:** 衍生自即時 API 探測或靜態模式的數值/字串限制。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -453,7 +477,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** 宣告欄位是否必須在其範圍內唯一。
+- **Purpose:** 宣告欄位是否在其範圍內必須唯一。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -462,12 +486,24 @@ i18n:
 - **Example:** `"x-f5xc-uniqueness": {"scope": "namespace"}`
 - **Pass-through from upstream:** no
 
+### x-f5xc-console-field
+
+- **Applied at:** schema property
+- **Purpose:** 此 API 屬性的主控台表單元件中繼資料。
+- **Consumers:** console-catalog, xcsh, browser-automation
+- **Value type:** object
+- **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
+- **Injected by:** scripts/utils/console_ui_enricher.py
+- **Driven by config:** config/console_field_metadata.yaml
+- **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
+- **Pass-through from upstream:** no
+
 ## 注入 — 操作層級
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** 指名操作主體中必須提供才能成功的欄位。
+- **Purpose:** 指名操作主體中必須提供以確保成功的欄位。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -479,7 +515,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** 分類操作的影響範圍（low／medium／high／critical）。
+- **Purpose:** 分類操作的爆炸半徑（low/medium/high/critical）。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -491,7 +527,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** CLI／UI 是否應在執行前提示使用者確認。
+- **Purpose:** CLI/UI 在執行前是否應提示使用者確認。
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -503,7 +539,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** 列出操作的可觀測副作用（重啟、重新設定等）。
+- **Purpose:** 列出操作的可觀測副作用（重新啟動、重新設定等）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -515,7 +551,7 @@ i18n:
 ### x-f5xc-discovered-response-time
 
 - **Applied at:** operation
-- **Purpose:** 探索期間對此操作實際測量的回應時間。
+- **Purpose:** 探索期間此操作的實測回應時間。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -527,7 +563,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** 從即時 API 呈現的觀測速率限制標頭／行為。
+- **Purpose:** 從即時 API 中觀測到的速率限制標頭/行為。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -539,7 +575,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** 即時探索期間觀測到的錯誤回應目錄，含範例有效負載。
+- **Purpose:** 即時探索期間觀測到的錯誤回應目錄，包含範例載荷。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -548,12 +584,12 @@ i18n:
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## 注入 — 索引層級（網域元資料）
+## 注入 — 索引層級（網域中繼資料）
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** 網域的頂層 CLI／UI／文件／Terraform 分組類別。
+- **Purpose:** 網域的頂層 CLI / UI / 文件 / Terraform 分組類別。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -577,7 +613,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** 需要特別謹慎處理的資源（生產關鍵）。
+- **Purpose:** 需要提升注意的資源（生產關鍵）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -589,7 +625,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** 簡短（約 60 字元）的網域描述。亦適用於屬性層級的長描述。
+- **Purpose:** 簡短（約 60 字元）的網域描述。也適用於屬性層級以說明較長的描述。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -601,7 +637,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** 中等長度（約 150 字元）的網域描述。亦適用於屬性層級。
+- **Purpose:** 中等長度（約 150 字元）的網域描述。也適用於屬性層級。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -613,7 +649,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** 詳細（約 500 字元）的網域描述。
+- **Purpose:** 較長（約 500 字元）的網域描述。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -625,7 +661,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** 在此網域中撰寫設定的相對複雜度層級。
+- **Purpose:** 在此網域中撰寫設定的相對複雜度等級。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -637,7 +673,7 @@ i18n:
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** 所需的最低 F5 XC 訂閱層級。
+- **Purpose:** 所需的最低 F5 XC 訂閱方案等級。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -649,7 +685,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** 將網域標記為預覽／測試版功能。
+- **Purpose:** 將網域標記為預覽/測試版功能。
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -673,7 +709,7 @@ i18n:
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** 在 UI 中呈現此網域時使用的圖示識別碼。
+- **Purpose:** 在 UI 中呈現此網域時所使用的圖示識別碼。
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -697,7 +733,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** 交叉連結至通常與此網域一起使用的其他網域。
+- **Purpose:** 交叉連結至通常與此網域搭配使用的其他網域。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -709,7 +745,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** 已渲染文件的文件章節／導覽分組 slug。
+- **Purpose:** 已呈現文件的文件區段/導覽分組代號。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -723,7 +759,7 @@ i18n:
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規範原樣保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -735,7 +771,7 @@ i18n:
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規範原樣保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -747,7 +783,7 @@ i18n:
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規範原樣保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -759,7 +795,7 @@ i18n:
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規範原樣保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -771,7 +807,7 @@ i18n:
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規範原樣保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -783,7 +819,7 @@ i18n:
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規範原樣保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -795,7 +831,7 @@ i18n:
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規範原樣保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -807,7 +843,7 @@ i18n:
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規範原樣保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -819,7 +855,7 @@ i18n:
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規範原樣保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A


### PR DESCRIPTION
Regenerates all 12 locale translations of `docs/en/extensions/catalog.md` so their `i18n.sourceHash` matches the current English source (they had drifted).

Generated with the docs-theme translator. Prepares the repo for the upcoming whole-repo translation-freshness gate.

Closes #753