### PR TITLE
feat: publish minimal-export-defaults.json for downstream minimum-settings export

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -684,7 +684,8 @@ jobs:
           # Copy domain specifications to domains/ subdirectory
           for spec_file in docs/specifications/api/*.json; do
             basename_f=$(basename "$spec_file")
-            if [ "$basename_f" != "openapi.json" ] && [ "$basename_f" != "index.json" ]; then
+            if [ "$basename_f" != "openapi.json" ] && [ "$basename_f" != "index.json" ] \
+               && [ "$basename_f" != "minimal-export-defaults.json" ]; then
               cp "$spec_file" "$RELEASE_DIR/domains/"
               echo "Copied domain: $basename_f"
             fi
@@ -733,6 +734,7 @@ jobs:
             "${zip_name}" \
             docs/specifications/api/openapi.json \
             docs/specifications/api/index.json \
+            docs/specifications/api/minimal-export-defaults.json \
             release/api-catalog.json
 
           echo "::notice::Created release: v$VERSION"

--- a/docs/specifications/api/minimal-export-defaults.json
+++ b/docs/specifications/api/minimal-export-defaults.json
@@ -1,0 +1,5124 @@
+{
+  "resources": {
+    "alert_receiver": {
+      "fieldConflicts": {
+        "spec.email": [
+          "opsgenie",
+          "pagerduty",
+          "slack",
+          "sms",
+          "webhook"
+        ],
+        "spec.opsgenie": [
+          "email",
+          "pagerduty",
+          "slack",
+          "sms",
+          "webhook"
+        ],
+        "spec.opsgenie.api_key.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.opsgenie.api_key.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.pagerduty": [
+          "email",
+          "opsgenie",
+          "slack",
+          "sms",
+          "webhook"
+        ],
+        "spec.pagerduty.routing_key.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.pagerduty.routing_key.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.slack": [
+          "email",
+          "opsgenie",
+          "pagerduty",
+          "sms",
+          "webhook"
+        ],
+        "spec.slack.url.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.slack.url.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.sms": [
+          "email",
+          "opsgenie",
+          "pagerduty",
+          "slack",
+          "webhook"
+        ],
+        "spec.webhook": [
+          "email",
+          "opsgenie",
+          "pagerduty",
+          "slack",
+          "sms"
+        ],
+        "spec.webhook.http_config.auth_token": [
+          "basic_auth",
+          "client_cert_obj",
+          "no_authorization"
+        ],
+        "spec.webhook.http_config.auth_token.token.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.webhook.http_config.auth_token.token.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.webhook.http_config.basic_auth": [
+          "auth_token",
+          "client_cert_obj",
+          "no_authorization"
+        ],
+        "spec.webhook.http_config.basic_auth.password.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.webhook.http_config.basic_auth.password.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.webhook.http_config.client_cert_obj": [
+          "auth_token",
+          "basic_auth",
+          "no_authorization"
+        ],
+        "spec.webhook.http_config.no_authorization": [
+          "auth_token",
+          "basic_auth",
+          "client_cert_obj"
+        ],
+        "spec.webhook.http_config.no_tls": [
+          "use_tls"
+        ],
+        "spec.webhook.http_config.use_tls": [
+          "no_tls"
+        ],
+        "spec.webhook.http_config.use_tls.disable_sni": [
+          "sni"
+        ],
+        "spec.webhook.http_config.use_tls.sni": [
+          "disable_sni"
+        ],
+        "spec.webhook.http_config.use_tls.use_server_verification": [
+          "volterra_trusted_ca"
+        ],
+        "spec.webhook.http_config.use_tls.volterra_trusted_ca": [
+          "use_server_verification"
+        ],
+        "spec.webhook.url.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.webhook.url.clear_secret_info": [
+          "blindfold_secret_info"
+        ]
+      },
+      "fieldDefaults": {},
+      "minimumConfigFields": [
+        "spec.opsgenie.api_key.blindfold_secret_info.location",
+        "spec.opsgenie.api_key.clear_secret_info.url",
+        "spec.opsgenie.url",
+        "spec.pagerduty.routing_key.blindfold_secret_info.location",
+        "spec.pagerduty.routing_key.clear_secret_info.url",
+        "spec.pagerduty.url",
+        "spec.slack.channel",
+        "spec.slack.url.blindfold_secret_info.location",
+        "spec.slack.url.clear_secret_info.url",
+        "spec.webhook.http_config.basic_auth.user_name",
+        "spec.webhook.url.blindfold_secret_info.location",
+        "spec.webhook.url.clear_secret_info.url"
+      ],
+      "serverDefaultFields": []
+    },
+    "api_definition": {
+      "fieldConflicts": {
+        "spec.mixed_schema_origin": [
+          "strict_schema_origin"
+        ],
+        "spec.strict_schema_origin": [
+          "mixed_schema_origin"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.api_inventory_exclusion_list": [],
+        "spec.api_inventory_inclusion_list": [],
+        "spec.non_api_endpoints": [],
+        "spec.strict_schema_origin": {},
+        "spec.swagger_specs": []
+      },
+      "minimumConfigFields": [],
+      "serverDefaultFields": [
+        "spec.api_inventory_exclusion_list",
+        "spec.api_inventory_inclusion_list",
+        "spec.non_api_endpoints",
+        "spec.strict_schema_origin",
+        "spec.swagger_specs"
+      ]
+    },
+    "api_definition_views": {
+      "fieldConflicts": {
+        "spec.mixed_schema_origin": [
+          "strict_schema_origin"
+        ],
+        "spec.strict_schema_origin": [
+          "mixed_schema_origin"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.api_inventory_exclusion_list": [],
+        "spec.api_inventory_inclusion_list": [],
+        "spec.non_api_endpoints": [],
+        "spec.strict_schema_origin": {},
+        "spec.swagger_specs": []
+      },
+      "minimumConfigFields": [],
+      "serverDefaultFields": [
+        "spec.api_inventory_exclusion_list",
+        "spec.api_inventory_inclusion_list",
+        "spec.non_api_endpoints",
+        "spec.strict_schema_origin",
+        "spec.swagger_specs"
+      ]
+    },
+    "api_discovery": {
+      "fieldConflicts": {},
+      "fieldDefaults": {
+        "spec.custom_auth_types": []
+      },
+      "minimumConfigFields": [],
+      "serverDefaultFields": [
+        "spec.custom_auth_types"
+      ]
+    },
+    "app_firewall": {
+      "fieldConflicts": {
+        "spec.allow_all_response_codes": [
+          "allowed_response_codes"
+        ],
+        "spec.allowed_response_codes": [
+          "allow_all_response_codes"
+        ],
+        "spec.blocking": [
+          "monitoring"
+        ],
+        "spec.blocking_page": [
+          "use_default_blocking_page"
+        ],
+        "spec.bot_protection_setting": [
+          "default_bot_setting"
+        ],
+        "spec.custom_anonymization": [
+          "default_anonymization",
+          "disable_anonymization"
+        ],
+        "spec.default_anonymization": [
+          "custom_anonymization",
+          "disable_anonymization"
+        ],
+        "spec.default_bot_setting": [
+          "bot_protection_setting"
+        ],
+        "spec.default_detection_settings": [
+          "detection_settings"
+        ],
+        "spec.detection_settings": [
+          "default_detection_settings"
+        ],
+        "spec.detection_settings.bot_protection_setting": [
+          "default_bot_setting"
+        ],
+        "spec.detection_settings.default_bot_setting": [
+          "bot_protection_setting"
+        ],
+        "spec.detection_settings.default_violation_settings": [
+          "violation_settings"
+        ],
+        "spec.detection_settings.disable_staging": [
+          "stage_new_and_updated_signatures",
+          "stage_new_signatures"
+        ],
+        "spec.detection_settings.disable_suppression": [
+          "enable_suppression"
+        ],
+        "spec.detection_settings.disable_threat_campaigns": [
+          "enable_threat_campaigns"
+        ],
+        "spec.detection_settings.enable_suppression": [
+          "disable_suppression"
+        ],
+        "spec.detection_settings.enable_threat_campaigns": [
+          "disable_threat_campaigns"
+        ],
+        "spec.detection_settings.signature_selection_setting.attack_type_settings": [
+          "default_attack_type_settings"
+        ],
+        "spec.detection_settings.signature_selection_setting.default_attack_type_settings": [
+          "attack_type_settings"
+        ],
+        "spec.detection_settings.signature_selection_setting.high_medium_accuracy_signatures": [
+          "high_medium_low_accuracy_signatures",
+          "only_high_accuracy_signatures"
+        ],
+        "spec.detection_settings.signature_selection_setting.high_medium_low_accuracy_signatures": [
+          "high_medium_accuracy_signatures",
+          "only_high_accuracy_signatures"
+        ],
+        "spec.detection_settings.signature_selection_setting.only_high_accuracy_signatures": [
+          "high_medium_accuracy_signatures",
+          "high_medium_low_accuracy_signatures"
+        ],
+        "spec.detection_settings.stage_new_and_updated_signatures": [
+          "disable_staging",
+          "stage_new_signatures"
+        ],
+        "spec.detection_settings.stage_new_signatures": [
+          "disable_staging",
+          "stage_new_and_updated_signatures"
+        ],
+        "spec.detection_settings.violation_settings": [
+          "default_violation_settings"
+        ],
+        "spec.disable_ai_enhancements": [
+          "enable_ai_enhancements"
+        ],
+        "spec.disable_anonymization": [
+          "custom_anonymization",
+          "default_anonymization"
+        ],
+        "spec.enable_ai_enhancements": [
+          "disable_ai_enhancements"
+        ],
+        "spec.enable_ai_enhancements.mitigate_high_medium_risk_action": [
+          "mitigate_high_risk_action"
+        ],
+        "spec.enable_ai_enhancements.mitigate_high_risk_action": [
+          "mitigate_high_medium_risk_action"
+        ],
+        "spec.monitoring": [
+          "blocking"
+        ],
+        "spec.use_default_blocking_page": [
+          "blocking_page"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.allow_all_response_codes": {},
+        "spec.default_anonymization": {},
+        "spec.default_bot_setting": {},
+        "spec.default_detection_settings": {},
+        "spec.disable_ai_enhancements": {},
+        "spec.monitoring": {},
+        "spec.use_default_blocking_page": {}
+      },
+      "minimumConfigFields": [
+        "spec.allowed_response_codes.response_code",
+        "spec.custom_anonymization.anonymization_config",
+        "spec.detection_settings.signature_selection_setting.attack_type_settings.disabled_attack_types",
+        "spec.detection_settings.stage_new_and_updated_signatures.staging_period",
+        "spec.detection_settings.stage_new_signatures.staging_period",
+        "spec.detection_settings.violation_settings.disabled_violation_types",
+        "spec.detection_settings.violations_view"
+      ],
+      "serverDefaultFields": [
+        "spec.allow_all_response_codes",
+        "spec.default_anonymization",
+        "spec.default_bot_setting",
+        "spec.default_detection_settings",
+        "spec.disable_ai_enhancements",
+        "spec.monitoring",
+        "spec.use_default_blocking_page"
+      ]
+    },
+    "azure_vnet_site": {
+      "fieldConflicts": {
+        "spec.admin_password.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.admin_password.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.alternate_region": [
+          "azure_region"
+        ],
+        "spec.azure_region": [
+          "alternate_region"
+        ],
+        "spec.block_all_services": [
+          "blocked_services",
+          "default_blocked_services"
+        ],
+        "spec.blocked_services": [
+          "block_all_services",
+          "default_blocked_services"
+        ],
+        "spec.default_blocked_services": [
+          "block_all_services",
+          "blocked_services"
+        ],
+        "spec.disable_encryption": [
+          "enable_encryption"
+        ],
+        "spec.enable_encryption": [
+          "disable_encryption"
+        ],
+        "spec.ingress_egress_gw": [
+          "ingress_egress_gw_ar",
+          "ingress_gw",
+          "ingress_gw_ar",
+          "voltstack_cluster",
+          "voltstack_cluster_ar"
+        ],
+        "spec.ingress_egress_gw.accelerated_networking.disable": [
+          "enable"
+        ],
+        "spec.ingress_egress_gw.accelerated_networking.enable": [
+          "disable"
+        ],
+        "spec.ingress_egress_gw.active_enhanced_firewall_policies": [
+          "active_network_policies",
+          "no_network_policy"
+        ],
+        "spec.ingress_egress_gw.active_forward_proxy_policies": [
+          "forward_proxy_allow_all",
+          "no_forward_proxy"
+        ],
+        "spec.ingress_egress_gw.active_network_policies": [
+          "active_enhanced_firewall_policies",
+          "no_network_policy"
+        ],
+        "spec.ingress_egress_gw.dc_cluster_group_inside_vn": [
+          "dc_cluster_group_outside_vn",
+          "no_dc_cluster_group"
+        ],
+        "spec.ingress_egress_gw.dc_cluster_group_outside_vn": [
+          "dc_cluster_group_inside_vn",
+          "no_dc_cluster_group"
+        ],
+        "spec.ingress_egress_gw.forward_proxy_allow_all": [
+          "active_forward_proxy_policies",
+          "no_forward_proxy"
+        ],
+        "spec.ingress_egress_gw.global_network_list": [
+          "no_global_network"
+        ],
+        "spec.ingress_egress_gw.hub": [
+          "not_hub"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_disabled": [
+          "express_route_enabled"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled": [
+          "express_route_disabled"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.advertise_to_route_server": [
+          "do_not_advertise_to_route_server"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.auto_asn": [
+          "custom_asn"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.custom_asn": [
+          "auto_asn"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.do_not_advertise_to_route_server": [
+          "advertise_to_route_server"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.gateway_subnet.auto": [
+          "subnet",
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.gateway_subnet.subnet": [
+          "auto",
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.gateway_subnet.subnet_param": [
+          "auto",
+          "subnet"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.route_server_subnet.auto": [
+          "subnet",
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.route_server_subnet.subnet": [
+          "auto",
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.route_server_subnet.subnet_param": [
+          "auto",
+          "subnet"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.site_registration_over_express_route": [
+          "site_registration_over_internet"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.site_registration_over_internet": [
+          "site_registration_over_express_route"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.sku_ergw1az": [
+          "sku_ergw2az",
+          "sku_high_perf",
+          "sku_standard"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.sku_ergw2az": [
+          "sku_ergw1az",
+          "sku_high_perf",
+          "sku_standard"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.sku_high_perf": [
+          "sku_ergw1az",
+          "sku_ergw2az",
+          "sku_standard"
+        ],
+        "spec.ingress_egress_gw.hub.express_route_enabled.sku_standard": [
+          "sku_ergw1az",
+          "sku_ergw2az",
+          "sku_high_perf"
+        ],
+        "spec.ingress_egress_gw.inside_static_routes": [
+          "no_inside_static_routes"
+        ],
+        "spec.ingress_egress_gw.no_dc_cluster_group": [
+          "dc_cluster_group_inside_vn",
+          "dc_cluster_group_outside_vn"
+        ],
+        "spec.ingress_egress_gw.no_forward_proxy": [
+          "active_forward_proxy_policies",
+          "forward_proxy_allow_all"
+        ],
+        "spec.ingress_egress_gw.no_global_network": [
+          "global_network_list"
+        ],
+        "spec.ingress_egress_gw.no_inside_static_routes": [
+          "inside_static_routes"
+        ],
+        "spec.ingress_egress_gw.no_network_policy": [
+          "active_enhanced_firewall_policies",
+          "active_network_policies"
+        ],
+        "spec.ingress_egress_gw.no_outside_static_routes": [
+          "outside_static_routes"
+        ],
+        "spec.ingress_egress_gw.not_hub": [
+          "hub"
+        ],
+        "spec.ingress_egress_gw.outside_static_routes": [
+          "no_outside_static_routes"
+        ],
+        "spec.ingress_egress_gw.performance_enhancement_mode.perf_mode_l3_enhanced": [
+          "perf_mode_l7_enhanced"
+        ],
+        "spec.ingress_egress_gw.performance_enhancement_mode.perf_mode_l3_enhanced.jumbo": [
+          "no_jumbo"
+        ],
+        "spec.ingress_egress_gw.performance_enhancement_mode.perf_mode_l3_enhanced.no_jumbo": [
+          "jumbo"
+        ],
+        "spec.ingress_egress_gw.performance_enhancement_mode.perf_mode_l7_enhanced": [
+          "perf_mode_l3_enhanced"
+        ],
+        "spec.ingress_egress_gw.sm_connection_public_ip": [
+          "sm_connection_pvt_ip"
+        ],
+        "spec.ingress_egress_gw.sm_connection_pvt_ip": [
+          "sm_connection_public_ip"
+        ],
+        "spec.ingress_egress_gw_ar": [
+          "ingress_egress_gw",
+          "ingress_gw",
+          "ingress_gw_ar",
+          "voltstack_cluster",
+          "voltstack_cluster_ar"
+        ],
+        "spec.ingress_egress_gw_ar.accelerated_networking.disable": [
+          "enable"
+        ],
+        "spec.ingress_egress_gw_ar.accelerated_networking.enable": [
+          "disable"
+        ],
+        "spec.ingress_egress_gw_ar.active_enhanced_firewall_policies": [
+          "active_network_policies",
+          "no_network_policy"
+        ],
+        "spec.ingress_egress_gw_ar.active_forward_proxy_policies": [
+          "forward_proxy_allow_all",
+          "no_forward_proxy"
+        ],
+        "spec.ingress_egress_gw_ar.active_network_policies": [
+          "active_enhanced_firewall_policies",
+          "no_network_policy"
+        ],
+        "spec.ingress_egress_gw_ar.dc_cluster_group_inside_vn": [
+          "dc_cluster_group_outside_vn",
+          "no_dc_cluster_group"
+        ],
+        "spec.ingress_egress_gw_ar.dc_cluster_group_outside_vn": [
+          "dc_cluster_group_inside_vn",
+          "no_dc_cluster_group"
+        ],
+        "spec.ingress_egress_gw_ar.forward_proxy_allow_all": [
+          "active_forward_proxy_policies",
+          "no_forward_proxy"
+        ],
+        "spec.ingress_egress_gw_ar.global_network_list": [
+          "no_global_network"
+        ],
+        "spec.ingress_egress_gw_ar.hub": [
+          "not_hub"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_disabled": [
+          "express_route_enabled"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled": [
+          "express_route_disabled"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.advertise_to_route_server": [
+          "do_not_advertise_to_route_server"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.auto_asn": [
+          "custom_asn"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.custom_asn": [
+          "auto_asn"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.do_not_advertise_to_route_server": [
+          "advertise_to_route_server"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.gateway_subnet.auto": [
+          "subnet",
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.gateway_subnet.subnet": [
+          "auto",
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.gateway_subnet.subnet_param": [
+          "auto",
+          "subnet"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.route_server_subnet.auto": [
+          "subnet",
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.route_server_subnet.subnet": [
+          "auto",
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.route_server_subnet.subnet_param": [
+          "auto",
+          "subnet"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.site_registration_over_express_route": [
+          "site_registration_over_internet"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.site_registration_over_internet": [
+          "site_registration_over_express_route"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.sku_ergw1az": [
+          "sku_ergw2az",
+          "sku_high_perf",
+          "sku_standard"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.sku_ergw2az": [
+          "sku_ergw1az",
+          "sku_high_perf",
+          "sku_standard"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.sku_high_perf": [
+          "sku_ergw1az",
+          "sku_ergw2az",
+          "sku_standard"
+        ],
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.sku_standard": [
+          "sku_ergw1az",
+          "sku_ergw2az",
+          "sku_high_perf"
+        ],
+        "spec.ingress_egress_gw_ar.inside_static_routes": [
+          "no_inside_static_routes"
+        ],
+        "spec.ingress_egress_gw_ar.no_dc_cluster_group": [
+          "dc_cluster_group_inside_vn",
+          "dc_cluster_group_outside_vn"
+        ],
+        "spec.ingress_egress_gw_ar.no_forward_proxy": [
+          "active_forward_proxy_policies",
+          "forward_proxy_allow_all"
+        ],
+        "spec.ingress_egress_gw_ar.no_global_network": [
+          "global_network_list"
+        ],
+        "spec.ingress_egress_gw_ar.no_inside_static_routes": [
+          "inside_static_routes"
+        ],
+        "spec.ingress_egress_gw_ar.no_network_policy": [
+          "active_enhanced_firewall_policies",
+          "active_network_policies"
+        ],
+        "spec.ingress_egress_gw_ar.no_outside_static_routes": [
+          "outside_static_routes"
+        ],
+        "spec.ingress_egress_gw_ar.node.inside_subnet.subnet": [
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw_ar.node.inside_subnet.subnet.subnet_resource_grp": [
+          "vnet_resource_group"
+        ],
+        "spec.ingress_egress_gw_ar.node.inside_subnet.subnet.vnet_resource_group": [
+          "subnet_resource_grp"
+        ],
+        "spec.ingress_egress_gw_ar.node.inside_subnet.subnet_param": [
+          "subnet"
+        ],
+        "spec.ingress_egress_gw_ar.node.outside_subnet.subnet": [
+          "subnet_param"
+        ],
+        "spec.ingress_egress_gw_ar.node.outside_subnet.subnet.subnet_resource_grp": [
+          "vnet_resource_group"
+        ],
+        "spec.ingress_egress_gw_ar.node.outside_subnet.subnet.vnet_resource_group": [
+          "subnet_resource_grp"
+        ],
+        "spec.ingress_egress_gw_ar.node.outside_subnet.subnet_param": [
+          "subnet"
+        ],
+        "spec.ingress_egress_gw_ar.not_hub": [
+          "hub"
+        ],
+        "spec.ingress_egress_gw_ar.outside_static_routes": [
+          "no_outside_static_routes"
+        ],
+        "spec.ingress_egress_gw_ar.performance_enhancement_mode.perf_mode_l3_enhanced": [
+          "perf_mode_l7_enhanced"
+        ],
+        "spec.ingress_egress_gw_ar.performance_enhancement_mode.perf_mode_l3_enhanced.jumbo": [
+          "no_jumbo"
+        ],
+        "spec.ingress_egress_gw_ar.performance_enhancement_mode.perf_mode_l3_enhanced.no_jumbo": [
+          "jumbo"
+        ],
+        "spec.ingress_egress_gw_ar.performance_enhancement_mode.perf_mode_l7_enhanced": [
+          "perf_mode_l3_enhanced"
+        ],
+        "spec.ingress_egress_gw_ar.sm_connection_public_ip": [
+          "sm_connection_pvt_ip"
+        ],
+        "spec.ingress_egress_gw_ar.sm_connection_pvt_ip": [
+          "sm_connection_public_ip"
+        ],
+        "spec.ingress_gw": [
+          "ingress_egress_gw",
+          "ingress_egress_gw_ar",
+          "ingress_gw_ar",
+          "voltstack_cluster",
+          "voltstack_cluster_ar"
+        ],
+        "spec.ingress_gw.accelerated_networking.disable": [
+          "enable"
+        ],
+        "spec.ingress_gw.accelerated_networking.enable": [
+          "disable"
+        ],
+        "spec.ingress_gw.performance_enhancement_mode.perf_mode_l3_enhanced": [
+          "perf_mode_l7_enhanced"
+        ],
+        "spec.ingress_gw.performance_enhancement_mode.perf_mode_l3_enhanced.jumbo": [
+          "no_jumbo"
+        ],
+        "spec.ingress_gw.performance_enhancement_mode.perf_mode_l3_enhanced.no_jumbo": [
+          "jumbo"
+        ],
+        "spec.ingress_gw.performance_enhancement_mode.perf_mode_l7_enhanced": [
+          "perf_mode_l3_enhanced"
+        ],
+        "spec.ingress_gw_ar": [
+          "ingress_egress_gw",
+          "ingress_egress_gw_ar",
+          "ingress_gw",
+          "voltstack_cluster",
+          "voltstack_cluster_ar"
+        ],
+        "spec.ingress_gw_ar.accelerated_networking.disable": [
+          "enable"
+        ],
+        "spec.ingress_gw_ar.accelerated_networking.enable": [
+          "disable"
+        ],
+        "spec.ingress_gw_ar.node.local_subnet.subnet": [
+          "subnet_param"
+        ],
+        "spec.ingress_gw_ar.node.local_subnet.subnet.subnet_resource_grp": [
+          "vnet_resource_group"
+        ],
+        "spec.ingress_gw_ar.node.local_subnet.subnet.vnet_resource_group": [
+          "subnet_resource_grp"
+        ],
+        "spec.ingress_gw_ar.node.local_subnet.subnet_param": [
+          "subnet"
+        ],
+        "spec.ingress_gw_ar.performance_enhancement_mode.perf_mode_l3_enhanced": [
+          "perf_mode_l7_enhanced"
+        ],
+        "spec.ingress_gw_ar.performance_enhancement_mode.perf_mode_l3_enhanced.jumbo": [
+          "no_jumbo"
+        ],
+        "spec.ingress_gw_ar.performance_enhancement_mode.perf_mode_l3_enhanced.no_jumbo": [
+          "jumbo"
+        ],
+        "spec.ingress_gw_ar.performance_enhancement_mode.perf_mode_l7_enhanced": [
+          "perf_mode_l3_enhanced"
+        ],
+        "spec.kubernetes_upgrade_drain.disable_upgrade_drain": [
+          "enable_upgrade_drain"
+        ],
+        "spec.kubernetes_upgrade_drain.enable_upgrade_drain": [
+          "disable_upgrade_drain"
+        ],
+        "spec.kubernetes_upgrade_drain.enable_upgrade_drain.disable_vega_upgrade_mode": [
+          "enable_vega_upgrade_mode"
+        ],
+        "spec.kubernetes_upgrade_drain.enable_upgrade_drain.enable_vega_upgrade_mode": [
+          "disable_vega_upgrade_mode"
+        ],
+        "spec.log_receiver": [
+          "logs_streaming_disabled"
+        ],
+        "spec.logs_streaming_disabled": [
+          "log_receiver"
+        ],
+        "spec.no_worker_nodes": [
+          "nodes_per_az",
+          "total_nodes"
+        ],
+        "spec.nodes_per_az": [
+          "no_worker_nodes",
+          "total_nodes"
+        ],
+        "spec.offline_survivability_mode.enable_offline_survivability_mode": [
+          "no_offline_survivability_mode"
+        ],
+        "spec.offline_survivability_mode.no_offline_survivability_mode": [
+          "enable_offline_survivability_mode"
+        ],
+        "spec.os.default_os_version": [
+          "operating_system_version"
+        ],
+        "spec.os.operating_system_version": [
+          "default_os_version"
+        ],
+        "spec.sw.default_sw_version": [
+          "volterra_software_version"
+        ],
+        "spec.sw.volterra_software_version": [
+          "default_sw_version"
+        ],
+        "spec.total_nodes": [
+          "no_worker_nodes",
+          "nodes_per_az"
+        ],
+        "spec.vnet.existing_vnet": [
+          "new_vnet"
+        ],
+        "spec.vnet.existing_vnet.f5_orchestrated_routing": [
+          "manual_routing"
+        ],
+        "spec.vnet.existing_vnet.manual_routing": [
+          "f5_orchestrated_routing"
+        ],
+        "spec.vnet.new_vnet": [
+          "existing_vnet"
+        ],
+        "spec.vnet.new_vnet.autogenerate": [
+          "name"
+        ],
+        "spec.vnet.new_vnet.name": [
+          "autogenerate"
+        ],
+        "spec.voltstack_cluster": [
+          "ingress_egress_gw",
+          "ingress_egress_gw_ar",
+          "ingress_gw",
+          "ingress_gw_ar",
+          "voltstack_cluster_ar"
+        ],
+        "spec.voltstack_cluster.accelerated_networking.disable": [
+          "enable"
+        ],
+        "spec.voltstack_cluster.accelerated_networking.enable": [
+          "disable"
+        ],
+        "spec.voltstack_cluster.active_enhanced_firewall_policies": [
+          "active_network_policies",
+          "no_network_policy"
+        ],
+        "spec.voltstack_cluster.active_forward_proxy_policies": [
+          "forward_proxy_allow_all",
+          "no_forward_proxy"
+        ],
+        "spec.voltstack_cluster.active_network_policies": [
+          "active_enhanced_firewall_policies",
+          "no_network_policy"
+        ],
+        "spec.voltstack_cluster.dc_cluster_group": [
+          "no_dc_cluster_group"
+        ],
+        "spec.voltstack_cluster.default_storage": [
+          "storage_class_list"
+        ],
+        "spec.voltstack_cluster.forward_proxy_allow_all": [
+          "active_forward_proxy_policies",
+          "no_forward_proxy"
+        ],
+        "spec.voltstack_cluster.global_network_list": [
+          "no_global_network"
+        ],
+        "spec.voltstack_cluster.k8s_cluster": [
+          "no_k8s_cluster"
+        ],
+        "spec.voltstack_cluster.no_dc_cluster_group": [
+          "dc_cluster_group"
+        ],
+        "spec.voltstack_cluster.no_forward_proxy": [
+          "active_forward_proxy_policies",
+          "forward_proxy_allow_all"
+        ],
+        "spec.voltstack_cluster.no_global_network": [
+          "global_network_list"
+        ],
+        "spec.voltstack_cluster.no_k8s_cluster": [
+          "k8s_cluster"
+        ],
+        "spec.voltstack_cluster.no_network_policy": [
+          "active_enhanced_firewall_policies",
+          "active_network_policies"
+        ],
+        "spec.voltstack_cluster.no_outside_static_routes": [
+          "outside_static_routes"
+        ],
+        "spec.voltstack_cluster.outside_static_routes": [
+          "no_outside_static_routes"
+        ],
+        "spec.voltstack_cluster.sm_connection_public_ip": [
+          "sm_connection_pvt_ip"
+        ],
+        "spec.voltstack_cluster.sm_connection_pvt_ip": [
+          "sm_connection_public_ip"
+        ],
+        "spec.voltstack_cluster.storage_class_list": [
+          "default_storage"
+        ],
+        "spec.voltstack_cluster_ar": [
+          "ingress_egress_gw",
+          "ingress_egress_gw_ar",
+          "ingress_gw",
+          "ingress_gw_ar",
+          "voltstack_cluster"
+        ],
+        "spec.voltstack_cluster_ar.accelerated_networking.disable": [
+          "enable"
+        ],
+        "spec.voltstack_cluster_ar.accelerated_networking.enable": [
+          "disable"
+        ],
+        "spec.voltstack_cluster_ar.active_enhanced_firewall_policies": [
+          "active_network_policies",
+          "no_network_policy"
+        ],
+        "spec.voltstack_cluster_ar.active_forward_proxy_policies": [
+          "forward_proxy_allow_all",
+          "no_forward_proxy"
+        ],
+        "spec.voltstack_cluster_ar.active_network_policies": [
+          "active_enhanced_firewall_policies",
+          "no_network_policy"
+        ],
+        "spec.voltstack_cluster_ar.dc_cluster_group": [
+          "no_dc_cluster_group"
+        ],
+        "spec.voltstack_cluster_ar.default_storage": [
+          "storage_class_list"
+        ],
+        "spec.voltstack_cluster_ar.forward_proxy_allow_all": [
+          "active_forward_proxy_policies",
+          "no_forward_proxy"
+        ],
+        "spec.voltstack_cluster_ar.global_network_list": [
+          "no_global_network"
+        ],
+        "spec.voltstack_cluster_ar.k8s_cluster": [
+          "no_k8s_cluster"
+        ],
+        "spec.voltstack_cluster_ar.no_dc_cluster_group": [
+          "dc_cluster_group"
+        ],
+        "spec.voltstack_cluster_ar.no_forward_proxy": [
+          "active_forward_proxy_policies",
+          "forward_proxy_allow_all"
+        ],
+        "spec.voltstack_cluster_ar.no_global_network": [
+          "global_network_list"
+        ],
+        "spec.voltstack_cluster_ar.no_k8s_cluster": [
+          "k8s_cluster"
+        ],
+        "spec.voltstack_cluster_ar.no_network_policy": [
+          "active_enhanced_firewall_policies",
+          "active_network_policies"
+        ],
+        "spec.voltstack_cluster_ar.no_outside_static_routes": [
+          "outside_static_routes"
+        ],
+        "spec.voltstack_cluster_ar.node.local_subnet.subnet": [
+          "subnet_param"
+        ],
+        "spec.voltstack_cluster_ar.node.local_subnet.subnet.subnet_resource_grp": [
+          "vnet_resource_group"
+        ],
+        "spec.voltstack_cluster_ar.node.local_subnet.subnet.vnet_resource_group": [
+          "subnet_resource_grp"
+        ],
+        "spec.voltstack_cluster_ar.node.local_subnet.subnet_param": [
+          "subnet"
+        ],
+        "spec.voltstack_cluster_ar.outside_static_routes": [
+          "no_outside_static_routes"
+        ],
+        "spec.voltstack_cluster_ar.sm_connection_public_ip": [
+          "sm_connection_pvt_ip"
+        ],
+        "spec.voltstack_cluster_ar.sm_connection_pvt_ip": [
+          "sm_connection_public_ip"
+        ],
+        "spec.voltstack_cluster_ar.storage_class_list": [
+          "default_storage"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.block_all_services": {},
+        "spec.disk_size": 0,
+        "spec.ingress_gw.accelerated_networking": null,
+        "spec.ingress_gw.performance_enhancement_mode": null,
+        "spec.logs_streaming_disabled": {},
+        "spec.machine_type": "",
+        "spec.no_worker_nodes": {},
+        "spec.tags": {}
+      },
+      "minimumConfigFields": [
+        "spec.admin_password.blindfold_secret_info.location",
+        "spec.admin_password.clear_secret_info.url",
+        "spec.azure_cred.name",
+        "spec.enable_encryption.disk_encryption_set_id",
+        "spec.enable_encryption.resource_group",
+        "spec.ingress_egress_gw.active_enhanced_firewall_policies.enhanced_firewall_policies",
+        "spec.ingress_egress_gw.active_forward_proxy_policies.forward_proxy_policies",
+        "spec.ingress_egress_gw.active_network_policies.network_policies",
+        "spec.ingress_egress_gw.az_nodes",
+        "spec.ingress_egress_gw.azure_certified_hw",
+        "spec.ingress_egress_gw.dc_cluster_group_inside_vn.name",
+        "spec.ingress_egress_gw.dc_cluster_group_outside_vn.name",
+        "spec.ingress_egress_gw.global_network_list.global_network_connections",
+        "spec.ingress_egress_gw.hub.express_route_enabled.connections",
+        "spec.ingress_egress_gw.hub.express_route_enabled.site_registration_over_express_route.cloudlink_network_name",
+        "spec.ingress_egress_gw.inside_static_routes.static_route_list",
+        "spec.ingress_egress_gw.outside_static_routes.static_route_list",
+        "spec.ingress_egress_gw_ar.active_enhanced_firewall_policies.enhanced_firewall_policies",
+        "spec.ingress_egress_gw_ar.active_forward_proxy_policies.forward_proxy_policies",
+        "spec.ingress_egress_gw_ar.active_network_policies.network_policies",
+        "spec.ingress_egress_gw_ar.azure_certified_hw",
+        "spec.ingress_egress_gw_ar.dc_cluster_group_inside_vn.name",
+        "spec.ingress_egress_gw_ar.dc_cluster_group_outside_vn.name",
+        "spec.ingress_egress_gw_ar.global_network_list.global_network_connections",
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.connections",
+        "spec.ingress_egress_gw_ar.hub.express_route_enabled.site_registration_over_express_route.cloudlink_network_name",
+        "spec.ingress_egress_gw_ar.inside_static_routes.static_route_list",
+        "spec.ingress_egress_gw_ar.node.fault_domain",
+        "spec.ingress_egress_gw_ar.node.inside_subnet.subnet.subnet_name",
+        "spec.ingress_egress_gw_ar.node.inside_subnet.subnet_param.ipv4",
+        "spec.ingress_egress_gw_ar.node.node_number",
+        "spec.ingress_egress_gw_ar.node.outside_subnet.subnet.subnet_name",
+        "spec.ingress_egress_gw_ar.node.outside_subnet.subnet_param.ipv4",
+        "spec.ingress_egress_gw_ar.node.update_domain",
+        "spec.ingress_egress_gw_ar.outside_static_routes.static_route_list",
+        "spec.ingress_gw.az_nodes",
+        "spec.ingress_gw.azure_certified_hw",
+        "spec.ingress_gw_ar.azure_certified_hw",
+        "spec.ingress_gw_ar.node.fault_domain",
+        "spec.ingress_gw_ar.node.local_subnet.subnet.subnet_name",
+        "spec.ingress_gw_ar.node.local_subnet.subnet_param.ipv4",
+        "spec.ingress_gw_ar.node.node_number",
+        "spec.ingress_gw_ar.node.update_domain",
+        "spec.kubernetes_upgrade_drain.enable_upgrade_drain.drain_node_timeout",
+        "spec.log_receiver.name",
+        "spec.machine_type",
+        "spec.resource_group",
+        "spec.ssh_key",
+        "spec.vnet.existing_vnet.resource_group",
+        "spec.vnet.existing_vnet.vnet_name",
+        "spec.vnet.new_vnet.primary_ipv4",
+        "spec.voltstack_cluster.active_enhanced_firewall_policies.enhanced_firewall_policies",
+        "spec.voltstack_cluster.active_forward_proxy_policies.forward_proxy_policies",
+        "spec.voltstack_cluster.active_network_policies.network_policies",
+        "spec.voltstack_cluster.az_nodes",
+        "spec.voltstack_cluster.azure_certified_hw",
+        "spec.voltstack_cluster.dc_cluster_group.name",
+        "spec.voltstack_cluster.global_network_list.global_network_connections",
+        "spec.voltstack_cluster.k8s_cluster.name",
+        "spec.voltstack_cluster.outside_static_routes.static_route_list",
+        "spec.voltstack_cluster_ar.active_enhanced_firewall_policies.enhanced_firewall_policies",
+        "spec.voltstack_cluster_ar.active_forward_proxy_policies.forward_proxy_policies",
+        "spec.voltstack_cluster_ar.active_network_policies.network_policies",
+        "spec.voltstack_cluster_ar.azure_certified_hw",
+        "spec.voltstack_cluster_ar.dc_cluster_group.name",
+        "spec.voltstack_cluster_ar.global_network_list.global_network_connections",
+        "spec.voltstack_cluster_ar.k8s_cluster.name",
+        "spec.voltstack_cluster_ar.node.fault_domain",
+        "spec.voltstack_cluster_ar.node.local_subnet.subnet.subnet_name",
+        "spec.voltstack_cluster_ar.node.local_subnet.subnet_param.ipv4",
+        "spec.voltstack_cluster_ar.node.node_number",
+        "spec.voltstack_cluster_ar.node.update_domain",
+        "spec.voltstack_cluster_ar.outside_static_routes.static_route_list"
+      ],
+      "serverDefaultFields": [
+        "spec.block_all_services",
+        "spec.disk_size",
+        "spec.ingress_gw.accelerated_networking",
+        "spec.ingress_gw.performance_enhancement_mode",
+        "spec.logs_streaming_disabled",
+        "spec.machine_type",
+        "spec.no_worker_nodes",
+        "spec.tags"
+      ]
+    },
+    "certificate": {
+      "fieldConflicts": {
+        "spec.custom_hash_algorithms": [
+          "disable_ocsp_stapling",
+          "use_system_defaults"
+        ],
+        "spec.disable_ocsp_stapling": [
+          "custom_hash_algorithms",
+          "use_system_defaults"
+        ],
+        "spec.private_key.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.private_key.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.use_system_defaults": [
+          "custom_hash_algorithms",
+          "disable_ocsp_stapling"
+        ]
+      },
+      "fieldDefaults": {},
+      "minimumConfigFields": [
+        "spec.certificate_chain.name",
+        "spec.certificate_url",
+        "spec.custom_hash_algorithms.hash_algorithms",
+        "spec.private_key.blindfold_secret_info.location",
+        "spec.private_key.clear_secret_info.url"
+      ],
+      "serverDefaultFields": []
+    },
+    "certificate_views": {
+      "fieldConflicts": {
+        "spec.custom_hash_algorithms": [
+          "disable_ocsp_stapling",
+          "use_system_defaults"
+        ],
+        "spec.disable_ocsp_stapling": [
+          "custom_hash_algorithms",
+          "use_system_defaults"
+        ],
+        "spec.private_key.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.private_key.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.use_system_defaults": [
+          "custom_hash_algorithms",
+          "disable_ocsp_stapling"
+        ]
+      },
+      "fieldDefaults": {},
+      "minimumConfigFields": [
+        "spec.certificate_chain.name",
+        "spec.certificate_url",
+        "spec.custom_hash_algorithms.hash_algorithms",
+        "spec.private_key.blindfold_secret_info.location",
+        "spec.private_key.clear_secret_info.url"
+      ],
+      "serverDefaultFields": []
+    },
+    "enhanced_firewall_policy": {
+      "fieldConflicts": {
+        "spec.allow_all": [
+          "allowed_destinations",
+          "allowed_sources",
+          "denied_destinations",
+          "denied_sources",
+          "deny_all",
+          "rule_list"
+        ],
+        "spec.allowed_destinations": [
+          "allow_all",
+          "allowed_sources",
+          "denied_destinations",
+          "denied_sources",
+          "deny_all",
+          "rule_list"
+        ],
+        "spec.allowed_sources": [
+          "allow_all",
+          "allowed_destinations",
+          "denied_destinations",
+          "denied_sources",
+          "deny_all",
+          "rule_list"
+        ],
+        "spec.denied_destinations": [
+          "allow_all",
+          "allowed_destinations",
+          "allowed_sources",
+          "denied_sources",
+          "deny_all",
+          "rule_list"
+        ],
+        "spec.denied_sources": [
+          "allow_all",
+          "allowed_destinations",
+          "allowed_sources",
+          "denied_destinations",
+          "deny_all",
+          "rule_list"
+        ],
+        "spec.deny_all": [
+          "allow_all",
+          "allowed_destinations",
+          "allowed_sources",
+          "denied_destinations",
+          "denied_sources",
+          "rule_list"
+        ],
+        "spec.rule_list": [
+          "allow_all",
+          "allowed_destinations",
+          "allowed_sources",
+          "denied_destinations",
+          "denied_sources",
+          "deny_all"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.allow_all": {}
+      },
+      "minimumConfigFields": [
+        "spec.rule_list.rules"
+      ],
+      "serverDefaultFields": [
+        "spec.allow_all"
+      ]
+    },
+    "fast_acl": {
+      "fieldConflicts": {
+        "spec.action.policer_action": [
+          "protocol_policer_action",
+          "simple_action"
+        ],
+        "spec.action.protocol_policer_action": [
+          "policer_action",
+          "simple_action"
+        ],
+        "spec.action.simple_action": [
+          "policer_action",
+          "protocol_policer_action"
+        ],
+        "spec.ip_prefix_set": [
+          "prefix"
+        ],
+        "spec.prefix": [
+          "ip_prefix_set"
+        ]
+      },
+      "fieldDefaults": {},
+      "minimumConfigFields": [
+        "spec.port"
+      ],
+      "serverDefaultFields": []
+    },
+    "forward_proxy_policy": {
+      "fieldConflicts": {
+        "spec.allow_all": [
+          "allow_list",
+          "deny_list",
+          "rule_list"
+        ],
+        "spec.allow_list": [
+          "allow_all",
+          "deny_list",
+          "rule_list"
+        ],
+        "spec.allow_list.default_action_allow": [
+          "default_action_deny",
+          "default_action_next_policy"
+        ],
+        "spec.allow_list.default_action_deny": [
+          "default_action_allow",
+          "default_action_next_policy"
+        ],
+        "spec.allow_list.default_action_next_policy": [
+          "default_action_allow",
+          "default_action_deny"
+        ],
+        "spec.any_proxy": [
+          "drp_http_connect",
+          "network_connector",
+          "proxy_label_selector"
+        ],
+        "spec.deny_list": [
+          "allow_all",
+          "allow_list",
+          "rule_list"
+        ],
+        "spec.deny_list.default_action_allow": [
+          "default_action_deny",
+          "default_action_next_policy"
+        ],
+        "spec.deny_list.default_action_deny": [
+          "default_action_allow",
+          "default_action_next_policy"
+        ],
+        "spec.deny_list.default_action_next_policy": [
+          "default_action_allow",
+          "default_action_deny"
+        ],
+        "spec.drp_http_connect": [
+          "any_proxy",
+          "network_connector",
+          "proxy_label_selector"
+        ],
+        "spec.network_connector": [
+          "any_proxy",
+          "drp_http_connect",
+          "proxy_label_selector"
+        ],
+        "spec.proxy_label_selector": [
+          "any_proxy",
+          "drp_http_connect",
+          "network_connector"
+        ],
+        "spec.rule_list": [
+          "allow_all",
+          "allow_list",
+          "deny_list"
+        ]
+      },
+      "fieldDefaults": {},
+      "minimumConfigFields": [
+        "spec.network_connector.name",
+        "spec.proxy_label_selector.expressions",
+        "spec.rule_list.rules"
+      ],
+      "serverDefaultFields": []
+    },
+    "global_log_receiver": {
+      "fieldConflicts": {
+        "spec.audit_logs": [
+          "dns_logs",
+          "request_logs",
+          "security_events"
+        ],
+        "spec.aws_cloud_watch_receiver": [
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.aws_cloud_watch_receiver.batch.max_bytes": [
+          "max_bytes_disabled"
+        ],
+        "spec.aws_cloud_watch_receiver.batch.max_bytes_disabled": [
+          "max_bytes"
+        ],
+        "spec.aws_cloud_watch_receiver.batch.max_events": [
+          "max_events_disabled"
+        ],
+        "spec.aws_cloud_watch_receiver.batch.max_events_disabled": [
+          "max_events"
+        ],
+        "spec.aws_cloud_watch_receiver.batch.timeout_seconds": [
+          "timeout_seconds_default"
+        ],
+        "spec.aws_cloud_watch_receiver.batch.timeout_seconds_default": [
+          "timeout_seconds"
+        ],
+        "spec.aws_cloud_watch_receiver.compression.compression_default": [
+          "compression_gzip",
+          "compression_none"
+        ],
+        "spec.aws_cloud_watch_receiver.compression.compression_gzip": [
+          "compression_default",
+          "compression_none"
+        ],
+        "spec.aws_cloud_watch_receiver.compression.compression_none": [
+          "compression_default",
+          "compression_gzip"
+        ],
+        "spec.azure_event_hubs_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.azure_event_hubs_receiver.connection_string.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.azure_event_hubs_receiver.connection_string.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.azure_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.azure_receiver.batch.max_bytes": [
+          "max_bytes_disabled"
+        ],
+        "spec.azure_receiver.batch.max_bytes_disabled": [
+          "max_bytes"
+        ],
+        "spec.azure_receiver.batch.max_events": [
+          "max_events_disabled"
+        ],
+        "spec.azure_receiver.batch.max_events_disabled": [
+          "max_events"
+        ],
+        "spec.azure_receiver.batch.timeout_seconds": [
+          "timeout_seconds_default"
+        ],
+        "spec.azure_receiver.batch.timeout_seconds_default": [
+          "timeout_seconds"
+        ],
+        "spec.azure_receiver.compression.compression_default": [
+          "compression_gzip",
+          "compression_none"
+        ],
+        "spec.azure_receiver.compression.compression_gzip": [
+          "compression_default",
+          "compression_none"
+        ],
+        "spec.azure_receiver.compression.compression_none": [
+          "compression_default",
+          "compression_gzip"
+        ],
+        "spec.azure_receiver.connection_string.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.azure_receiver.connection_string.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.azure_receiver.filename_options.custom_folder": [
+          "log_type_folder",
+          "no_folder"
+        ],
+        "spec.azure_receiver.filename_options.log_type_folder": [
+          "custom_folder",
+          "no_folder"
+        ],
+        "spec.azure_receiver.filename_options.no_folder": [
+          "custom_folder",
+          "log_type_folder"
+        ],
+        "spec.datadog_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.datadog_receiver.batch.max_bytes": [
+          "max_bytes_disabled"
+        ],
+        "spec.datadog_receiver.batch.max_bytes_disabled": [
+          "max_bytes"
+        ],
+        "spec.datadog_receiver.batch.max_events": [
+          "max_events_disabled"
+        ],
+        "spec.datadog_receiver.batch.max_events_disabled": [
+          "max_events"
+        ],
+        "spec.datadog_receiver.batch.timeout_seconds": [
+          "timeout_seconds_default"
+        ],
+        "spec.datadog_receiver.batch.timeout_seconds_default": [
+          "timeout_seconds"
+        ],
+        "spec.datadog_receiver.compression.compression_default": [
+          "compression_gzip",
+          "compression_none"
+        ],
+        "spec.datadog_receiver.compression.compression_gzip": [
+          "compression_default",
+          "compression_none"
+        ],
+        "spec.datadog_receiver.compression.compression_none": [
+          "compression_default",
+          "compression_gzip"
+        ],
+        "spec.datadog_receiver.datadog_api_key.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.datadog_receiver.datadog_api_key.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.datadog_receiver.endpoint": [
+          "site"
+        ],
+        "spec.datadog_receiver.no_tls": [
+          "use_tls"
+        ],
+        "spec.datadog_receiver.site": [
+          "endpoint"
+        ],
+        "spec.datadog_receiver.use_tls": [
+          "no_tls"
+        ],
+        "spec.datadog_receiver.use_tls.disable_verify_certificate": [
+          "enable_verify_certificate"
+        ],
+        "spec.datadog_receiver.use_tls.disable_verify_hostname": [
+          "enable_verify_hostname"
+        ],
+        "spec.datadog_receiver.use_tls.enable_verify_certificate": [
+          "disable_verify_certificate"
+        ],
+        "spec.datadog_receiver.use_tls.enable_verify_hostname": [
+          "disable_verify_hostname"
+        ],
+        "spec.datadog_receiver.use_tls.mtls_disabled": [
+          "mtls_enable"
+        ],
+        "spec.datadog_receiver.use_tls.mtls_enable": [
+          "mtls_disabled"
+        ],
+        "spec.datadog_receiver.use_tls.mtls_enable.key_url.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.datadog_receiver.use_tls.mtls_enable.key_url.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.datadog_receiver.use_tls.no_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.datadog_receiver.use_tls.trusted_ca_url": [
+          "no_ca"
+        ],
+        "spec.dns_logs": [
+          "audit_logs",
+          "request_logs",
+          "security_events"
+        ],
+        "spec.gcp_bucket_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.gcp_bucket_receiver.batch.max_bytes": [
+          "max_bytes_disabled"
+        ],
+        "spec.gcp_bucket_receiver.batch.max_bytes_disabled": [
+          "max_bytes"
+        ],
+        "spec.gcp_bucket_receiver.batch.max_events": [
+          "max_events_disabled"
+        ],
+        "spec.gcp_bucket_receiver.batch.max_events_disabled": [
+          "max_events"
+        ],
+        "spec.gcp_bucket_receiver.batch.timeout_seconds": [
+          "timeout_seconds_default"
+        ],
+        "spec.gcp_bucket_receiver.batch.timeout_seconds_default": [
+          "timeout_seconds"
+        ],
+        "spec.gcp_bucket_receiver.compression.compression_default": [
+          "compression_gzip",
+          "compression_none"
+        ],
+        "spec.gcp_bucket_receiver.compression.compression_gzip": [
+          "compression_default",
+          "compression_none"
+        ],
+        "spec.gcp_bucket_receiver.compression.compression_none": [
+          "compression_default",
+          "compression_gzip"
+        ],
+        "spec.gcp_bucket_receiver.filename_options.custom_folder": [
+          "log_type_folder",
+          "no_folder"
+        ],
+        "spec.gcp_bucket_receiver.filename_options.log_type_folder": [
+          "custom_folder",
+          "no_folder"
+        ],
+        "spec.gcp_bucket_receiver.filename_options.no_folder": [
+          "custom_folder",
+          "log_type_folder"
+        ],
+        "spec.http_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.http_receiver.auth_basic": [
+          "auth_none",
+          "auth_token"
+        ],
+        "spec.http_receiver.auth_basic.password.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.http_receiver.auth_basic.password.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.http_receiver.auth_none": [
+          "auth_basic",
+          "auth_token"
+        ],
+        "spec.http_receiver.auth_token": [
+          "auth_basic",
+          "auth_none"
+        ],
+        "spec.http_receiver.auth_token.token.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.http_receiver.auth_token.token.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.http_receiver.batch.max_bytes": [
+          "max_bytes_disabled"
+        ],
+        "spec.http_receiver.batch.max_bytes_disabled": [
+          "max_bytes"
+        ],
+        "spec.http_receiver.batch.max_events": [
+          "max_events_disabled"
+        ],
+        "spec.http_receiver.batch.max_events_disabled": [
+          "max_events"
+        ],
+        "spec.http_receiver.batch.timeout_seconds": [
+          "timeout_seconds_default"
+        ],
+        "spec.http_receiver.batch.timeout_seconds_default": [
+          "timeout_seconds"
+        ],
+        "spec.http_receiver.compression.compression_default": [
+          "compression_gzip",
+          "compression_none"
+        ],
+        "spec.http_receiver.compression.compression_gzip": [
+          "compression_default",
+          "compression_none"
+        ],
+        "spec.http_receiver.compression.compression_none": [
+          "compression_default",
+          "compression_gzip"
+        ],
+        "spec.http_receiver.no_tls": [
+          "use_tls"
+        ],
+        "spec.http_receiver.use_tls": [
+          "no_tls"
+        ],
+        "spec.http_receiver.use_tls.disable_verify_certificate": [
+          "enable_verify_certificate"
+        ],
+        "spec.http_receiver.use_tls.disable_verify_hostname": [
+          "enable_verify_hostname"
+        ],
+        "spec.http_receiver.use_tls.enable_verify_certificate": [
+          "disable_verify_certificate"
+        ],
+        "spec.http_receiver.use_tls.enable_verify_hostname": [
+          "disable_verify_hostname"
+        ],
+        "spec.http_receiver.use_tls.mtls_disabled": [
+          "mtls_enable"
+        ],
+        "spec.http_receiver.use_tls.mtls_enable": [
+          "mtls_disabled"
+        ],
+        "spec.http_receiver.use_tls.mtls_enable.key_url.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.http_receiver.use_tls.mtls_enable.key_url.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.http_receiver.use_tls.no_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.http_receiver.use_tls.trusted_ca_url": [
+          "no_ca"
+        ],
+        "spec.kafka_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.kafka_receiver.batch.max_bytes": [
+          "max_bytes_disabled"
+        ],
+        "spec.kafka_receiver.batch.max_bytes_disabled": [
+          "max_bytes"
+        ],
+        "spec.kafka_receiver.batch.max_events": [
+          "max_events_disabled"
+        ],
+        "spec.kafka_receiver.batch.max_events_disabled": [
+          "max_events"
+        ],
+        "spec.kafka_receiver.batch.timeout_seconds": [
+          "timeout_seconds_default"
+        ],
+        "spec.kafka_receiver.batch.timeout_seconds_default": [
+          "timeout_seconds"
+        ],
+        "spec.kafka_receiver.compression.compression_default": [
+          "compression_gzip",
+          "compression_none"
+        ],
+        "spec.kafka_receiver.compression.compression_gzip": [
+          "compression_default",
+          "compression_none"
+        ],
+        "spec.kafka_receiver.compression.compression_none": [
+          "compression_default",
+          "compression_gzip"
+        ],
+        "spec.kafka_receiver.no_tls": [
+          "use_tls"
+        ],
+        "spec.kafka_receiver.use_tls": [
+          "no_tls"
+        ],
+        "spec.kafka_receiver.use_tls.disable_verify_certificate": [
+          "enable_verify_certificate"
+        ],
+        "spec.kafka_receiver.use_tls.disable_verify_hostname": [
+          "enable_verify_hostname"
+        ],
+        "spec.kafka_receiver.use_tls.enable_verify_certificate": [
+          "disable_verify_certificate"
+        ],
+        "spec.kafka_receiver.use_tls.enable_verify_hostname": [
+          "disable_verify_hostname"
+        ],
+        "spec.kafka_receiver.use_tls.mtls_disabled": [
+          "mtls_enable"
+        ],
+        "spec.kafka_receiver.use_tls.mtls_enable": [
+          "mtls_disabled"
+        ],
+        "spec.kafka_receiver.use_tls.mtls_enable.key_url.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.kafka_receiver.use_tls.mtls_enable.key_url.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.kafka_receiver.use_tls.no_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.kafka_receiver.use_tls.trusted_ca_url": [
+          "no_ca"
+        ],
+        "spec.new_relic_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.new_relic_receiver.api_key.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.new_relic_receiver.api_key.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.new_relic_receiver.eu": [
+          "us"
+        ],
+        "spec.new_relic_receiver.us": [
+          "eu"
+        ],
+        "spec.ns_all": [
+          "ns_current",
+          "ns_list"
+        ],
+        "spec.ns_current": [
+          "ns_all",
+          "ns_list"
+        ],
+        "spec.ns_list": [
+          "ns_all",
+          "ns_current"
+        ],
+        "spec.qradar_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "s3_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.qradar_receiver.batch.max_bytes": [
+          "max_bytes_disabled"
+        ],
+        "spec.qradar_receiver.batch.max_bytes_disabled": [
+          "max_bytes"
+        ],
+        "spec.qradar_receiver.batch.max_events": [
+          "max_events_disabled"
+        ],
+        "spec.qradar_receiver.batch.max_events_disabled": [
+          "max_events"
+        ],
+        "spec.qradar_receiver.batch.timeout_seconds": [
+          "timeout_seconds_default"
+        ],
+        "spec.qradar_receiver.batch.timeout_seconds_default": [
+          "timeout_seconds"
+        ],
+        "spec.qradar_receiver.compression.compression_default": [
+          "compression_gzip",
+          "compression_none"
+        ],
+        "spec.qradar_receiver.compression.compression_gzip": [
+          "compression_default",
+          "compression_none"
+        ],
+        "spec.qradar_receiver.compression.compression_none": [
+          "compression_default",
+          "compression_gzip"
+        ],
+        "spec.qradar_receiver.no_tls": [
+          "use_tls"
+        ],
+        "spec.qradar_receiver.use_tls": [
+          "no_tls"
+        ],
+        "spec.qradar_receiver.use_tls.disable_verify_certificate": [
+          "enable_verify_certificate"
+        ],
+        "spec.qradar_receiver.use_tls.disable_verify_hostname": [
+          "enable_verify_hostname"
+        ],
+        "spec.qradar_receiver.use_tls.enable_verify_certificate": [
+          "disable_verify_certificate"
+        ],
+        "spec.qradar_receiver.use_tls.enable_verify_hostname": [
+          "disable_verify_hostname"
+        ],
+        "spec.qradar_receiver.use_tls.mtls_disabled": [
+          "mtls_enable"
+        ],
+        "spec.qradar_receiver.use_tls.mtls_enable": [
+          "mtls_disabled"
+        ],
+        "spec.qradar_receiver.use_tls.mtls_enable.key_url.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.qradar_receiver.use_tls.mtls_enable.key_url.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.qradar_receiver.use_tls.no_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.qradar_receiver.use_tls.trusted_ca_url": [
+          "no_ca"
+        ],
+        "spec.request_logs": [
+          "audit_logs",
+          "dns_logs",
+          "security_events"
+        ],
+        "spec.s3_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "splunk_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.s3_receiver.batch.max_bytes": [
+          "max_bytes_disabled"
+        ],
+        "spec.s3_receiver.batch.max_bytes_disabled": [
+          "max_bytes"
+        ],
+        "spec.s3_receiver.batch.max_events": [
+          "max_events_disabled"
+        ],
+        "spec.s3_receiver.batch.max_events_disabled": [
+          "max_events"
+        ],
+        "spec.s3_receiver.batch.timeout_seconds": [
+          "timeout_seconds_default"
+        ],
+        "spec.s3_receiver.batch.timeout_seconds_default": [
+          "timeout_seconds"
+        ],
+        "spec.s3_receiver.compression.compression_default": [
+          "compression_gzip",
+          "compression_none"
+        ],
+        "spec.s3_receiver.compression.compression_gzip": [
+          "compression_default",
+          "compression_none"
+        ],
+        "spec.s3_receiver.compression.compression_none": [
+          "compression_default",
+          "compression_gzip"
+        ],
+        "spec.s3_receiver.filename_options.custom_folder": [
+          "log_type_folder",
+          "no_folder"
+        ],
+        "spec.s3_receiver.filename_options.log_type_folder": [
+          "custom_folder",
+          "no_folder"
+        ],
+        "spec.s3_receiver.filename_options.no_folder": [
+          "custom_folder",
+          "log_type_folder"
+        ],
+        "spec.security_events": [
+          "audit_logs",
+          "dns_logs",
+          "request_logs"
+        ],
+        "spec.splunk_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "sumo_logic_receiver"
+        ],
+        "spec.splunk_receiver.batch.max_bytes": [
+          "max_bytes_disabled"
+        ],
+        "spec.splunk_receiver.batch.max_bytes_disabled": [
+          "max_bytes"
+        ],
+        "spec.splunk_receiver.batch.max_events": [
+          "max_events_disabled"
+        ],
+        "spec.splunk_receiver.batch.max_events_disabled": [
+          "max_events"
+        ],
+        "spec.splunk_receiver.batch.timeout_seconds": [
+          "timeout_seconds_default"
+        ],
+        "spec.splunk_receiver.batch.timeout_seconds_default": [
+          "timeout_seconds"
+        ],
+        "spec.splunk_receiver.compression.compression_default": [
+          "compression_gzip",
+          "compression_none"
+        ],
+        "spec.splunk_receiver.compression.compression_gzip": [
+          "compression_default",
+          "compression_none"
+        ],
+        "spec.splunk_receiver.compression.compression_none": [
+          "compression_default",
+          "compression_gzip"
+        ],
+        "spec.splunk_receiver.no_tls": [
+          "use_tls"
+        ],
+        "spec.splunk_receiver.splunk_hec_token.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.splunk_receiver.splunk_hec_token.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.splunk_receiver.use_tls": [
+          "no_tls"
+        ],
+        "spec.splunk_receiver.use_tls.disable_verify_certificate": [
+          "enable_verify_certificate"
+        ],
+        "spec.splunk_receiver.use_tls.disable_verify_hostname": [
+          "enable_verify_hostname"
+        ],
+        "spec.splunk_receiver.use_tls.enable_verify_certificate": [
+          "disable_verify_certificate"
+        ],
+        "spec.splunk_receiver.use_tls.enable_verify_hostname": [
+          "disable_verify_hostname"
+        ],
+        "spec.splunk_receiver.use_tls.mtls_disabled": [
+          "mtls_enable"
+        ],
+        "spec.splunk_receiver.use_tls.mtls_enable": [
+          "mtls_disabled"
+        ],
+        "spec.splunk_receiver.use_tls.mtls_enable.key_url.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.splunk_receiver.use_tls.mtls_enable.key_url.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.splunk_receiver.use_tls.no_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.splunk_receiver.use_tls.trusted_ca_url": [
+          "no_ca"
+        ],
+        "spec.sumo_logic_receiver": [
+          "aws_cloud_watch_receiver",
+          "azure_event_hubs_receiver",
+          "azure_receiver",
+          "datadog_receiver",
+          "gcp_bucket_receiver",
+          "http_receiver",
+          "kafka_receiver",
+          "new_relic_receiver",
+          "qradar_receiver",
+          "s3_receiver",
+          "splunk_receiver"
+        ],
+        "spec.sumo_logic_receiver.url.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.sumo_logic_receiver.url.clear_secret_info": [
+          "blindfold_secret_info"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.ns_current": {}
+      },
+      "minimumConfigFields": [
+        "spec.aws_cloud_watch_receiver.aws_cred.name",
+        "spec.aws_cloud_watch_receiver.aws_region",
+        "spec.aws_cloud_watch_receiver.group_name",
+        "spec.aws_cloud_watch_receiver.stream_name",
+        "spec.azure_event_hubs_receiver.connection_string.blindfold_secret_info.location",
+        "spec.azure_event_hubs_receiver.connection_string.clear_secret_info.url",
+        "spec.azure_event_hubs_receiver.instance",
+        "spec.azure_event_hubs_receiver.namespace",
+        "spec.azure_receiver.connection_string.blindfold_secret_info.location",
+        "spec.azure_receiver.connection_string.clear_secret_info.url",
+        "spec.azure_receiver.container_name",
+        "spec.datadog_receiver.datadog_api_key.blindfold_secret_info.location",
+        "spec.datadog_receiver.datadog_api_key.clear_secret_info.url",
+        "spec.gcp_bucket_receiver.bucket",
+        "spec.gcp_bucket_receiver.gcp_cred.name",
+        "spec.http_receiver.auth_basic.password.blindfold_secret_info.location",
+        "spec.http_receiver.auth_basic.password.clear_secret_info.url",
+        "spec.http_receiver.auth_token.token.blindfold_secret_info.location",
+        "spec.http_receiver.auth_token.token.clear_secret_info.url",
+        "spec.http_receiver.uri",
+        "spec.kafka_receiver.bootstrap_servers",
+        "spec.kafka_receiver.kafka_topic",
+        "spec.new_relic_receiver.api_key.blindfold_secret_info.location",
+        "spec.new_relic_receiver.api_key.clear_secret_info.url",
+        "spec.ns_list.namespaces",
+        "spec.qradar_receiver.uri",
+        "spec.s3_receiver.aws_cred.name",
+        "spec.s3_receiver.aws_region",
+        "spec.s3_receiver.bucket",
+        "spec.splunk_receiver.endpoint",
+        "spec.splunk_receiver.splunk_hec_token.blindfold_secret_info.location",
+        "spec.splunk_receiver.splunk_hec_token.clear_secret_info.url",
+        "spec.sumo_logic_receiver.url.blindfold_secret_info.location",
+        "spec.sumo_logic_receiver.url.clear_secret_info.url"
+      ],
+      "serverDefaultFields": [
+        "spec.ns_current"
+      ]
+    },
+    "healthcheck": {
+      "fieldConflicts": {
+        "spec.http_health_check": [
+          "tcp_health_check",
+          "udp_icmp_health_check"
+        ],
+        "spec.http_health_check.host_header": [
+          "use_origin_server_name"
+        ],
+        "spec.http_health_check.use_origin_server_name": [
+          "host_header"
+        ],
+        "spec.tcp_health_check": [
+          "http_health_check",
+          "udp_icmp_health_check"
+        ],
+        "spec.udp_icmp_health_check": [
+          "http_health_check",
+          "tcp_health_check"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.http_health_check.expected_response": "",
+        "spec.http_health_check.expected_status_codes": [],
+        "spec.http_health_check.headers": {},
+        "spec.http_health_check.request_headers_to_remove": [],
+        "spec.http_health_check.use_http2": false,
+        "spec.http_health_check.use_origin_server_name": {},
+        "spec.jitter_percent": 0
+      },
+      "minimumConfigFields": [
+        "spec.healthy_threshold",
+        "spec.http_health_check.path",
+        "spec.interval",
+        "spec.timeout",
+        "spec.unhealthy_threshold"
+      ],
+      "serverDefaultFields": [
+        "spec.http_health_check.expected_response",
+        "spec.http_health_check.expected_status_codes",
+        "spec.http_health_check.headers",
+        "spec.http_health_check.request_headers_to_remove",
+        "spec.http_health_check.use_http2",
+        "spec.http_health_check.use_origin_server_name",
+        "spec.jitter_percent"
+      ]
+    },
+    "http_loadbalancer": {
+      "fieldConflicts": {
+        "spec.active_service_policies": [
+          "no_service_policies",
+          "service_policies_from_namespace"
+        ],
+        "spec.advertise_custom": [
+          "advertise_on_public",
+          "advertise_on_public_default_vip",
+          "do_not_advertise"
+        ],
+        "spec.advertise_on_public": [
+          "advertise_custom",
+          "advertise_on_public_default_vip",
+          "do_not_advertise"
+        ],
+        "spec.advertise_on_public_default_vip": [
+          "advertise_custom",
+          "advertise_on_public",
+          "do_not_advertise"
+        ],
+        "spec.api_rate_limit": [
+          "disable_rate_limit",
+          "rate_limit"
+        ],
+        "spec.api_rate_limit.bypass_rate_limiting_rules": [
+          "custom_ip_allowed_list",
+          "ip_allowed_list",
+          "no_ip_allowed_list"
+        ],
+        "spec.api_rate_limit.custom_ip_allowed_list": [
+          "bypass_rate_limiting_rules",
+          "ip_allowed_list",
+          "no_ip_allowed_list"
+        ],
+        "spec.api_rate_limit.ip_allowed_list": [
+          "bypass_rate_limiting_rules",
+          "custom_ip_allowed_list",
+          "no_ip_allowed_list"
+        ],
+        "spec.api_rate_limit.no_ip_allowed_list": [
+          "bypass_rate_limiting_rules",
+          "custom_ip_allowed_list",
+          "ip_allowed_list"
+        ],
+        "spec.api_specification": [
+          "disable_api_definition"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints": [
+          "validation_custom_list",
+          "validation_disabled"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.fall_through_mode.fall_through_mode_allow": [
+          "fall_through_mode_custom"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.fall_through_mode.fall_through_mode_custom": [
+          "fall_through_mode_allow"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.settings.oversized_body_fail_validation": [
+          "oversized_body_skip_validation"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.settings.oversized_body_skip_validation": [
+          "oversized_body_fail_validation"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.settings.property_validation_settings_custom": [
+          "property_validation_settings_default"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.settings.property_validation_settings_default": [
+          "property_validation_settings_custom"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.response_validation_mode_active": [
+          "skip_response_validation"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.response_validation_mode_active.enforcement_block": [
+          "enforcement_report"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.response_validation_mode_active.enforcement_report": [
+          "enforcement_block"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.skip_response_validation": [
+          "response_validation_mode_active"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.skip_validation": [
+          "validation_mode_active"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.validation_mode_active": [
+          "skip_validation"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.validation_mode_active.enforcement_block": [
+          "enforcement_report"
+        ],
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.validation_mode_active.enforcement_report": [
+          "enforcement_block"
+        ],
+        "spec.api_specification.validation_custom_list": [
+          "validation_all_spec_endpoints",
+          "validation_disabled"
+        ],
+        "spec.api_specification.validation_custom_list.fall_through_mode.fall_through_mode_allow": [
+          "fall_through_mode_custom"
+        ],
+        "spec.api_specification.validation_custom_list.fall_through_mode.fall_through_mode_custom": [
+          "fall_through_mode_allow"
+        ],
+        "spec.api_specification.validation_custom_list.settings.oversized_body_fail_validation": [
+          "oversized_body_skip_validation"
+        ],
+        "spec.api_specification.validation_custom_list.settings.oversized_body_skip_validation": [
+          "oversized_body_fail_validation"
+        ],
+        "spec.api_specification.validation_custom_list.settings.property_validation_settings_custom": [
+          "property_validation_settings_default"
+        ],
+        "spec.api_specification.validation_custom_list.settings.property_validation_settings_default": [
+          "property_validation_settings_custom"
+        ],
+        "spec.api_specification.validation_disabled": [
+          "validation_all_spec_endpoints",
+          "validation_custom_list"
+        ],
+        "spec.api_testing": [
+          "disable_api_testing"
+        ],
+        "spec.api_testing.every_day": [
+          "every_month",
+          "every_week"
+        ],
+        "spec.api_testing.every_month": [
+          "every_day",
+          "every_week"
+        ],
+        "spec.api_testing.every_week": [
+          "every_day",
+          "every_month"
+        ],
+        "spec.app_firewall": [
+          "disable_waf"
+        ],
+        "spec.bot_defense": [
+          "bot_defense_advanced",
+          "disable_bot_defense"
+        ],
+        "spec.bot_defense.disable_cors_support": [
+          "enable_cors_support"
+        ],
+        "spec.bot_defense.enable_cors_support": [
+          "disable_cors_support"
+        ],
+        "spec.bot_defense.policy.disable_js_insert": [
+          "js_insert_all_pages",
+          "js_insert_all_pages_except",
+          "js_insertion_rules"
+        ],
+        "spec.bot_defense.policy.disable_mobile_sdk": [
+          "mobile_sdk_config"
+        ],
+        "spec.bot_defense.policy.js_insert_all_pages": [
+          "disable_js_insert",
+          "js_insert_all_pages_except",
+          "js_insertion_rules"
+        ],
+        "spec.bot_defense.policy.js_insert_all_pages_except": [
+          "disable_js_insert",
+          "js_insert_all_pages",
+          "js_insertion_rules"
+        ],
+        "spec.bot_defense.policy.js_insertion_rules": [
+          "disable_js_insert",
+          "js_insert_all_pages",
+          "js_insert_all_pages_except"
+        ],
+        "spec.bot_defense.policy.mobile_sdk_config": [
+          "disable_mobile_sdk"
+        ],
+        "spec.bot_defense_advanced": [
+          "bot_defense",
+          "disable_bot_defense"
+        ],
+        "spec.bot_defense_advanced.disable_js_insert": [
+          "js_insert_all_pages",
+          "js_insert_all_pages_except",
+          "js_insertion_rules"
+        ],
+        "spec.bot_defense_advanced.disable_mobile_sdk": [
+          "mobile_sdk_config"
+        ],
+        "spec.bot_defense_advanced.js_insert_all_pages": [
+          "disable_js_insert",
+          "js_insert_all_pages_except",
+          "js_insertion_rules"
+        ],
+        "spec.bot_defense_advanced.js_insert_all_pages_except": [
+          "disable_js_insert",
+          "js_insert_all_pages",
+          "js_insertion_rules"
+        ],
+        "spec.bot_defense_advanced.js_insertion_rules": [
+          "disable_js_insert",
+          "js_insert_all_pages",
+          "js_insert_all_pages_except"
+        ],
+        "spec.bot_defense_advanced.mobile_sdk_config": [
+          "disable_mobile_sdk"
+        ],
+        "spec.caching_policy": [
+          "disable_caching"
+        ],
+        "spec.caching_policy.default_cache_action.cache_disabled": [
+          "cache_ttl_default",
+          "cache_ttl_override"
+        ],
+        "spec.caching_policy.default_cache_action.cache_ttl_default": [
+          "cache_disabled",
+          "cache_ttl_override"
+        ],
+        "spec.caching_policy.default_cache_action.cache_ttl_override": [
+          "cache_disabled",
+          "cache_ttl_default"
+        ],
+        "spec.captcha_challenge": [
+          "enable_challenge",
+          "js_challenge",
+          "no_challenge",
+          "policy_based_challenge"
+        ],
+        "spec.client_side_defense": [
+          "disable_client_side_defense"
+        ],
+        "spec.client_side_defense.policy.disable_js_insert": [
+          "js_insert_all_pages",
+          "js_insert_all_pages_except",
+          "js_insertion_rules"
+        ],
+        "spec.client_side_defense.policy.js_insert_all_pages": [
+          "disable_js_insert",
+          "js_insert_all_pages_except",
+          "js_insertion_rules"
+        ],
+        "spec.client_side_defense.policy.js_insert_all_pages_except": [
+          "disable_js_insert",
+          "js_insert_all_pages",
+          "js_insertion_rules"
+        ],
+        "spec.client_side_defense.policy.js_insertion_rules": [
+          "disable_js_insert",
+          "js_insert_all_pages",
+          "js_insert_all_pages_except"
+        ],
+        "spec.cookie_stickiness": [
+          "least_active",
+          "random",
+          "ring_hash",
+          "round_robin",
+          "source_ip_stickiness"
+        ],
+        "spec.cookie_stickiness.add_httponly": [
+          "ignore_httponly"
+        ],
+        "spec.cookie_stickiness.add_secure": [
+          "ignore_secure"
+        ],
+        "spec.cookie_stickiness.ignore_httponly": [
+          "add_httponly"
+        ],
+        "spec.cookie_stickiness.ignore_samesite": [
+          "samesite_lax",
+          "samesite_none",
+          "samesite_strict"
+        ],
+        "spec.cookie_stickiness.ignore_secure": [
+          "add_secure"
+        ],
+        "spec.cookie_stickiness.samesite_lax": [
+          "ignore_samesite",
+          "samesite_none",
+          "samesite_strict"
+        ],
+        "spec.cookie_stickiness.samesite_none": [
+          "ignore_samesite",
+          "samesite_lax",
+          "samesite_strict"
+        ],
+        "spec.cookie_stickiness.samesite_strict": [
+          "ignore_samesite",
+          "samesite_lax",
+          "samesite_none"
+        ],
+        "spec.csrf_policy.all_load_balancer_domains": [
+          "custom_domain_list",
+          "disabled"
+        ],
+        "spec.csrf_policy.custom_domain_list": [
+          "all_load_balancer_domains",
+          "disabled"
+        ],
+        "spec.csrf_policy.disabled": [
+          "all_load_balancer_domains",
+          "custom_domain_list"
+        ],
+        "spec.default_pool": [
+          "default_pool_list"
+        ],
+        "spec.default_pool.advanced_options.auto_http_config": [
+          "http1_config",
+          "http2_options"
+        ],
+        "spec.default_pool.advanced_options.circuit_breaker": [
+          "default_circuit_breaker",
+          "disable_circuit_breaker"
+        ],
+        "spec.default_pool.advanced_options.default_circuit_breaker": [
+          "circuit_breaker",
+          "disable_circuit_breaker"
+        ],
+        "spec.default_pool.advanced_options.disable_circuit_breaker": [
+          "circuit_breaker",
+          "default_circuit_breaker"
+        ],
+        "spec.default_pool.advanced_options.disable_lb_source_ip_persistance": [
+          "enable_lb_source_ip_persistance"
+        ],
+        "spec.default_pool.advanced_options.disable_outlier_detection": [
+          "outlier_detection"
+        ],
+        "spec.default_pool.advanced_options.disable_proxy_protocol": [
+          "proxy_protocol_v1",
+          "proxy_protocol_v2"
+        ],
+        "spec.default_pool.advanced_options.disable_subsets": [
+          "enable_subsets"
+        ],
+        "spec.default_pool.advanced_options.enable_lb_source_ip_persistance": [
+          "disable_lb_source_ip_persistance"
+        ],
+        "spec.default_pool.advanced_options.enable_subsets": [
+          "disable_subsets"
+        ],
+        "spec.default_pool.advanced_options.enable_subsets.any_endpoint": [
+          "default_subset",
+          "fail_request"
+        ],
+        "spec.default_pool.advanced_options.enable_subsets.default_subset": [
+          "any_endpoint",
+          "fail_request"
+        ],
+        "spec.default_pool.advanced_options.enable_subsets.fail_request": [
+          "any_endpoint",
+          "default_subset"
+        ],
+        "spec.default_pool.advanced_options.http1_config": [
+          "auto_http_config",
+          "http2_options"
+        ],
+        "spec.default_pool.advanced_options.http1_config.header_transformation.default_header_transformation": [
+          "legacy_header_transformation",
+          "preserve_case_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.default_pool.advanced_options.http1_config.header_transformation.legacy_header_transformation": [
+          "default_header_transformation",
+          "preserve_case_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.default_pool.advanced_options.http1_config.header_transformation.preserve_case_header_transformation": [
+          "default_header_transformation",
+          "legacy_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.default_pool.advanced_options.http1_config.header_transformation.proper_case_header_transformation": [
+          "default_header_transformation",
+          "legacy_header_transformation",
+          "preserve_case_header_transformation"
+        ],
+        "spec.default_pool.advanced_options.http2_options": [
+          "auto_http_config",
+          "http1_config"
+        ],
+        "spec.default_pool.advanced_options.max_requests_per_connection": [
+          "no_request_limit_per_connection"
+        ],
+        "spec.default_pool.advanced_options.no_panic_threshold": [
+          "panic_threshold"
+        ],
+        "spec.default_pool.advanced_options.no_request_limit_per_connection": [
+          "max_requests_per_connection"
+        ],
+        "spec.default_pool.advanced_options.outlier_detection": [
+          "disable_outlier_detection"
+        ],
+        "spec.default_pool.advanced_options.panic_threshold": [
+          "no_panic_threshold"
+        ],
+        "spec.default_pool.advanced_options.proxy_protocol_v1": [
+          "disable_proxy_protocol",
+          "proxy_protocol_v2"
+        ],
+        "spec.default_pool.advanced_options.proxy_protocol_v2": [
+          "disable_proxy_protocol",
+          "proxy_protocol_v1"
+        ],
+        "spec.default_pool.automatic_port": [
+          "lb_port",
+          "port"
+        ],
+        "spec.default_pool.health_check_port": [
+          "same_as_endpoint_port"
+        ],
+        "spec.default_pool.lb_port": [
+          "automatic_port",
+          "port"
+        ],
+        "spec.default_pool.no_tls": [
+          "use_tls"
+        ],
+        "spec.default_pool.port": [
+          "automatic_port",
+          "lb_port"
+        ],
+        "spec.default_pool.same_as_endpoint_port": [
+          "health_check_port"
+        ],
+        "spec.default_pool.upstream_conn_pool_reuse_type.disable_conn_pool_reuse": [
+          "enable_conn_pool_reuse"
+        ],
+        "spec.default_pool.upstream_conn_pool_reuse_type.enable_conn_pool_reuse": [
+          "disable_conn_pool_reuse"
+        ],
+        "spec.default_pool.use_tls": [
+          "no_tls"
+        ],
+        "spec.default_pool.use_tls.default_session_key_caching": [
+          "disable_session_key_caching",
+          "max_session_keys"
+        ],
+        "spec.default_pool.use_tls.disable_session_key_caching": [
+          "default_session_key_caching",
+          "max_session_keys"
+        ],
+        "spec.default_pool.use_tls.disable_sni": [
+          "sni",
+          "use_host_header_as_sni"
+        ],
+        "spec.default_pool.use_tls.max_session_keys": [
+          "default_session_key_caching",
+          "disable_session_key_caching"
+        ],
+        "spec.default_pool.use_tls.no_mtls": [
+          "use_mtls",
+          "use_mtls_obj"
+        ],
+        "spec.default_pool.use_tls.skip_server_verification": [
+          "use_server_verification",
+          "volterra_trusted_ca"
+        ],
+        "spec.default_pool.use_tls.sni": [
+          "disable_sni",
+          "use_host_header_as_sni"
+        ],
+        "spec.default_pool.use_tls.tls_config.custom_security": [
+          "default_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.default_pool.use_tls.tls_config.default_security": [
+          "custom_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.default_pool.use_tls.tls_config.low_security": [
+          "custom_security",
+          "default_security",
+          "medium_security"
+        ],
+        "spec.default_pool.use_tls.tls_config.medium_security": [
+          "custom_security",
+          "default_security",
+          "low_security"
+        ],
+        "spec.default_pool.use_tls.use_host_header_as_sni": [
+          "disable_sni",
+          "sni"
+        ],
+        "spec.default_pool.use_tls.use_mtls": [
+          "no_mtls",
+          "use_mtls_obj"
+        ],
+        "spec.default_pool.use_tls.use_mtls_obj": [
+          "no_mtls",
+          "use_mtls"
+        ],
+        "spec.default_pool.use_tls.use_server_verification": [
+          "skip_server_verification",
+          "volterra_trusted_ca"
+        ],
+        "spec.default_pool.use_tls.use_server_verification.trusted_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.default_pool.use_tls.use_server_verification.trusted_ca_url": [
+          "trusted_ca"
+        ],
+        "spec.default_pool.use_tls.volterra_trusted_ca": [
+          "skip_server_verification",
+          "use_server_verification"
+        ],
+        "spec.default_pool_list": [
+          "default_pool"
+        ],
+        "spec.default_sensitive_data_policy": [
+          "sensitive_data_policy"
+        ],
+        "spec.disable_api_definition": [
+          "api_specification"
+        ],
+        "spec.disable_api_discovery": [
+          "enable_api_discovery"
+        ],
+        "spec.disable_api_testing": [
+          "api_testing"
+        ],
+        "spec.disable_bot_defense": [
+          "bot_defense",
+          "bot_defense_advanced"
+        ],
+        "spec.disable_caching": [
+          "caching_policy"
+        ],
+        "spec.disable_client_side_defense": [
+          "client_side_defense"
+        ],
+        "spec.disable_ip_reputation": [
+          "enable_ip_reputation"
+        ],
+        "spec.disable_malicious_user_detection": [
+          "enable_malicious_user_detection"
+        ],
+        "spec.disable_malware_protection": [
+          "malware_protection_settings"
+        ],
+        "spec.disable_rate_limit": [
+          "api_rate_limit",
+          "rate_limit"
+        ],
+        "spec.disable_threat_mesh": [
+          "enable_threat_mesh"
+        ],
+        "spec.disable_trust_client_ip_headers": [
+          "enable_trust_client_ip_headers"
+        ],
+        "spec.disable_waf": [
+          "app_firewall"
+        ],
+        "spec.do_not_advertise": [
+          "advertise_custom",
+          "advertise_on_public",
+          "advertise_on_public_default_vip"
+        ],
+        "spec.enable_api_discovery": [
+          "disable_api_discovery"
+        ],
+        "spec.enable_api_discovery.api_crawler.api_crawler_config": [
+          "disable_api_crawler"
+        ],
+        "spec.enable_api_discovery.api_crawler.disable_api_crawler": [
+          "api_crawler_config"
+        ],
+        "spec.enable_api_discovery.custom_api_auth_discovery": [
+          "default_api_auth_discovery"
+        ],
+        "spec.enable_api_discovery.default_api_auth_discovery": [
+          "custom_api_auth_discovery"
+        ],
+        "spec.enable_api_discovery.disable_learn_from_redirect_traffic": [
+          "enable_learn_from_redirect_traffic"
+        ],
+        "spec.enable_api_discovery.enable_learn_from_redirect_traffic": [
+          "disable_learn_from_redirect_traffic"
+        ],
+        "spec.enable_challenge": [
+          "captcha_challenge",
+          "js_challenge",
+          "no_challenge",
+          "policy_based_challenge"
+        ],
+        "spec.enable_challenge.captcha_challenge_parameters": [
+          "default_captcha_challenge_parameters"
+        ],
+        "spec.enable_challenge.default_captcha_challenge_parameters": [
+          "captcha_challenge_parameters"
+        ],
+        "spec.enable_challenge.default_js_challenge_parameters": [
+          "js_challenge_parameters"
+        ],
+        "spec.enable_challenge.default_mitigation_settings": [
+          "malicious_user_mitigation"
+        ],
+        "spec.enable_challenge.js_challenge_parameters": [
+          "default_js_challenge_parameters"
+        ],
+        "spec.enable_challenge.malicious_user_mitigation": [
+          "default_mitigation_settings"
+        ],
+        "spec.enable_ip_reputation": [
+          "disable_ip_reputation"
+        ],
+        "spec.enable_malicious_user_detection": [
+          "disable_malicious_user_detection"
+        ],
+        "spec.enable_threat_mesh": [
+          "disable_threat_mesh"
+        ],
+        "spec.enable_trust_client_ip_headers": [
+          "disable_trust_client_ip_headers"
+        ],
+        "spec.http": [
+          "https",
+          "https_auto_cert"
+        ],
+        "spec.http.port": [
+          "port_ranges"
+        ],
+        "spec.http.port_ranges": [
+          "port"
+        ],
+        "spec.https": [
+          "http",
+          "https_auto_cert"
+        ],
+        "spec.https.append_server_name": [
+          "default_header",
+          "pass_through",
+          "server_name"
+        ],
+        "spec.https.coalescing_options.default_coalescing": [
+          "strict_coalescing"
+        ],
+        "spec.https.coalescing_options.strict_coalescing": [
+          "default_coalescing"
+        ],
+        "spec.https.default_header": [
+          "append_server_name",
+          "pass_through",
+          "server_name"
+        ],
+        "spec.https.default_loadbalancer": [
+          "non_default_loadbalancer"
+        ],
+        "spec.https.disable_path_normalize": [
+          "enable_path_normalize"
+        ],
+        "spec.https.enable_path_normalize": [
+          "disable_path_normalize"
+        ],
+        "spec.https.http_protocol_options.http_protocol_enable_v1_only": [
+          "http_protocol_enable_v1_v2",
+          "http_protocol_enable_v2_only"
+        ],
+        "spec.https.http_protocol_options.http_protocol_enable_v1_only.header_transformation.default_header_transformation": [
+          "legacy_header_transformation",
+          "preserve_case_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.https.http_protocol_options.http_protocol_enable_v1_only.header_transformation.legacy_header_transformation": [
+          "default_header_transformation",
+          "preserve_case_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.https.http_protocol_options.http_protocol_enable_v1_only.header_transformation.preserve_case_header_transformation": [
+          "default_header_transformation",
+          "legacy_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.https.http_protocol_options.http_protocol_enable_v1_only.header_transformation.proper_case_header_transformation": [
+          "default_header_transformation",
+          "legacy_header_transformation",
+          "preserve_case_header_transformation"
+        ],
+        "spec.https.http_protocol_options.http_protocol_enable_v1_v2": [
+          "http_protocol_enable_v1_only",
+          "http_protocol_enable_v2_only"
+        ],
+        "spec.https.http_protocol_options.http_protocol_enable_v2_only": [
+          "http_protocol_enable_v1_only",
+          "http_protocol_enable_v1_v2"
+        ],
+        "spec.https.non_default_loadbalancer": [
+          "default_loadbalancer"
+        ],
+        "spec.https.pass_through": [
+          "append_server_name",
+          "default_header",
+          "server_name"
+        ],
+        "spec.https.port": [
+          "port_ranges"
+        ],
+        "spec.https.port_ranges": [
+          "port"
+        ],
+        "spec.https.server_name": [
+          "append_server_name",
+          "default_header",
+          "pass_through"
+        ],
+        "spec.https.tls_cert_params": [
+          "tls_parameters"
+        ],
+        "spec.https.tls_cert_params.no_mtls": [
+          "use_mtls"
+        ],
+        "spec.https.tls_cert_params.tls_config.custom_security": [
+          "default_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.https.tls_cert_params.tls_config.default_security": [
+          "custom_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.https.tls_cert_params.tls_config.low_security": [
+          "custom_security",
+          "default_security",
+          "medium_security"
+        ],
+        "spec.https.tls_cert_params.tls_config.medium_security": [
+          "custom_security",
+          "default_security",
+          "low_security"
+        ],
+        "spec.https.tls_cert_params.use_mtls": [
+          "no_mtls"
+        ],
+        "spec.https.tls_cert_params.use_mtls.crl": [
+          "no_crl"
+        ],
+        "spec.https.tls_cert_params.use_mtls.no_crl": [
+          "crl"
+        ],
+        "spec.https.tls_cert_params.use_mtls.trusted_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.https.tls_cert_params.use_mtls.trusted_ca_url": [
+          "trusted_ca"
+        ],
+        "spec.https.tls_cert_params.use_mtls.xfcc_disabled": [
+          "xfcc_options"
+        ],
+        "spec.https.tls_cert_params.use_mtls.xfcc_options": [
+          "xfcc_disabled"
+        ],
+        "spec.https.tls_parameters": [
+          "tls_cert_params"
+        ],
+        "spec.https.tls_parameters.no_mtls": [
+          "use_mtls"
+        ],
+        "spec.https.tls_parameters.tls_config.custom_security": [
+          "default_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.https.tls_parameters.tls_config.default_security": [
+          "custom_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.https.tls_parameters.tls_config.low_security": [
+          "custom_security",
+          "default_security",
+          "medium_security"
+        ],
+        "spec.https.tls_parameters.tls_config.medium_security": [
+          "custom_security",
+          "default_security",
+          "low_security"
+        ],
+        "spec.https.tls_parameters.use_mtls": [
+          "no_mtls"
+        ],
+        "spec.https.tls_parameters.use_mtls.crl": [
+          "no_crl"
+        ],
+        "spec.https.tls_parameters.use_mtls.no_crl": [
+          "crl"
+        ],
+        "spec.https.tls_parameters.use_mtls.trusted_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.https.tls_parameters.use_mtls.trusted_ca_url": [
+          "trusted_ca"
+        ],
+        "spec.https.tls_parameters.use_mtls.xfcc_disabled": [
+          "xfcc_options"
+        ],
+        "spec.https.tls_parameters.use_mtls.xfcc_options": [
+          "xfcc_disabled"
+        ],
+        "spec.https_auto_cert": [
+          "http",
+          "https"
+        ],
+        "spec.https_auto_cert.append_server_name": [
+          "default_header",
+          "pass_through",
+          "server_name"
+        ],
+        "spec.https_auto_cert.coalescing_options.default_coalescing": [
+          "strict_coalescing"
+        ],
+        "spec.https_auto_cert.coalescing_options.strict_coalescing": [
+          "default_coalescing"
+        ],
+        "spec.https_auto_cert.default_header": [
+          "append_server_name",
+          "pass_through",
+          "server_name"
+        ],
+        "spec.https_auto_cert.default_loadbalancer": [
+          "non_default_loadbalancer"
+        ],
+        "spec.https_auto_cert.disable_path_normalize": [
+          "enable_path_normalize"
+        ],
+        "spec.https_auto_cert.enable_path_normalize": [
+          "disable_path_normalize"
+        ],
+        "spec.https_auto_cert.http_protocol_options.http_protocol_enable_v1_only": [
+          "http_protocol_enable_v1_v2",
+          "http_protocol_enable_v2_only"
+        ],
+        "spec.https_auto_cert.http_protocol_options.http_protocol_enable_v1_only.header_transformation.default_header_transformation": [
+          "legacy_header_transformation",
+          "preserve_case_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.https_auto_cert.http_protocol_options.http_protocol_enable_v1_only.header_transformation.legacy_header_transformation": [
+          "default_header_transformation",
+          "preserve_case_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.https_auto_cert.http_protocol_options.http_protocol_enable_v1_only.header_transformation.preserve_case_header_transformation": [
+          "default_header_transformation",
+          "legacy_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.https_auto_cert.http_protocol_options.http_protocol_enable_v1_only.header_transformation.proper_case_header_transformation": [
+          "default_header_transformation",
+          "legacy_header_transformation",
+          "preserve_case_header_transformation"
+        ],
+        "spec.https_auto_cert.http_protocol_options.http_protocol_enable_v1_v2": [
+          "http_protocol_enable_v1_only",
+          "http_protocol_enable_v2_only"
+        ],
+        "spec.https_auto_cert.http_protocol_options.http_protocol_enable_v2_only": [
+          "http_protocol_enable_v1_only",
+          "http_protocol_enable_v1_v2"
+        ],
+        "spec.https_auto_cert.no_mtls": [
+          "use_mtls"
+        ],
+        "spec.https_auto_cert.non_default_loadbalancer": [
+          "default_loadbalancer"
+        ],
+        "spec.https_auto_cert.pass_through": [
+          "append_server_name",
+          "default_header",
+          "server_name"
+        ],
+        "spec.https_auto_cert.port": [
+          "port_ranges"
+        ],
+        "spec.https_auto_cert.port_ranges": [
+          "port"
+        ],
+        "spec.https_auto_cert.server_name": [
+          "append_server_name",
+          "default_header",
+          "pass_through"
+        ],
+        "spec.https_auto_cert.tls_config.custom_security": [
+          "default_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.https_auto_cert.tls_config.default_security": [
+          "custom_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.https_auto_cert.tls_config.low_security": [
+          "custom_security",
+          "default_security",
+          "medium_security"
+        ],
+        "spec.https_auto_cert.tls_config.medium_security": [
+          "custom_security",
+          "default_security",
+          "low_security"
+        ],
+        "spec.https_auto_cert.use_mtls": [
+          "no_mtls"
+        ],
+        "spec.https_auto_cert.use_mtls.crl": [
+          "no_crl"
+        ],
+        "spec.https_auto_cert.use_mtls.no_crl": [
+          "crl"
+        ],
+        "spec.https_auto_cert.use_mtls.trusted_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.https_auto_cert.use_mtls.trusted_ca_url": [
+          "trusted_ca"
+        ],
+        "spec.https_auto_cert.use_mtls.xfcc_disabled": [
+          "xfcc_options"
+        ],
+        "spec.https_auto_cert.use_mtls.xfcc_options": [
+          "xfcc_disabled"
+        ],
+        "spec.js_challenge": [
+          "captcha_challenge",
+          "enable_challenge",
+          "no_challenge",
+          "policy_based_challenge"
+        ],
+        "spec.jwt_validation.action.block": [
+          "report"
+        ],
+        "spec.jwt_validation.action.report": [
+          "block"
+        ],
+        "spec.jwt_validation.reserved_claims.audience": [
+          "audience_disable"
+        ],
+        "spec.jwt_validation.reserved_claims.audience_disable": [
+          "audience"
+        ],
+        "spec.jwt_validation.reserved_claims.issuer": [
+          "issuer_disable"
+        ],
+        "spec.jwt_validation.reserved_claims.issuer_disable": [
+          "issuer"
+        ],
+        "spec.jwt_validation.reserved_claims.validate_period_disable": [
+          "validate_period_enable"
+        ],
+        "spec.jwt_validation.reserved_claims.validate_period_enable": [
+          "validate_period_disable"
+        ],
+        "spec.jwt_validation.target.all_endpoint": [
+          "api_groups",
+          "base_paths"
+        ],
+        "spec.jwt_validation.target.api_groups": [
+          "all_endpoint",
+          "base_paths"
+        ],
+        "spec.jwt_validation.target.base_paths": [
+          "all_endpoint",
+          "api_groups"
+        ],
+        "spec.l7_ddos_action_block": [
+          "l7_ddos_action_default",
+          "l7_ddos_action_js_challenge"
+        ],
+        "spec.l7_ddos_action_default": [
+          "l7_ddos_action_block",
+          "l7_ddos_action_js_challenge"
+        ],
+        "spec.l7_ddos_action_js_challenge": [
+          "l7_ddos_action_block",
+          "l7_ddos_action_default"
+        ],
+        "spec.l7_ddos_protection.clientside_action_captcha_challenge": [
+          "clientside_action_js_challenge",
+          "clientside_action_none"
+        ],
+        "spec.l7_ddos_protection.clientside_action_js_challenge": [
+          "clientside_action_captcha_challenge",
+          "clientside_action_none"
+        ],
+        "spec.l7_ddos_protection.clientside_action_none": [
+          "clientside_action_captcha_challenge",
+          "clientside_action_js_challenge"
+        ],
+        "spec.l7_ddos_protection.ddos_policy_custom": [
+          "ddos_policy_none"
+        ],
+        "spec.l7_ddos_protection.ddos_policy_none": [
+          "ddos_policy_custom"
+        ],
+        "spec.l7_ddos_protection.default_rps_threshold": [
+          "rps_threshold"
+        ],
+        "spec.l7_ddos_protection.mitigation_block": [
+          "mitigation_captcha_challenge",
+          "mitigation_js_challenge"
+        ],
+        "spec.l7_ddos_protection.mitigation_captcha_challenge": [
+          "mitigation_block",
+          "mitigation_js_challenge"
+        ],
+        "spec.l7_ddos_protection.mitigation_js_challenge": [
+          "mitigation_block",
+          "mitigation_captcha_challenge"
+        ],
+        "spec.l7_ddos_protection.rps_threshold": [
+          "default_rps_threshold"
+        ],
+        "spec.least_active": [
+          "cookie_stickiness",
+          "random",
+          "ring_hash",
+          "round_robin",
+          "source_ip_stickiness"
+        ],
+        "spec.malware_protection_settings": [
+          "disable_malware_protection"
+        ],
+        "spec.more_option.disable_path_normalize": [
+          "enable_path_normalize"
+        ],
+        "spec.more_option.enable_path_normalize": [
+          "disable_path_normalize"
+        ],
+        "spec.more_option.max_requests_per_connection": [
+          "no_request_limit_per_connection"
+        ],
+        "spec.more_option.no_request_limit_per_connection": [
+          "max_requests_per_connection"
+        ],
+        "spec.multi_lb_app": [
+          "single_lb_app"
+        ],
+        "spec.no_challenge": [
+          "captcha_challenge",
+          "enable_challenge",
+          "js_challenge",
+          "policy_based_challenge"
+        ],
+        "spec.no_service_policies": [
+          "active_service_policies",
+          "service_policies_from_namespace"
+        ],
+        "spec.policy_based_challenge": [
+          "captcha_challenge",
+          "enable_challenge",
+          "js_challenge",
+          "no_challenge"
+        ],
+        "spec.policy_based_challenge.always_enable_captcha_challenge": [
+          "always_enable_js_challenge",
+          "no_challenge"
+        ],
+        "spec.policy_based_challenge.always_enable_js_challenge": [
+          "always_enable_captcha_challenge",
+          "no_challenge"
+        ],
+        "spec.policy_based_challenge.captcha_challenge_parameters": [
+          "default_captcha_challenge_parameters"
+        ],
+        "spec.policy_based_challenge.default_captcha_challenge_parameters": [
+          "captcha_challenge_parameters"
+        ],
+        "spec.policy_based_challenge.default_js_challenge_parameters": [
+          "js_challenge_parameters"
+        ],
+        "spec.policy_based_challenge.default_mitigation_settings": [
+          "malicious_user_mitigation"
+        ],
+        "spec.policy_based_challenge.default_temporary_blocking_parameters": [
+          "temporary_user_blocking"
+        ],
+        "spec.policy_based_challenge.js_challenge_parameters": [
+          "default_js_challenge_parameters"
+        ],
+        "spec.policy_based_challenge.malicious_user_mitigation": [
+          "default_mitigation_settings"
+        ],
+        "spec.policy_based_challenge.no_challenge": [
+          "always_enable_captcha_challenge",
+          "always_enable_js_challenge"
+        ],
+        "spec.policy_based_challenge.temporary_user_blocking": [
+          "default_temporary_blocking_parameters"
+        ],
+        "spec.random": [
+          "cookie_stickiness",
+          "least_active",
+          "ring_hash",
+          "round_robin",
+          "source_ip_stickiness"
+        ],
+        "spec.rate_limit": [
+          "api_rate_limit",
+          "disable_rate_limit"
+        ],
+        "spec.rate_limit.custom_ip_allowed_list": [
+          "ip_allowed_list",
+          "no_ip_allowed_list"
+        ],
+        "spec.rate_limit.ip_allowed_list": [
+          "custom_ip_allowed_list",
+          "no_ip_allowed_list"
+        ],
+        "spec.rate_limit.no_ip_allowed_list": [
+          "custom_ip_allowed_list",
+          "ip_allowed_list"
+        ],
+        "spec.rate_limit.no_policies": [
+          "policies"
+        ],
+        "spec.rate_limit.policies": [
+          "no_policies"
+        ],
+        "spec.rate_limit.rate_limiter.action_block": [
+          "disabled"
+        ],
+        "spec.rate_limit.rate_limiter.action_block.hours": [
+          "minutes",
+          "seconds"
+        ],
+        "spec.rate_limit.rate_limiter.action_block.minutes": [
+          "hours",
+          "seconds"
+        ],
+        "spec.rate_limit.rate_limiter.action_block.seconds": [
+          "hours",
+          "minutes"
+        ],
+        "spec.rate_limit.rate_limiter.disabled": [
+          "action_block"
+        ],
+        "spec.rate_limit.rate_limiter.leaky_bucket": [
+          "token_bucket"
+        ],
+        "spec.rate_limit.rate_limiter.token_bucket": [
+          "leaky_bucket"
+        ],
+        "spec.ring_hash": [
+          "cookie_stickiness",
+          "least_active",
+          "random",
+          "round_robin",
+          "source_ip_stickiness"
+        ],
+        "spec.round_robin": [
+          "cookie_stickiness",
+          "least_active",
+          "random",
+          "ring_hash",
+          "source_ip_stickiness"
+        ],
+        "spec.sensitive_data_policy": [
+          "default_sensitive_data_policy"
+        ],
+        "spec.service_policies_from_namespace": [
+          "active_service_policies",
+          "no_service_policies"
+        ],
+        "spec.single_lb_app": [
+          "multi_lb_app"
+        ],
+        "spec.single_lb_app.disable_discovery": [
+          "enable_discovery"
+        ],
+        "spec.single_lb_app.disable_malicious_user_detection": [
+          "enable_malicious_user_detection"
+        ],
+        "spec.single_lb_app.enable_discovery": [
+          "disable_discovery"
+        ],
+        "spec.single_lb_app.enable_discovery.api_crawler.api_crawler_config": [
+          "disable_api_crawler"
+        ],
+        "spec.single_lb_app.enable_discovery.api_crawler.disable_api_crawler": [
+          "api_crawler_config"
+        ],
+        "spec.single_lb_app.enable_discovery.custom_api_auth_discovery": [
+          "default_api_auth_discovery"
+        ],
+        "spec.single_lb_app.enable_discovery.default_api_auth_discovery": [
+          "custom_api_auth_discovery"
+        ],
+        "spec.single_lb_app.enable_discovery.disable_learn_from_redirect_traffic": [
+          "enable_learn_from_redirect_traffic"
+        ],
+        "spec.single_lb_app.enable_discovery.enable_learn_from_redirect_traffic": [
+          "disable_learn_from_redirect_traffic"
+        ],
+        "spec.single_lb_app.enable_malicious_user_detection": [
+          "disable_malicious_user_detection"
+        ],
+        "spec.slow_ddos_mitigation": [
+          "system_default_timeouts"
+        ],
+        "spec.slow_ddos_mitigation.disable_request_timeout": [
+          "request_timeout"
+        ],
+        "spec.slow_ddos_mitigation.request_timeout": [
+          "disable_request_timeout"
+        ],
+        "spec.source_ip_stickiness": [
+          "cookie_stickiness",
+          "least_active",
+          "random",
+          "ring_hash",
+          "round_robin"
+        ],
+        "spec.system_default_timeouts": [
+          "slow_ddos_mitigation"
+        ],
+        "spec.user_id_client_ip": [
+          "user_identification"
+        ],
+        "spec.user_identification": [
+          "user_id_client_ip"
+        ],
+        "spec.waf_exclusion.waf_exclusion_inline_rules": [
+          "waf_exclusion_policy"
+        ],
+        "spec.waf_exclusion.waf_exclusion_policy": [
+          "waf_exclusion_inline_rules"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.add_location": false,
+        "spec.default_pool.advanced_options.auto_http_config": {},
+        "spec.default_pool.advanced_options.connection_timeout": 0,
+        "spec.default_pool.advanced_options.default_circuit_breaker": {},
+        "spec.default_pool.advanced_options.disable_outlier_detection": {},
+        "spec.default_pool.advanced_options.disable_subsets": {},
+        "spec.default_pool.advanced_options.http_idle_timeout": 0,
+        "spec.default_pool.advanced_options.no_panic_threshold": {},
+        "spec.default_pool.advanced_options.no_request_limit_per_connection": {},
+        "spec.default_pool.endpoint_selection": "DISTRIBUTED",
+        "spec.default_pool.healthcheck": [],
+        "spec.default_pool.loadbalancer_algorithm": "ROUND_ROBIN",
+        "spec.default_pool.no_tls": {},
+        "spec.default_pool.same_as_endpoint_port": {},
+        "spec.default_pool.use_tls.default_session_key_caching": {},
+        "spec.default_pool.use_tls.no_mtls": {},
+        "spec.default_pool.use_tls.use_host_header_as_sni": {},
+        "spec.default_pool.use_tls.volterra_trusted_ca": {},
+        "spec.default_sensitive_data_policy": {},
+        "spec.disable_api_definition": {},
+        "spec.disable_api_discovery": {},
+        "spec.disable_api_testing": {},
+        "spec.disable_bot_defense": {},
+        "spec.disable_ip_reputation": {},
+        "spec.disable_malicious_user_detection": {},
+        "spec.disable_malware_protection": {},
+        "spec.disable_rate_limit": {},
+        "spec.disable_threat_mesh": {},
+        "spec.disable_trust_client_ip_headers": {},
+        "spec.disable_waf": {},
+        "spec.https_auto_cert.add_hsts": false,
+        "spec.https_auto_cert.connection_idle_timeout": 0,
+        "spec.https_auto_cert.enable_path_normalize": {},
+        "spec.https_auto_cert.http_redirect": false,
+        "spec.https_auto_cert.no_mtls": {},
+        "spec.l7_ddos_protection": {},
+        "spec.no_challenge": {},
+        "spec.rate_limit.no_ip_allowed_list": {},
+        "spec.rate_limit.no_policies": {},
+        "spec.rate_limit.rate_limiter.period_multiplier": 0,
+        "spec.round_robin": {},
+        "spec.service_policies_from_namespace": {},
+        "spec.user_id_client_ip": {}
+      },
+      "minimumConfigFields": [
+        "spec.active_service_policies.policies",
+        "spec.advertise_custom.advertise_where",
+        "spec.advertise_on_public.public_ip.name",
+        "spec.api_rate_limit.custom_ip_allowed_list.rate_limiter_allowed_prefixes",
+        "spec.api_specification.api_definition.name",
+        "spec.api_specification.validation_all_spec_endpoints.fall_through_mode.fall_through_mode_custom.open_api_validation_rules",
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.response_validation_mode_active.response_validation_properties",
+        "spec.api_specification.validation_all_spec_endpoints.validation_mode.validation_mode_active.request_validation_properties",
+        "spec.api_specification.validation_custom_list.fall_through_mode.fall_through_mode_custom.open_api_validation_rules",
+        "spec.api_specification.validation_custom_list.open_api_validation_rules",
+        "spec.api_testing.domains",
+        "spec.app_firewall.name",
+        "spec.bot_defense.policy.js_insertion_rules.rules",
+        "spec.bot_defense.policy.protected_app_endpoints",
+        "spec.bot_defense_advanced.js_insertion_rules.rules",
+        "spec.bot_defense_advanced.mobile.name",
+        "spec.bot_defense_advanced.web.name",
+        "spec.captcha_challenge.cookie_expiry",
+        "spec.client_side_defense.policy.js_insertion_rules.rules",
+        "spec.cookie_stickiness.name",
+        "spec.csrf_policy.custom_domain_list.domains",
+        "spec.default_pool.advanced_options.enable_subsets.endpoint_subsets",
+        "spec.default_pool.origin_servers",
+        "spec.default_pool.use_tls.tls_config.custom_security.cipher_suites",
+        "spec.default_pool.use_tls.use_mtls.tls_certificates",
+        "spec.default_pool.use_tls.use_mtls_obj.name",
+        "spec.default_pool.use_tls.use_server_verification.trusted_ca.name",
+        "spec.default_pool.view_internal.name",
+        "spec.domains",
+        "spec.enable_api_discovery.api_crawler.api_crawler_config.domains",
+        "spec.enable_api_discovery.api_discovery_from_code_scan.code_base_integrations",
+        "spec.enable_api_discovery.custom_api_auth_discovery.api_discovery_ref.name",
+        "spec.enable_api_discovery.discovered_api_settings.purge_duration_for_inactive_discovered_apis",
+        "spec.enable_challenge.captcha_challenge_parameters.cookie_expiry",
+        "spec.enable_challenge.js_challenge_parameters.cookie_expiry",
+        "spec.enable_challenge.js_challenge_parameters.js_script_delay",
+        "spec.enable_challenge.malicious_user_mitigation.name",
+        "spec.enable_ip_reputation.ip_threat_categories",
+        "spec.enable_trust_client_ip_headers.client_ip_headers",
+        "spec.https.tls_cert_params.certificates",
+        "spec.https.tls_cert_params.tls_config.custom_security.cipher_suites",
+        "spec.https.tls_cert_params.use_mtls.crl.name",
+        "spec.https.tls_cert_params.use_mtls.trusted_ca.name",
+        "spec.https.tls_cert_params.use_mtls.xfcc_options.xfcc_header_elements",
+        "spec.https.tls_parameters.tls_certificates",
+        "spec.https.tls_parameters.tls_config.custom_security.cipher_suites",
+        "spec.https.tls_parameters.use_mtls.crl.name",
+        "spec.https.tls_parameters.use_mtls.trusted_ca.name",
+        "spec.https.tls_parameters.use_mtls.xfcc_options.xfcc_header_elements",
+        "spec.https_auto_cert.tls_config.custom_security.cipher_suites",
+        "spec.https_auto_cert.use_mtls.crl.name",
+        "spec.https_auto_cert.use_mtls.trusted_ca.name",
+        "spec.https_auto_cert.use_mtls.xfcc_options.xfcc_header_elements",
+        "spec.js_challenge.cookie_expiry",
+        "spec.js_challenge.js_script_delay",
+        "spec.jwt_validation.authorization_server.authorization_servers",
+        "spec.jwt_validation.reserved_claims.audience.audiences",
+        "spec.jwt_validation.target.api_groups.api_groups",
+        "spec.jwt_validation.target.base_paths.base_paths",
+        "spec.l7_ddos_action_js_challenge.cookie_expiry",
+        "spec.l7_ddos_action_js_challenge.js_script_delay",
+        "spec.l7_ddos_protection.clientside_action_captcha_challenge.cookie_expiry",
+        "spec.l7_ddos_protection.clientside_action_js_challenge.cookie_expiry",
+        "spec.l7_ddos_protection.clientside_action_js_challenge.js_script_delay",
+        "spec.l7_ddos_protection.ddos_policy_custom.name",
+        "spec.l7_ddos_protection.mitigation_captcha_challenge.cookie_expiry",
+        "spec.l7_ddos_protection.mitigation_js_challenge.cookie_expiry",
+        "spec.l7_ddos_protection.mitigation_js_challenge.js_script_delay",
+        "spec.malware_protection_settings.malware_protection_rules",
+        "spec.more_option.compression_params.content_length",
+        "spec.policy_based_challenge.captcha_challenge_parameters.cookie_expiry",
+        "spec.policy_based_challenge.js_challenge_parameters.cookie_expiry",
+        "spec.policy_based_challenge.js_challenge_parameters.js_script_delay",
+        "spec.policy_based_challenge.malicious_user_mitigation.name",
+        "spec.rate_limit.custom_ip_allowed_list.rate_limiter_allowed_prefixes",
+        "spec.rate_limit.policies.policies",
+        "spec.rate_limit.rate_limiter.total_number",
+        "spec.ring_hash.hash_policy",
+        "spec.sensitive_data_policy.sensitive_data_policy_ref.name",
+        "spec.single_lb_app.enable_discovery.api_crawler.api_crawler_config.domains",
+        "spec.single_lb_app.enable_discovery.api_discovery_from_code_scan.code_base_integrations",
+        "spec.single_lb_app.enable_discovery.custom_api_auth_discovery.api_discovery_ref.name",
+        "spec.single_lb_app.enable_discovery.discovered_api_settings.purge_duration_for_inactive_discovered_apis",
+        "spec.slow_ddos_mitigation.request_headers_timeout",
+        "spec.user_identification.name",
+        "spec.waf_exclusion.waf_exclusion_policy.name"
+      ],
+      "serverDefaultFields": [
+        "spec.add_location",
+        "spec.default_pool.advanced_options.auto_http_config",
+        "spec.default_pool.advanced_options.connection_timeout",
+        "spec.default_pool.advanced_options.default_circuit_breaker",
+        "spec.default_pool.advanced_options.disable_outlier_detection",
+        "spec.default_pool.advanced_options.disable_subsets",
+        "spec.default_pool.advanced_options.http_idle_timeout",
+        "spec.default_pool.advanced_options.no_panic_threshold",
+        "spec.default_pool.advanced_options.no_request_limit_per_connection",
+        "spec.default_pool.endpoint_selection",
+        "spec.default_pool.healthcheck",
+        "spec.default_pool.loadbalancer_algorithm",
+        "spec.default_pool.no_tls",
+        "spec.default_pool.same_as_endpoint_port",
+        "spec.default_pool.use_tls.default_session_key_caching",
+        "spec.default_pool.use_tls.no_mtls",
+        "spec.default_pool.use_tls.use_host_header_as_sni",
+        "spec.default_pool.use_tls.volterra_trusted_ca",
+        "spec.default_sensitive_data_policy",
+        "spec.disable_api_definition",
+        "spec.disable_api_discovery",
+        "spec.disable_api_testing",
+        "spec.disable_bot_defense",
+        "spec.disable_ip_reputation",
+        "spec.disable_malicious_user_detection",
+        "spec.disable_malware_protection",
+        "spec.disable_rate_limit",
+        "spec.disable_threat_mesh",
+        "spec.disable_trust_client_ip_headers",
+        "spec.disable_waf",
+        "spec.https_auto_cert.add_hsts",
+        "spec.https_auto_cert.connection_idle_timeout",
+        "spec.https_auto_cert.enable_path_normalize",
+        "spec.https_auto_cert.http_redirect",
+        "spec.https_auto_cert.no_mtls",
+        "spec.l7_ddos_protection",
+        "spec.no_challenge",
+        "spec.rate_limit.no_ip_allowed_list",
+        "spec.rate_limit.no_policies",
+        "spec.rate_limit.rate_limiter.period_multiplier",
+        "spec.round_robin",
+        "spec.service_policies_from_namespace",
+        "spec.user_id_client_ip"
+      ]
+    },
+    "k8s_cluster": {
+      "fieldConflicts": {
+        "spec.cluster_scoped_access_deny": [
+          "cluster_scoped_access_permit"
+        ],
+        "spec.cluster_scoped_access_permit": [
+          "cluster_scoped_access_deny"
+        ],
+        "spec.cluster_wide_app_list": [
+          "no_cluster_wide_apps"
+        ],
+        "spec.global_access_enable": [
+          "no_global_access"
+        ],
+        "spec.insecure_registry_list": [
+          "no_insecure_registries"
+        ],
+        "spec.local_access_config": [
+          "no_local_access"
+        ],
+        "spec.local_access_config.default_port": [
+          "port"
+        ],
+        "spec.local_access_config.port": [
+          "default_port"
+        ],
+        "spec.no_cluster_wide_apps": [
+          "cluster_wide_app_list"
+        ],
+        "spec.no_global_access": [
+          "global_access_enable"
+        ],
+        "spec.no_insecure_registries": [
+          "insecure_registry_list"
+        ],
+        "spec.no_local_access": [
+          "local_access_config"
+        ],
+        "spec.use_custom_cluster_role_bindings": [
+          "use_default_cluster_role_bindings"
+        ],
+        "spec.use_custom_cluster_role_list": [
+          "use_default_cluster_roles"
+        ],
+        "spec.use_custom_pod_security_admission": [
+          "use_default_pod_security_admission"
+        ],
+        "spec.use_custom_psp_list": [
+          "use_default_psp"
+        ],
+        "spec.use_default_cluster_role_bindings": [
+          "use_custom_cluster_role_bindings"
+        ],
+        "spec.use_default_cluster_roles": [
+          "use_custom_cluster_role_list"
+        ],
+        "spec.use_default_pod_security_admission": [
+          "use_custom_pod_security_admission"
+        ],
+        "spec.use_default_psp": [
+          "use_custom_psp_list"
+        ],
+        "spec.vk8s_namespace_access_deny": [
+          "vk8s_namespace_access_permit"
+        ],
+        "spec.vk8s_namespace_access_permit": [
+          "vk8s_namespace_access_deny"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.cluster_scoped_access_deny": {},
+        "spec.no_cluster_wide_apps": {},
+        "spec.no_global_access": {},
+        "spec.no_insecure_registries": {},
+        "spec.no_local_access": {},
+        "spec.use_default_cluster_role_bindings": {},
+        "spec.use_default_cluster_roles": {},
+        "spec.use_default_psp": {},
+        "spec.vk8s_namespace_access_deny": {}
+      },
+      "minimumConfigFields": [
+        "spec.cluster_wide_app_list.cluster_wide_apps",
+        "spec.insecure_registry_list.insecure_registries",
+        "spec.local_access_config.local_domain",
+        "spec.use_custom_cluster_role_bindings.cluster_role_bindings",
+        "spec.use_custom_cluster_role_list.cluster_roles",
+        "spec.use_custom_pod_security_admission.name",
+        "spec.use_custom_psp_list.pod_security_policies"
+      ],
+      "serverDefaultFields": [
+        "spec.cluster_scoped_access_deny",
+        "spec.no_cluster_wide_apps",
+        "spec.no_global_access",
+        "spec.no_insecure_registries",
+        "spec.no_local_access",
+        "spec.use_default_cluster_role_bindings",
+        "spec.use_default_cluster_roles",
+        "spec.use_default_psp",
+        "spec.vk8s_namespace_access_deny"
+      ]
+    },
+    "malicious_user_mitigation": {
+      "fieldConflicts": {},
+      "fieldDefaults": {
+        "spec.mitigation_type": null
+      },
+      "minimumConfigFields": [
+        "spec.mitigation_type.rules"
+      ],
+      "serverDefaultFields": [
+        "spec.mitigation_type"
+      ]
+    },
+    "network_firewall": {
+      "fieldConflicts": {
+        "spec.active_enhanced_firewall_policies": [
+          "active_network_policies",
+          "disable_network_policy"
+        ],
+        "spec.active_fast_acls": [
+          "disable_fast_acl"
+        ],
+        "spec.active_forward_proxy_policies": [
+          "disable_forward_proxy_policy"
+        ],
+        "spec.active_network_policies": [
+          "active_enhanced_firewall_policies",
+          "disable_network_policy"
+        ],
+        "spec.disable_fast_acl": [
+          "active_fast_acls"
+        ],
+        "spec.disable_forward_proxy_policy": [
+          "active_forward_proxy_policies"
+        ],
+        "spec.disable_network_policy": [
+          "active_enhanced_firewall_policies",
+          "active_network_policies"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.disable_fast_acl": {},
+        "spec.disable_forward_proxy_policy": {},
+        "spec.disable_network_policy": {}
+      },
+      "minimumConfigFields": [
+        "spec.active_enhanced_firewall_policies.enhanced_firewall_policies",
+        "spec.active_fast_acls.fast_acls",
+        "spec.active_forward_proxy_policies.forward_proxy_policies",
+        "spec.active_network_policies.network_policies"
+      ],
+      "serverDefaultFields": [
+        "spec.disable_fast_acl",
+        "spec.disable_forward_proxy_policy",
+        "spec.disable_network_policy"
+      ]
+    },
+    "network_policy": {
+      "fieldConflicts": {
+        "spec.ip_prefix_set": [
+          "prefix",
+          "prefix_selector"
+        ],
+        "spec.prefix": [
+          "ip_prefix_set",
+          "prefix_selector"
+        ],
+        "spec.prefix_selector": [
+          "ip_prefix_set",
+          "prefix"
+        ]
+      },
+      "fieldDefaults": {},
+      "minimumConfigFields": [
+        "spec.prefix_selector.expressions"
+      ],
+      "serverDefaultFields": []
+    },
+    "origin_pool": {
+      "fieldConflicts": {
+        "spec.advanced_options.auto_http_config": [
+          "http1_config",
+          "http2_options"
+        ],
+        "spec.advanced_options.circuit_breaker": [
+          "default_circuit_breaker",
+          "disable_circuit_breaker"
+        ],
+        "spec.advanced_options.default_circuit_breaker": [
+          "circuit_breaker",
+          "disable_circuit_breaker"
+        ],
+        "spec.advanced_options.disable_circuit_breaker": [
+          "circuit_breaker",
+          "default_circuit_breaker"
+        ],
+        "spec.advanced_options.disable_lb_source_ip_persistance": [
+          "enable_lb_source_ip_persistance"
+        ],
+        "spec.advanced_options.disable_outlier_detection": [
+          "outlier_detection"
+        ],
+        "spec.advanced_options.disable_proxy_protocol": [
+          "proxy_protocol_v1",
+          "proxy_protocol_v2"
+        ],
+        "spec.advanced_options.disable_subsets": [
+          "enable_subsets"
+        ],
+        "spec.advanced_options.enable_lb_source_ip_persistance": [
+          "disable_lb_source_ip_persistance"
+        ],
+        "spec.advanced_options.enable_subsets": [
+          "disable_subsets"
+        ],
+        "spec.advanced_options.enable_subsets.any_endpoint": [
+          "default_subset",
+          "fail_request"
+        ],
+        "spec.advanced_options.enable_subsets.default_subset": [
+          "any_endpoint",
+          "fail_request"
+        ],
+        "spec.advanced_options.enable_subsets.fail_request": [
+          "any_endpoint",
+          "default_subset"
+        ],
+        "spec.advanced_options.http1_config": [
+          "auto_http_config",
+          "http2_options"
+        ],
+        "spec.advanced_options.http1_config.header_transformation.default_header_transformation": [
+          "legacy_header_transformation",
+          "preserve_case_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.advanced_options.http1_config.header_transformation.legacy_header_transformation": [
+          "default_header_transformation",
+          "preserve_case_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.advanced_options.http1_config.header_transformation.preserve_case_header_transformation": [
+          "default_header_transformation",
+          "legacy_header_transformation",
+          "proper_case_header_transformation"
+        ],
+        "spec.advanced_options.http1_config.header_transformation.proper_case_header_transformation": [
+          "default_header_transformation",
+          "legacy_header_transformation",
+          "preserve_case_header_transformation"
+        ],
+        "spec.advanced_options.http2_options": [
+          "auto_http_config",
+          "http1_config"
+        ],
+        "spec.advanced_options.max_requests_per_connection": [
+          "no_request_limit_per_connection"
+        ],
+        "spec.advanced_options.no_panic_threshold": [
+          "panic_threshold"
+        ],
+        "spec.advanced_options.no_request_limit_per_connection": [
+          "max_requests_per_connection"
+        ],
+        "spec.advanced_options.outlier_detection": [
+          "disable_outlier_detection"
+        ],
+        "spec.advanced_options.panic_threshold": [
+          "no_panic_threshold"
+        ],
+        "spec.advanced_options.proxy_protocol_v1": [
+          "disable_proxy_protocol",
+          "proxy_protocol_v2"
+        ],
+        "spec.advanced_options.proxy_protocol_v2": [
+          "disable_proxy_protocol",
+          "proxy_protocol_v1"
+        ],
+        "spec.automatic_port": [
+          "lb_port",
+          "port"
+        ],
+        "spec.health_check_port": [
+          "same_as_endpoint_port"
+        ],
+        "spec.lb_port": [
+          "automatic_port",
+          "port"
+        ],
+        "spec.no_tls": [
+          "use_tls"
+        ],
+        "spec.port": [
+          "automatic_port",
+          "lb_port"
+        ],
+        "spec.same_as_endpoint_port": [
+          "health_check_port"
+        ],
+        "spec.upstream_conn_pool_reuse_type.disable_conn_pool_reuse": [
+          "enable_conn_pool_reuse"
+        ],
+        "spec.upstream_conn_pool_reuse_type.enable_conn_pool_reuse": [
+          "disable_conn_pool_reuse"
+        ],
+        "spec.use_tls": [
+          "no_tls"
+        ],
+        "spec.use_tls.default_session_key_caching": [
+          "disable_session_key_caching",
+          "max_session_keys"
+        ],
+        "spec.use_tls.disable_session_key_caching": [
+          "default_session_key_caching",
+          "max_session_keys"
+        ],
+        "spec.use_tls.disable_sni": [
+          "sni",
+          "use_host_header_as_sni"
+        ],
+        "spec.use_tls.max_session_keys": [
+          "default_session_key_caching",
+          "disable_session_key_caching"
+        ],
+        "spec.use_tls.no_mtls": [
+          "use_mtls",
+          "use_mtls_obj"
+        ],
+        "spec.use_tls.skip_server_verification": [
+          "use_server_verification",
+          "volterra_trusted_ca"
+        ],
+        "spec.use_tls.sni": [
+          "disable_sni",
+          "use_host_header_as_sni"
+        ],
+        "spec.use_tls.tls_config.custom_security": [
+          "default_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.use_tls.tls_config.default_security": [
+          "custom_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.use_tls.tls_config.low_security": [
+          "custom_security",
+          "default_security",
+          "medium_security"
+        ],
+        "spec.use_tls.tls_config.medium_security": [
+          "custom_security",
+          "default_security",
+          "low_security"
+        ],
+        "spec.use_tls.use_host_header_as_sni": [
+          "disable_sni",
+          "sni"
+        ],
+        "spec.use_tls.use_mtls": [
+          "no_mtls",
+          "use_mtls_obj"
+        ],
+        "spec.use_tls.use_mtls_obj": [
+          "no_mtls",
+          "use_mtls"
+        ],
+        "spec.use_tls.use_server_verification": [
+          "skip_server_verification",
+          "volterra_trusted_ca"
+        ],
+        "spec.use_tls.use_server_verification.trusted_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.use_tls.use_server_verification.trusted_ca_url": [
+          "trusted_ca"
+        ],
+        "spec.use_tls.volterra_trusted_ca": [
+          "skip_server_verification",
+          "use_server_verification"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.advanced_options.auto_http_config": {},
+        "spec.advanced_options.connection_timeout": 0,
+        "spec.advanced_options.default_circuit_breaker": {},
+        "spec.advanced_options.disable_outlier_detection": {},
+        "spec.advanced_options.disable_subsets": {},
+        "spec.advanced_options.http_idle_timeout": 0,
+        "spec.advanced_options.no_panic_threshold": {},
+        "spec.advanced_options.no_request_limit_per_connection": {},
+        "spec.endpoint_selection": "DISTRIBUTED",
+        "spec.healthcheck": [],
+        "spec.loadbalancer_algorithm": "ROUND_ROBIN",
+        "spec.no_tls": {},
+        "spec.same_as_endpoint_port": {},
+        "spec.use_tls.default_session_key_caching": {},
+        "spec.use_tls.no_mtls": {},
+        "spec.use_tls.use_host_header_as_sni": {},
+        "spec.use_tls.volterra_trusted_ca": {}
+      },
+      "minimumConfigFields": [
+        "spec.advanced_options.enable_subsets.endpoint_subsets",
+        "spec.origin_servers",
+        "spec.use_tls.tls_config.custom_security.cipher_suites",
+        "spec.use_tls.use_mtls.tls_certificates",
+        "spec.use_tls.use_mtls_obj.name",
+        "spec.use_tls.use_server_verification.trusted_ca.name",
+        "spec.view_internal.name"
+      ],
+      "serverDefaultFields": [
+        "spec.advanced_options.auto_http_config",
+        "spec.advanced_options.connection_timeout",
+        "spec.advanced_options.default_circuit_breaker",
+        "spec.advanced_options.disable_outlier_detection",
+        "spec.advanced_options.disable_subsets",
+        "spec.advanced_options.http_idle_timeout",
+        "spec.advanced_options.no_panic_threshold",
+        "spec.advanced_options.no_request_limit_per_connection",
+        "spec.endpoint_selection",
+        "spec.healthcheck",
+        "spec.loadbalancer_algorithm",
+        "spec.no_tls",
+        "spec.same_as_endpoint_port",
+        "spec.use_tls.default_session_key_caching",
+        "spec.use_tls.no_mtls",
+        "spec.use_tls.use_host_header_as_sni",
+        "spec.use_tls.volterra_trusted_ca"
+      ]
+    },
+    "policer": {
+      "fieldConflicts": {},
+      "fieldDefaults": {
+        "spec.policer_mode": "POLICER_MODE_NOT_SHARED",
+        "spec.policer_type": "POLICER_SINGLE_RATE_TWO_COLOR"
+      },
+      "minimumConfigFields": [
+        "spec.burst_size",
+        "spec.committed_information_rate"
+      ],
+      "serverDefaultFields": [
+        "spec.policer_mode",
+        "spec.policer_type"
+      ]
+    },
+    "protocol_inspection": {
+      "fieldConflicts": {
+        "spec.enable_disable_compliance_checks.disable_compliance_checks": [
+          "enable_compliance_checks"
+        ],
+        "spec.enable_disable_compliance_checks.enable_compliance_checks": [
+          "disable_compliance_checks"
+        ],
+        "spec.enable_disable_signatures.disable_signature": [
+          "enable_signature"
+        ],
+        "spec.enable_disable_signatures.enable_signature": [
+          "disable_signature"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.action": "ALLOW"
+      },
+      "minimumConfigFields": [
+        "spec.enable_disable_compliance_checks.enable_compliance_checks.name"
+      ],
+      "serverDefaultFields": [
+        "spec.action"
+      ]
+    },
+    "rate_limiter": {
+      "fieldConflicts": {},
+      "fieldDefaults": {
+        "spec.user_identification": []
+      },
+      "minimumConfigFields": [],
+      "serverDefaultFields": [
+        "spec.user_identification"
+      ]
+    },
+    "rate_limiter_policy": {
+      "fieldConflicts": {
+        "spec.any_server": [
+          "server_name",
+          "server_name_matcher",
+          "server_selector"
+        ],
+        "spec.server_name": [
+          "any_server",
+          "server_name_matcher",
+          "server_selector"
+        ],
+        "spec.server_name_matcher": [
+          "any_server",
+          "server_name",
+          "server_selector"
+        ],
+        "spec.server_selector": [
+          "any_server",
+          "server_name",
+          "server_name_matcher"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.rules": []
+      },
+      "minimumConfigFields": [
+        "spec.server_selector.expressions"
+      ],
+      "serverDefaultFields": [
+        "spec.rules"
+      ]
+    },
+    "securemesh_site_v2": {
+      "fieldConflicts": {
+        "spec.active_enhanced_firewall_policies": [
+          "no_network_policy"
+        ],
+        "spec.active_forward_proxy_policies": [
+          "no_forward_proxy"
+        ],
+        "spec.admin_user_credentials.admin_password.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.admin_user_credentials.admin_password.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.aws": [
+          "azure",
+          "baremetal",
+          "equinix",
+          "gcp",
+          "kvm",
+          "nutanix",
+          "oci",
+          "openstack",
+          "vmware"
+        ],
+        "spec.azure": [
+          "aws",
+          "baremetal",
+          "equinix",
+          "gcp",
+          "kvm",
+          "nutanix",
+          "oci",
+          "openstack",
+          "vmware"
+        ],
+        "spec.baremetal": [
+          "aws",
+          "azure",
+          "equinix",
+          "gcp",
+          "kvm",
+          "nutanix",
+          "oci",
+          "openstack",
+          "vmware"
+        ],
+        "spec.block_all_services": [
+          "blocked_services"
+        ],
+        "spec.blocked_services": [
+          "block_all_services"
+        ],
+        "spec.custom_proxy": [
+          "f5_proxy"
+        ],
+        "spec.custom_proxy.disable_re_tunnel": [
+          "enable_re_tunnel"
+        ],
+        "spec.custom_proxy.enable_re_tunnel": [
+          "disable_re_tunnel"
+        ],
+        "spec.custom_proxy.password.blindfold_secret_info": [
+          "clear_secret_info"
+        ],
+        "spec.custom_proxy.password.clear_secret_info": [
+          "blindfold_secret_info"
+        ],
+        "spec.custom_proxy_bypass": [
+          "no_proxy_bypass"
+        ],
+        "spec.dc_cluster_group_sli": [
+          "no_s2s_connectivity_sli"
+        ],
+        "spec.dc_cluster_group_slo": [
+          "no_s2s_connectivity_slo",
+          "site_mesh_group_on_slo"
+        ],
+        "spec.disable_ha": [
+          "enable_ha"
+        ],
+        "spec.disable_management_network": [
+          "enable_management_network"
+        ],
+        "spec.disable_url_categorization": [
+          "enable_url_categorization"
+        ],
+        "spec.dns_ntp_config.custom_dns": [
+          "f5_dns_default"
+        ],
+        "spec.dns_ntp_config.custom_ntp": [
+          "f5_ntp_default"
+        ],
+        "spec.dns_ntp_config.f5_dns_default": [
+          "custom_dns"
+        ],
+        "spec.dns_ntp_config.f5_ntp_default": [
+          "custom_ntp"
+        ],
+        "spec.enable_ha": [
+          "disable_ha"
+        ],
+        "spec.enable_management_network": [
+          "disable_management_network"
+        ],
+        "spec.enable_url_categorization": [
+          "disable_url_categorization"
+        ],
+        "spec.equinix": [
+          "aws",
+          "azure",
+          "baremetal",
+          "gcp",
+          "kvm",
+          "nutanix",
+          "oci",
+          "openstack",
+          "vmware"
+        ],
+        "spec.f5_proxy": [
+          "custom_proxy"
+        ],
+        "spec.gcp": [
+          "aws",
+          "azure",
+          "baremetal",
+          "equinix",
+          "kvm",
+          "nutanix",
+          "oci",
+          "openstack",
+          "vmware"
+        ],
+        "spec.kvm": [
+          "aws",
+          "azure",
+          "baremetal",
+          "equinix",
+          "gcp",
+          "nutanix",
+          "oci",
+          "openstack",
+          "vmware"
+        ],
+        "spec.local_vrf.default_config": [
+          "slo_config"
+        ],
+        "spec.local_vrf.default_sli_config": [
+          "sli_config"
+        ],
+        "spec.local_vrf.sli_config": [
+          "default_sli_config"
+        ],
+        "spec.local_vrf.sli_config.no_static_routes": [
+          "static_routes"
+        ],
+        "spec.local_vrf.sli_config.no_v6_static_routes": [
+          "static_v6_routes"
+        ],
+        "spec.local_vrf.sli_config.static_routes": [
+          "no_static_routes"
+        ],
+        "spec.local_vrf.sli_config.static_v6_routes": [
+          "no_v6_static_routes"
+        ],
+        "spec.local_vrf.slo_config": [
+          "default_config"
+        ],
+        "spec.local_vrf.slo_config.no_static_routes": [
+          "static_routes"
+        ],
+        "spec.local_vrf.slo_config.no_v6_static_routes": [
+          "static_v6_routes"
+        ],
+        "spec.local_vrf.slo_config.static_routes": [
+          "no_static_routes"
+        ],
+        "spec.local_vrf.slo_config.static_v6_routes": [
+          "no_v6_static_routes"
+        ],
+        "spec.log_receiver": [
+          "logs_streaming_disabled"
+        ],
+        "spec.log_receiver_with_net.use_management_network": [
+          "use_slo_sli"
+        ],
+        "spec.log_receiver_with_net.use_slo_sli": [
+          "use_management_network"
+        ],
+        "spec.logs_streaming_disabled": [
+          "log_receiver"
+        ],
+        "spec.no_forward_proxy": [
+          "active_forward_proxy_policies"
+        ],
+        "spec.no_network_policy": [
+          "active_enhanced_firewall_policies"
+        ],
+        "spec.no_proxy_bypass": [
+          "custom_proxy_bypass"
+        ],
+        "spec.no_s2s_connectivity_sli": [
+          "dc_cluster_group_sli"
+        ],
+        "spec.no_s2s_connectivity_slo": [
+          "dc_cluster_group_slo",
+          "site_mesh_group_on_slo"
+        ],
+        "spec.nutanix": [
+          "aws",
+          "azure",
+          "baremetal",
+          "equinix",
+          "gcp",
+          "kvm",
+          "oci",
+          "openstack",
+          "vmware"
+        ],
+        "spec.oci": [
+          "aws",
+          "azure",
+          "baremetal",
+          "equinix",
+          "gcp",
+          "kvm",
+          "nutanix",
+          "openstack",
+          "vmware"
+        ],
+        "spec.offline_survivability_mode.enable_offline_survivability_mode": [
+          "no_offline_survivability_mode"
+        ],
+        "spec.offline_survivability_mode.no_offline_survivability_mode": [
+          "enable_offline_survivability_mode"
+        ],
+        "spec.openstack": [
+          "aws",
+          "azure",
+          "baremetal",
+          "equinix",
+          "gcp",
+          "kvm",
+          "nutanix",
+          "oci",
+          "vmware"
+        ],
+        "spec.performance_enhancement_mode.perf_mode_l3_enhanced": [
+          "perf_mode_l7_enhanced"
+        ],
+        "spec.performance_enhancement_mode.perf_mode_l3_enhanced.jumbo": [
+          "no_jumbo"
+        ],
+        "spec.performance_enhancement_mode.perf_mode_l3_enhanced.no_jumbo": [
+          "jumbo"
+        ],
+        "spec.performance_enhancement_mode.perf_mode_l7_enhanced": [
+          "perf_mode_l3_enhanced"
+        ],
+        "spec.re_select.geo_proximity": [
+          "specific_re"
+        ],
+        "spec.re_select.specific_re": [
+          "geo_proximity"
+        ],
+        "spec.site_mesh_group_on_slo": [
+          "dc_cluster_group_slo",
+          "no_s2s_connectivity_slo"
+        ],
+        "spec.site_mesh_group_on_slo.no_site_mesh_group": [
+          "site_mesh_group"
+        ],
+        "spec.site_mesh_group_on_slo.site_mesh_group": [
+          "no_site_mesh_group"
+        ],
+        "spec.site_mesh_group_on_slo.sm_connection_public_ip": [
+          "sm_connection_pvt_ip"
+        ],
+        "spec.site_mesh_group_on_slo.sm_connection_pvt_ip": [
+          "sm_connection_public_ip"
+        ],
+        "spec.software_settings.os.default_os_version": [
+          "operating_system_version"
+        ],
+        "spec.software_settings.os.operating_system_version": [
+          "default_os_version"
+        ],
+        "spec.software_settings.sw.default_sw_version": [
+          "volterra_software_version"
+        ],
+        "spec.software_settings.sw.volterra_software_version": [
+          "default_sw_version"
+        ],
+        "spec.upgrade_settings.kubernetes_upgrade_drain.disable_upgrade_drain": [
+          "enable_upgrade_drain"
+        ],
+        "spec.upgrade_settings.kubernetes_upgrade_drain.enable_upgrade_drain": [
+          "disable_upgrade_drain"
+        ],
+        "spec.upgrade_settings.kubernetes_upgrade_drain.enable_upgrade_drain.disable_vega_upgrade_mode": [
+          "enable_vega_upgrade_mode"
+        ],
+        "spec.upgrade_settings.kubernetes_upgrade_drain.enable_upgrade_drain.enable_vega_upgrade_mode": [
+          "disable_vega_upgrade_mode"
+        ],
+        "spec.vmware": [
+          "aws",
+          "azure",
+          "baremetal",
+          "equinix",
+          "gcp",
+          "kvm",
+          "nutanix",
+          "oci",
+          "openstack"
+        ]
+      },
+      "fieldDefaults": {},
+      "minimumConfigFields": [
+        "spec.active_enhanced_firewall_policies.enhanced_firewall_policies",
+        "spec.active_forward_proxy_policies.forward_proxy_policies",
+        "spec.admin_user_credentials.admin_password.blindfold_secret_info.location",
+        "spec.admin_user_credentials.admin_password.clear_secret_info.url",
+        "spec.custom_proxy.password.blindfold_secret_info.location",
+        "spec.custom_proxy.password.clear_secret_info.url",
+        "spec.custom_proxy.proxy_ip_address",
+        "spec.custom_proxy.proxy_port",
+        "spec.dc_cluster_group_sli.name",
+        "spec.dc_cluster_group_slo.name",
+        "spec.local_vrf.sli_config.static_routes.static_routes",
+        "spec.local_vrf.sli_config.static_v6_routes.static_routes",
+        "spec.local_vrf.slo_config.static_routes.static_routes",
+        "spec.local_vrf.slo_config.static_v6_routes.static_routes",
+        "spec.log_receiver.name",
+        "spec.log_receiver_with_net.log_receiver.name",
+        "spec.site_mesh_group_on_slo.site_mesh_group.name",
+        "spec.upgrade_settings.kubernetes_upgrade_drain.enable_upgrade_drain.drain_node_timeout"
+      ],
+      "serverDefaultFields": []
+    },
+    "sensitive_data_policy": {
+      "fieldConflicts": {},
+      "fieldDefaults": {
+        "spec.compliances": [],
+        "spec.custom_data_types": [],
+        "spec.disabled_predefined_data_types": []
+      },
+      "minimumConfigFields": [],
+      "serverDefaultFields": [
+        "spec.compliances",
+        "spec.custom_data_types",
+        "spec.disabled_predefined_data_types"
+      ]
+    },
+    "service_policy": {
+      "fieldConflicts": {
+        "spec.any_asn": [
+          "asn_list",
+          "asn_matcher"
+        ],
+        "spec.any_client": [
+          "client_name",
+          "client_name_matcher",
+          "client_selector",
+          "ip_threat_category_list"
+        ],
+        "spec.any_ip": [
+          "ip_matcher",
+          "ip_prefix_list"
+        ],
+        "spec.asn_list": [
+          "any_asn",
+          "asn_matcher"
+        ],
+        "spec.asn_matcher": [
+          "any_asn",
+          "asn_list"
+        ],
+        "spec.bot_action.bot_skip_processing": [
+          "none"
+        ],
+        "spec.bot_action.none": [
+          "bot_skip_processing"
+        ],
+        "spec.client_name": [
+          "any_client",
+          "client_name_matcher",
+          "client_selector",
+          "ip_threat_category_list"
+        ],
+        "spec.client_name_matcher": [
+          "any_client",
+          "client_name",
+          "client_selector",
+          "ip_threat_category_list"
+        ],
+        "spec.client_selector": [
+          "any_client",
+          "client_name",
+          "client_name_matcher",
+          "ip_threat_category_list"
+        ],
+        "spec.ip_matcher": [
+          "any_ip",
+          "ip_prefix_list"
+        ],
+        "spec.ip_prefix_list": [
+          "any_ip",
+          "ip_matcher"
+        ],
+        "spec.ip_threat_category_list": [
+          "any_client",
+          "client_name",
+          "client_name_matcher",
+          "client_selector"
+        ],
+        "spec.ja4_tls_fingerprint": [
+          "tls_fingerprint_matcher"
+        ],
+        "spec.mum_action.default": [
+          "skip_processing"
+        ],
+        "spec.mum_action.skip_processing": [
+          "default"
+        ],
+        "spec.request_constraints.max_cookie_count_exceeds": [
+          "max_cookie_count_none"
+        ],
+        "spec.request_constraints.max_cookie_count_none": [
+          "max_cookie_count_exceeds"
+        ],
+        "spec.request_constraints.max_cookie_key_size_exceeds": [
+          "max_cookie_key_size_none"
+        ],
+        "spec.request_constraints.max_cookie_key_size_none": [
+          "max_cookie_key_size_exceeds"
+        ],
+        "spec.request_constraints.max_cookie_value_size_exceeds": [
+          "max_cookie_value_size_none"
+        ],
+        "spec.request_constraints.max_cookie_value_size_none": [
+          "max_cookie_value_size_exceeds"
+        ],
+        "spec.request_constraints.max_header_count_exceeds": [
+          "max_header_count_none"
+        ],
+        "spec.request_constraints.max_header_count_none": [
+          "max_header_count_exceeds"
+        ],
+        "spec.request_constraints.max_header_key_size_exceeds": [
+          "max_header_key_size_none"
+        ],
+        "spec.request_constraints.max_header_key_size_none": [
+          "max_header_key_size_exceeds"
+        ],
+        "spec.request_constraints.max_header_value_size_exceeds": [
+          "max_header_value_size_none"
+        ],
+        "spec.request_constraints.max_header_value_size_none": [
+          "max_header_value_size_exceeds"
+        ],
+        "spec.request_constraints.max_parameter_count_exceeds": [
+          "max_parameter_count_none"
+        ],
+        "spec.request_constraints.max_parameter_count_none": [
+          "max_parameter_count_exceeds"
+        ],
+        "spec.request_constraints.max_parameter_name_size_exceeds": [
+          "max_parameter_name_size_none"
+        ],
+        "spec.request_constraints.max_parameter_name_size_none": [
+          "max_parameter_name_size_exceeds"
+        ],
+        "spec.request_constraints.max_parameter_value_size_exceeds": [
+          "max_parameter_value_size_none"
+        ],
+        "spec.request_constraints.max_parameter_value_size_none": [
+          "max_parameter_value_size_exceeds"
+        ],
+        "spec.request_constraints.max_query_size_exceeds": [
+          "max_query_size_none"
+        ],
+        "spec.request_constraints.max_query_size_none": [
+          "max_query_size_exceeds"
+        ],
+        "spec.request_constraints.max_request_line_size_exceeds": [
+          "max_request_line_size_none"
+        ],
+        "spec.request_constraints.max_request_line_size_none": [
+          "max_request_line_size_exceeds"
+        ],
+        "spec.request_constraints.max_request_size_exceeds": [
+          "max_request_size_none"
+        ],
+        "spec.request_constraints.max_request_size_none": [
+          "max_request_size_exceeds"
+        ],
+        "spec.request_constraints.max_url_size_exceeds": [
+          "max_url_size_none"
+        ],
+        "spec.request_constraints.max_url_size_none": [
+          "max_url_size_exceeds"
+        ],
+        "spec.segment_policy.dst_any": [
+          "dst_segments",
+          "intra_segment"
+        ],
+        "spec.segment_policy.dst_segments": [
+          "dst_any",
+          "intra_segment"
+        ],
+        "spec.segment_policy.intra_segment": [
+          "dst_any",
+          "dst_segments"
+        ],
+        "spec.segment_policy.src_any": [
+          "src_segments"
+        ],
+        "spec.segment_policy.src_segments": [
+          "src_any"
+        ],
+        "spec.tls_fingerprint_matcher": [
+          "ja4_tls_fingerprint"
+        ],
+        "spec.waf_action.app_firewall_detection_control": [
+          "none",
+          "waf_skip_processing"
+        ],
+        "spec.waf_action.none": [
+          "app_firewall_detection_control",
+          "waf_skip_processing"
+        ],
+        "spec.waf_action.waf_skip_processing": [
+          "app_firewall_detection_control",
+          "none"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.port_matcher": null
+      },
+      "minimumConfigFields": [
+        "spec.api_group_matcher.match",
+        "spec.asn_list.as_numbers",
+        "spec.asn_matcher.asn_sets",
+        "spec.client_selector.expressions",
+        "spec.ip_matcher.prefix_sets",
+        "spec.ip_threat_category_list.ip_threat_categories",
+        "spec.port_matcher.ports"
+      ],
+      "serverDefaultFields": [
+        "spec.port_matcher"
+      ]
+    },
+    "service_policy_views": {
+      "fieldConflicts": {
+        "spec.any_asn": [
+          "asn_list",
+          "asn_matcher"
+        ],
+        "spec.any_client": [
+          "client_name",
+          "client_name_matcher",
+          "client_selector",
+          "ip_threat_category_list"
+        ],
+        "spec.any_ip": [
+          "ip_matcher",
+          "ip_prefix_list"
+        ],
+        "spec.asn_list": [
+          "any_asn",
+          "asn_matcher"
+        ],
+        "spec.asn_matcher": [
+          "any_asn",
+          "asn_list"
+        ],
+        "spec.bot_action.bot_skip_processing": [
+          "none"
+        ],
+        "spec.bot_action.none": [
+          "bot_skip_processing"
+        ],
+        "spec.client_name": [
+          "any_client",
+          "client_name_matcher",
+          "client_selector",
+          "ip_threat_category_list"
+        ],
+        "spec.client_name_matcher": [
+          "any_client",
+          "client_name",
+          "client_selector",
+          "ip_threat_category_list"
+        ],
+        "spec.client_selector": [
+          "any_client",
+          "client_name",
+          "client_name_matcher",
+          "ip_threat_category_list"
+        ],
+        "spec.ip_matcher": [
+          "any_ip",
+          "ip_prefix_list"
+        ],
+        "spec.ip_prefix_list": [
+          "any_ip",
+          "ip_matcher"
+        ],
+        "spec.ip_threat_category_list": [
+          "any_client",
+          "client_name",
+          "client_name_matcher",
+          "client_selector"
+        ],
+        "spec.ja4_tls_fingerprint": [
+          "tls_fingerprint_matcher"
+        ],
+        "spec.mum_action.default": [
+          "skip_processing"
+        ],
+        "spec.mum_action.skip_processing": [
+          "default"
+        ],
+        "spec.request_constraints.max_cookie_count_exceeds": [
+          "max_cookie_count_none"
+        ],
+        "spec.request_constraints.max_cookie_count_none": [
+          "max_cookie_count_exceeds"
+        ],
+        "spec.request_constraints.max_cookie_key_size_exceeds": [
+          "max_cookie_key_size_none"
+        ],
+        "spec.request_constraints.max_cookie_key_size_none": [
+          "max_cookie_key_size_exceeds"
+        ],
+        "spec.request_constraints.max_cookie_value_size_exceeds": [
+          "max_cookie_value_size_none"
+        ],
+        "spec.request_constraints.max_cookie_value_size_none": [
+          "max_cookie_value_size_exceeds"
+        ],
+        "spec.request_constraints.max_header_count_exceeds": [
+          "max_header_count_none"
+        ],
+        "spec.request_constraints.max_header_count_none": [
+          "max_header_count_exceeds"
+        ],
+        "spec.request_constraints.max_header_key_size_exceeds": [
+          "max_header_key_size_none"
+        ],
+        "spec.request_constraints.max_header_key_size_none": [
+          "max_header_key_size_exceeds"
+        ],
+        "spec.request_constraints.max_header_value_size_exceeds": [
+          "max_header_value_size_none"
+        ],
+        "spec.request_constraints.max_header_value_size_none": [
+          "max_header_value_size_exceeds"
+        ],
+        "spec.request_constraints.max_parameter_count_exceeds": [
+          "max_parameter_count_none"
+        ],
+        "spec.request_constraints.max_parameter_count_none": [
+          "max_parameter_count_exceeds"
+        ],
+        "spec.request_constraints.max_parameter_name_size_exceeds": [
+          "max_parameter_name_size_none"
+        ],
+        "spec.request_constraints.max_parameter_name_size_none": [
+          "max_parameter_name_size_exceeds"
+        ],
+        "spec.request_constraints.max_parameter_value_size_exceeds": [
+          "max_parameter_value_size_none"
+        ],
+        "spec.request_constraints.max_parameter_value_size_none": [
+          "max_parameter_value_size_exceeds"
+        ],
+        "spec.request_constraints.max_query_size_exceeds": [
+          "max_query_size_none"
+        ],
+        "spec.request_constraints.max_query_size_none": [
+          "max_query_size_exceeds"
+        ],
+        "spec.request_constraints.max_request_line_size_exceeds": [
+          "max_request_line_size_none"
+        ],
+        "spec.request_constraints.max_request_line_size_none": [
+          "max_request_line_size_exceeds"
+        ],
+        "spec.request_constraints.max_request_size_exceeds": [
+          "max_request_size_none"
+        ],
+        "spec.request_constraints.max_request_size_none": [
+          "max_request_size_exceeds"
+        ],
+        "spec.request_constraints.max_url_size_exceeds": [
+          "max_url_size_none"
+        ],
+        "spec.request_constraints.max_url_size_none": [
+          "max_url_size_exceeds"
+        ],
+        "spec.segment_policy.dst_any": [
+          "dst_segments",
+          "intra_segment"
+        ],
+        "spec.segment_policy.dst_segments": [
+          "dst_any",
+          "intra_segment"
+        ],
+        "spec.segment_policy.intra_segment": [
+          "dst_any",
+          "dst_segments"
+        ],
+        "spec.segment_policy.src_any": [
+          "src_segments"
+        ],
+        "spec.segment_policy.src_segments": [
+          "src_any"
+        ],
+        "spec.tls_fingerprint_matcher": [
+          "ja4_tls_fingerprint"
+        ],
+        "spec.waf_action.app_firewall_detection_control": [
+          "none",
+          "waf_skip_processing"
+        ],
+        "spec.waf_action.none": [
+          "app_firewall_detection_control",
+          "waf_skip_processing"
+        ],
+        "spec.waf_action.waf_skip_processing": [
+          "app_firewall_detection_control",
+          "none"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.port_matcher": null
+      },
+      "minimumConfigFields": [
+        "spec.api_group_matcher.match",
+        "spec.asn_list.as_numbers",
+        "spec.asn_matcher.asn_sets",
+        "spec.client_selector.expressions",
+        "spec.ip_matcher.prefix_sets",
+        "spec.ip_threat_category_list.ip_threat_categories",
+        "spec.port_matcher.ports"
+      ],
+      "serverDefaultFields": [
+        "spec.port_matcher"
+      ]
+    },
+    "tcp_loadbalancer": {
+      "fieldConflicts": {
+        "spec.active_service_policies": [
+          "no_service_policies",
+          "service_policies_from_namespace"
+        ],
+        "spec.advertise_custom": [
+          "advertise_on_public",
+          "advertise_on_public_default_vip",
+          "do_not_advertise"
+        ],
+        "spec.advertise_on_public": [
+          "advertise_custom",
+          "advertise_on_public_default_vip",
+          "do_not_advertise"
+        ],
+        "spec.advertise_on_public_default_vip": [
+          "advertise_custom",
+          "advertise_on_public",
+          "do_not_advertise"
+        ],
+        "spec.default_lb_with_sni": [
+          "no_sni",
+          "sni"
+        ],
+        "spec.do_not_advertise": [
+          "advertise_custom",
+          "advertise_on_public",
+          "advertise_on_public_default_vip"
+        ],
+        "spec.do_not_retract_cluster": [
+          "retract_cluster"
+        ],
+        "spec.hash_policy_choice_least_active": [
+          "hash_policy_choice_random",
+          "hash_policy_choice_round_robin",
+          "hash_policy_choice_source_ip_stickiness"
+        ],
+        "spec.hash_policy_choice_random": [
+          "hash_policy_choice_least_active",
+          "hash_policy_choice_round_robin",
+          "hash_policy_choice_source_ip_stickiness"
+        ],
+        "spec.hash_policy_choice_round_robin": [
+          "hash_policy_choice_least_active",
+          "hash_policy_choice_random",
+          "hash_policy_choice_source_ip_stickiness"
+        ],
+        "spec.hash_policy_choice_source_ip_stickiness": [
+          "hash_policy_choice_least_active",
+          "hash_policy_choice_random",
+          "hash_policy_choice_round_robin"
+        ],
+        "spec.listen_port": [
+          "port_ranges"
+        ],
+        "spec.no_service_policies": [
+          "active_service_policies",
+          "service_policies_from_namespace"
+        ],
+        "spec.no_sni": [
+          "default_lb_with_sni",
+          "sni"
+        ],
+        "spec.port_ranges": [
+          "listen_port"
+        ],
+        "spec.retract_cluster": [
+          "do_not_retract_cluster"
+        ],
+        "spec.service_policies_from_namespace": [
+          "active_service_policies",
+          "no_service_policies"
+        ],
+        "spec.sni": [
+          "default_lb_with_sni",
+          "no_sni"
+        ],
+        "spec.tcp": [
+          "tls_tcp",
+          "tls_tcp_auto_cert"
+        ],
+        "spec.tls_tcp": [
+          "tcp",
+          "tls_tcp_auto_cert"
+        ],
+        "spec.tls_tcp.tls_cert_params": [
+          "tls_parameters"
+        ],
+        "spec.tls_tcp.tls_cert_params.no_mtls": [
+          "use_mtls"
+        ],
+        "spec.tls_tcp.tls_cert_params.tls_config.custom_security": [
+          "default_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.tls_tcp.tls_cert_params.tls_config.default_security": [
+          "custom_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.tls_tcp.tls_cert_params.tls_config.low_security": [
+          "custom_security",
+          "default_security",
+          "medium_security"
+        ],
+        "spec.tls_tcp.tls_cert_params.tls_config.medium_security": [
+          "custom_security",
+          "default_security",
+          "low_security"
+        ],
+        "spec.tls_tcp.tls_cert_params.use_mtls": [
+          "no_mtls"
+        ],
+        "spec.tls_tcp.tls_cert_params.use_mtls.crl": [
+          "no_crl"
+        ],
+        "spec.tls_tcp.tls_cert_params.use_mtls.no_crl": [
+          "crl"
+        ],
+        "spec.tls_tcp.tls_cert_params.use_mtls.trusted_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.tls_tcp.tls_cert_params.use_mtls.trusted_ca_url": [
+          "trusted_ca"
+        ],
+        "spec.tls_tcp.tls_cert_params.use_mtls.xfcc_disabled": [
+          "xfcc_options"
+        ],
+        "spec.tls_tcp.tls_cert_params.use_mtls.xfcc_options": [
+          "xfcc_disabled"
+        ],
+        "spec.tls_tcp.tls_parameters": [
+          "tls_cert_params"
+        ],
+        "spec.tls_tcp.tls_parameters.no_mtls": [
+          "use_mtls"
+        ],
+        "spec.tls_tcp.tls_parameters.tls_config.custom_security": [
+          "default_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.tls_tcp.tls_parameters.tls_config.default_security": [
+          "custom_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.tls_tcp.tls_parameters.tls_config.low_security": [
+          "custom_security",
+          "default_security",
+          "medium_security"
+        ],
+        "spec.tls_tcp.tls_parameters.tls_config.medium_security": [
+          "custom_security",
+          "default_security",
+          "low_security"
+        ],
+        "spec.tls_tcp.tls_parameters.use_mtls": [
+          "no_mtls"
+        ],
+        "spec.tls_tcp.tls_parameters.use_mtls.crl": [
+          "no_crl"
+        ],
+        "spec.tls_tcp.tls_parameters.use_mtls.no_crl": [
+          "crl"
+        ],
+        "spec.tls_tcp.tls_parameters.use_mtls.trusted_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.tls_tcp.tls_parameters.use_mtls.trusted_ca_url": [
+          "trusted_ca"
+        ],
+        "spec.tls_tcp.tls_parameters.use_mtls.xfcc_disabled": [
+          "xfcc_options"
+        ],
+        "spec.tls_tcp.tls_parameters.use_mtls.xfcc_options": [
+          "xfcc_disabled"
+        ],
+        "spec.tls_tcp_auto_cert": [
+          "tcp",
+          "tls_tcp"
+        ],
+        "spec.tls_tcp_auto_cert.no_mtls": [
+          "use_mtls"
+        ],
+        "spec.tls_tcp_auto_cert.tls_config.custom_security": [
+          "default_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.tls_tcp_auto_cert.tls_config.default_security": [
+          "custom_security",
+          "low_security",
+          "medium_security"
+        ],
+        "spec.tls_tcp_auto_cert.tls_config.low_security": [
+          "custom_security",
+          "default_security",
+          "medium_security"
+        ],
+        "spec.tls_tcp_auto_cert.tls_config.medium_security": [
+          "custom_security",
+          "default_security",
+          "low_security"
+        ],
+        "spec.tls_tcp_auto_cert.use_mtls": [
+          "no_mtls"
+        ],
+        "spec.tls_tcp_auto_cert.use_mtls.crl": [
+          "no_crl"
+        ],
+        "spec.tls_tcp_auto_cert.use_mtls.no_crl": [
+          "crl"
+        ],
+        "spec.tls_tcp_auto_cert.use_mtls.trusted_ca": [
+          "trusted_ca_url"
+        ],
+        "spec.tls_tcp_auto_cert.use_mtls.trusted_ca_url": [
+          "trusted_ca"
+        ],
+        "spec.tls_tcp_auto_cert.use_mtls.xfcc_disabled": [
+          "xfcc_options"
+        ],
+        "spec.tls_tcp_auto_cert.use_mtls.xfcc_options": [
+          "xfcc_disabled"
+        ]
+      },
+      "fieldDefaults": {
+        "spec.dns_volterra_managed": false,
+        "spec.hash_policy_choice_round_robin": {},
+        "spec.idle_timeout": 0,
+        "spec.no_sni": {},
+        "spec.retract_cluster": {},
+        "spec.service_policies_from_namespace": {},
+        "spec.tcp": {}
+      },
+      "minimumConfigFields": [
+        "spec.active_service_policies.policies",
+        "spec.advertise_custom.advertise_where",
+        "spec.advertise_on_public.public_ip.name",
+        "spec.tls_tcp.tls_cert_params.certificates",
+        "spec.tls_tcp.tls_cert_params.tls_config.custom_security.cipher_suites",
+        "spec.tls_tcp.tls_cert_params.use_mtls.crl.name",
+        "spec.tls_tcp.tls_cert_params.use_mtls.trusted_ca.name",
+        "spec.tls_tcp.tls_cert_params.use_mtls.xfcc_options.xfcc_header_elements",
+        "spec.tls_tcp.tls_parameters.tls_certificates",
+        "spec.tls_tcp.tls_parameters.tls_config.custom_security.cipher_suites",
+        "spec.tls_tcp.tls_parameters.use_mtls.crl.name",
+        "spec.tls_tcp.tls_parameters.use_mtls.trusted_ca.name",
+        "spec.tls_tcp.tls_parameters.use_mtls.xfcc_options.xfcc_header_elements",
+        "spec.tls_tcp_auto_cert.tls_config.custom_security.cipher_suites",
+        "spec.tls_tcp_auto_cert.use_mtls.crl.name",
+        "spec.tls_tcp_auto_cert.use_mtls.trusted_ca.name",
+        "spec.tls_tcp_auto_cert.use_mtls.xfcc_options.xfcc_header_elements"
+      ],
+      "serverDefaultFields": [
+        "spec.dns_volterra_managed",
+        "spec.hash_policy_choice_round_robin",
+        "spec.idle_timeout",
+        "spec.no_sni",
+        "spec.retract_cluster",
+        "spec.service_policies_from_namespace",
+        "spec.tcp"
+      ]
+    },
+    "user_identification": {
+      "fieldConflicts": {},
+      "fieldDefaults": {},
+      "minimumConfigFields": [
+        "spec.rules"
+      ],
+      "serverDefaultFields": []
+    },
+    "waf_exclusion_policy": {
+      "fieldConflicts": {},
+      "fieldDefaults": {},
+      "minimumConfigFields": [
+        "spec.waf_exclusion_rules"
+      ],
+      "serverDefaultFields": []
+    }
+  },
+  "version": "2.1.145"
+}

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -128,6 +128,7 @@ from scripts.utils.extension_constants import (
 )
 from scripts.utils.json_writer import write_json_file
 from scripts.utils.memory_profiler import MemoryProfiler
+from scripts.utils.minimal_defaults_exporter import MinimalDefaultsExporter
 from scripts.utils.server_variables import ServerVariableHelper
 
 console = Console()
@@ -1807,6 +1808,24 @@ def run_pipeline(
                 )
             except Exception as e:
                 console.print(f"[yellow]Warning: Failed to export validation spec: {e}[/yellow]")
+
+            # Export minimal-export-defaults.json for downstream minimum-settings
+            # export (xcsh, vscode-f5xc-tools). Walks each covered SpecType schema
+            # and emits the flat per-kind defaults table.
+            try:
+                minimal_exporter = MinimalDefaultsExporter()
+                minimal_schemas = MinimalDefaultsExporter.collect_schemas(domain_specs.values())
+                minimal_artifact = minimal_exporter.export(
+                    minimal_schemas,
+                    output_dir / "minimal-export-defaults.json",
+                    version=version,
+                )
+                console.print(
+                    f"[green]Exported minimal-export-defaults.json: "
+                    f"{len(minimal_artifact['resources'])} resources[/green]",
+                )
+            except Exception as e:
+                console.print(f"[yellow]Warning: Failed to export minimal defaults: {e}[/yellow]")
 
             console.print(f"[green]Created {len(domain_specs)} domain specs + master spec[/green]")
 

--- a/scripts/utils/minimal_defaults_exporter.py
+++ b/scripts/utils/minimal_defaults_exporter.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Emit ``minimal-export-defaults.json`` for downstream minimum-settings export.
+
+Downstream tools (xcsh, vscode-f5xc-tools) export F5XC resources with only the
+settings that differ from server-applied defaults. Rather than have each tool
+re-walk the enriched OpenAPI, this exporter computes the per-kind defaults once
+here — the single source of truth — and publishes a flat artifact:
+
+    {
+      "version": "<spec-version>",
+      "resources": {
+        "<kind>": {
+          "serverDefaultFields": ["spec.loadbalancer_algorithm", ...],
+          "fieldDefaults": { "spec.loadbalancer_algorithm": "ROUND_ROBIN", ... },
+          "minimumConfigFields": ["spec.origin_servers", ...],
+          "fieldConflicts": { "spec.round_robin": ["least_active", "random"] }
+        }
+      }
+    }
+
+Resource -> SpecType schema mapping reuses the ``schema_pattern`` regexes from
+``config/discovered_defaults.yaml`` (the same patterns the enricher uses to place
+the ``x-f5xc-*`` markers). Paths are ``spec.``-prefixed dot-paths; ``allOf``/``$ref``
+are resolved so nested object fields are reached.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from scripts.utils.extension_constants import (
+    X_F5XC_CONFLICTS_WITH,
+    X_F5XC_REQUIRED_FOR,
+    X_F5XC_SERVER_DEFAULT,
+)
+from scripts.utils.json_writer import write_json_file
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+logger = logging.getLogger(__name__)
+
+# Bound recursion into nested object schemas; mirrors DefaultValueEnricher.
+_MAX_DEPTH = 5
+
+# Prefer the canonical full-spec schema when several SpecTypes match a pattern.
+_SCHEMA_PREFERENCE = ("GlobalSpecType", "CreateSpecType", "ReplaceSpecType", "GetSpecType")
+
+
+class MinimalDefaultsExporter:
+    """Walks enriched SpecType schemas and emits the minimal-defaults artifact."""
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Load schema-pattern regexes from ``config/discovered_defaults.yaml``."""
+        self.config_path = (
+            config_path
+            or Path(__file__).parent.parent.parent / "config" / "discovered_defaults.yaml"
+        )
+        self._patterns: dict[str, re.Pattern[str]] = {}
+        self._load_patterns()
+
+    def _load_patterns(self) -> None:
+        try:
+            with self.config_path.open() as f:
+                config = yaml.safe_load(f) or {}
+        except FileNotFoundError:
+            logger.warning("discovered_defaults config not found: %s", self.config_path)
+            return
+        for name, cfg in (config.get("resources") or {}).items():
+            pattern = (cfg or {}).get("schema_pattern")
+            if not pattern:
+                continue
+            try:
+                self._patterns[name] = re.compile(pattern)
+            except re.error as exc:
+                logger.warning("Invalid schema_pattern for %s: %s (%s)", name, pattern, exc)
+
+    # -- schema resolution --------------------------------------------------
+
+    @staticmethod
+    def _ref_name(ref: str) -> str:
+        return ref.rsplit("/", maxsplit=1)[-1]
+
+    def _resolve_nested(
+        self, node: dict[str, Any], schemas: dict[str, Any], seen: set[str]
+    ) -> tuple[dict[str, Any] | None, str | None]:
+        """Resolve a property to the object schema holding its ``properties``.
+
+        Handles inline objects, a direct ``$ref``, and a single-item
+        ``allOf: [{$ref}]`` wrapper. Returns ``(schema, ref_name)`` — ``ref_name``
+        is ``None`` for inline objects, and ``(None, None)`` on cycles or when no
+        object schema is reachable.
+        """
+        if "properties" in node:
+            return node, None
+        ref = node.get("$ref")
+        if not ref:
+            for item in node.get("allOf", []):
+                if isinstance(item, dict) and "$ref" in item:
+                    ref = item["$ref"]
+                    break
+        if not ref:
+            return None, None
+        name = self._ref_name(ref)
+        if name in seen:
+            return None, None
+        target = schemas.get(name)
+        if not isinstance(target, dict):
+            return None, None
+        return target, name
+
+    def _select_schema(self, schemas: Iterable[str]) -> str | None:
+        matches = list(schemas)
+        if not matches:
+            return None
+        for marker in _SCHEMA_PREFERENCE:
+            preferred = sorted(n for n in matches if marker in n)
+            if preferred:
+                return preferred[0]
+        return sorted(matches)[0]
+
+    # -- marker collection --------------------------------------------------
+
+    def _walk(
+        self,
+        schema: dict[str, Any],
+        prefix: str,
+        schemas: dict[str, Any],
+        seen: set[str],
+        out: dict[str, Any],
+        depth: int,
+    ) -> None:
+        if depth > _MAX_DEPTH:
+            return
+        properties = schema.get("properties")
+        if not isinstance(properties, dict):
+            return
+        for name, prop in properties.items():
+            if not isinstance(prop, dict):
+                continue
+            path = f"{prefix}.{name}"
+
+            is_server_default = prop.get(X_F5XC_SERVER_DEFAULT) is True
+            if is_server_default:
+                out["serverDefaultFields"].append(path)
+                if "default" in prop:
+                    out["fieldDefaults"][path] = prop["default"]
+
+            required_for = prop.get(X_F5XC_REQUIRED_FOR)
+            if isinstance(required_for, dict) and required_for.get("minimum_config") is True:
+                out["minimumConfigFields"].append(path)
+
+            conflicts = prop.get(X_F5XC_CONFLICTS_WITH)
+            if isinstance(conflicts, list) and conflicts:
+                out["fieldConflicts"][path] = list(conflicts)
+
+            nested, ref_name = self._resolve_nested(prop, schemas, seen)
+            if nested is not None:
+                child_seen = seen | ({ref_name} if ref_name else set())
+                self._walk(nested, path, schemas, child_seen, out, depth + 1)
+
+    def _build_resource(
+        self, spec_schema: dict[str, Any], schemas: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        out: dict[str, Any] = {
+            "serverDefaultFields": [],
+            "fieldDefaults": {},
+            "minimumConfigFields": [],
+            "fieldConflicts": {},
+        }
+        self._walk(spec_schema, "spec", schemas, set(), out, depth=1)
+        if not any(out[k] for k in out):
+            return None
+        out["serverDefaultFields"] = sorted(out["serverDefaultFields"])
+        out["minimumConfigFields"] = sorted(out["minimumConfigFields"])
+        return out
+
+    # -- public API ---------------------------------------------------------
+
+    def build(self, schemas: dict[str, Any], version: str = "unknown") -> dict[str, Any]:
+        """Build the artifact dict from a flat component-schemas map."""
+        resources: dict[str, Any] = {}
+        for kind, pattern in self._patterns.items():
+            chosen = self._select_schema(n for n in schemas if pattern.search(n))
+            if not chosen:
+                continue
+            entry = self._build_resource(schemas[chosen], schemas)
+            if entry is not None:
+                resources[kind] = entry
+        return {"version": version, "resources": dict(sorted(resources.items()))}
+
+    def export(
+        self, schemas: dict[str, Any], output_path: Path, version: str = "unknown"
+    ) -> dict[str, Any]:
+        """Build the artifact and write it (Biome-formatted under the docs tree)."""
+        artifact = self.build(schemas, version=version)
+        write_json_file(artifact, output_path, indent=2, sort_keys=True, ensure_ascii=False)
+        logger.info("Wrote %s (%d resources)", output_path, len(artifact["resources"]))
+        return artifact
+
+    @staticmethod
+    def collect_schemas(specs: Iterable[dict[str, Any]]) -> dict[str, Any]:
+        """Merge ``components.schemas`` across one or more specs into one map."""
+        merged: dict[str, Any] = {}
+        for spec in specs:
+            schemas = (spec.get("components") or {}).get("schemas") or {}
+            merged.update(schemas)
+        return merged

--- a/tests/test_minimal_defaults_exporter.py
+++ b/tests/test_minimal_defaults_exporter.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for MinimalDefaultsExporter.
+
+Verifies that the exporter walks each covered resource's SpecType schema
+(resolving allOf/$ref, building spec.-prefixed dot-paths) and emits the flat
+{serverDefaultFields, fieldDefaults, minimumConfigFields, fieldConflicts}
+artifact consumed by @f5xc-salesdemos/pi-resource-management.
+"""
+
+import pytest
+
+from scripts.utils.minimal_defaults_exporter import MinimalDefaultsExporter
+
+
+@pytest.fixture
+def exporter(tmp_path):
+    """Exporter with a one-resource config matching origin_pool SpecTypes."""
+    config_file = tmp_path / "discovered_defaults.yaml"
+    config_file.write_text(
+        """\
+settings: {}
+resources:
+  origin_pool:
+    schema_pattern: "origin_pool.*SpecType"
+"""
+    )
+    return MinimalDefaultsExporter(config_path=config_file)
+
+
+@pytest.fixture
+def schemas():
+    """A minimal enriched component-schema set for origin_pool."""
+    return {
+        "viewsorigin_poolGlobalSpecType": {
+            "properties": {
+                "endpoint_selection": {
+                    "type": "string",
+                    "default": "DISTRIBUTED",
+                    "x-f5xc-server-default": True,
+                },
+                "round_robin": {
+                    "allOf": [{"$ref": "#/components/schemas/ioschemaEmpty"}],
+                    "default": {},
+                    "x-f5xc-server-default": True,
+                    "x-f5xc-conflicts-with": ["least_active", "random"],
+                },
+                "origin_servers": {
+                    "type": "array",
+                    "x-f5xc-required-for": {"minimum_config": True, "create": True},
+                },
+                "advanced_options": {
+                    "allOf": [{"$ref": "#/components/schemas/originPoolAdvancedOptions"}],
+                },
+            },
+        },
+        "ioschemaEmpty": {"type": "object", "properties": {}},
+        "originPoolAdvancedOptions": {
+            "properties": {
+                "connection_timeout": {
+                    "type": "integer",
+                    "default": 0,
+                    "x-f5xc-server-default": True,
+                },
+            },
+        },
+    }
+
+
+class TestBuild:
+    def test_collects_server_default_fields_with_spec_prefix(self, exporter, schemas):
+        result = exporter.build(schemas)
+        op = result["resources"]["origin_pool"]
+        assert sorted(op["serverDefaultFields"]) == [
+            "spec.advanced_options.connection_timeout",
+            "spec.endpoint_selection",
+            "spec.round_robin",
+        ]
+
+    def test_records_known_default_values(self, exporter, schemas):
+        op = exporter.build(schemas)["resources"]["origin_pool"]
+        assert op["fieldDefaults"] == {
+            "spec.endpoint_selection": "DISTRIBUTED",
+            "spec.round_robin": {},
+            "spec.advanced_options.connection_timeout": 0,
+        }
+
+    def test_collects_minimum_config_fields(self, exporter, schemas):
+        op = exporter.build(schemas)["resources"]["origin_pool"]
+        assert op["minimumConfigFields"] == ["spec.origin_servers"]
+
+    def test_collects_field_conflicts(self, exporter, schemas):
+        op = exporter.build(schemas)["resources"]["origin_pool"]
+        assert op["fieldConflicts"] == {"spec.round_robin": ["least_active", "random"]}
+
+    def test_includes_version(self, exporter, schemas):
+        result = exporter.build(schemas, version="2.1.145")
+        assert result["version"] == "2.1.145"
+        assert "resources" in result
+
+    def test_resource_with_no_markers_is_omitted(self, exporter):
+        # SpecType present but no markers anywhere -> no resource entry.
+        schemas = {"viewsorigin_poolGlobalSpecType": {"properties": {"name": {"type": "string"}}}}
+        result = exporter.build(schemas)
+        assert "origin_pool" not in result["resources"]
+
+    def test_unmatched_resource_absent(self, exporter):
+        # No schema matches the origin_pool pattern.
+        result = exporter.build({"somethingElse": {"properties": {}}})
+        assert result["resources"] == {}


### PR DESCRIPTION
Closes #774

## What

Computes per-kind defaults knowledge once here (the SoT) and publishes a flat **`minimal-export-defaults.json`** release artifact, so xcsh and vscode-f5xc-tools can export F5XC resources with only minimum (non-default) settings without each re-walking the enriched OpenAPI.

## How

- **`scripts/utils/minimal_defaults_exporter.py`** — walks each covered resource's SpecType schema (matched via the existing `discovered_defaults.yaml` `schema_pattern` regexes), resolving `allOf`/`$ref` into `spec.`-prefixed dot-paths, and emits per kind:
  `{serverDefaultFields, fieldDefaults, minimumConfigFields, fieldConflicts}` from the `x-f5xc-server-default` / `default` / `x-f5xc-required-for.minimum_config` / `x-f5xc-conflicts-with` markers.
- **`pipeline.py`** — emits `docs/specifications/api/minimal-export-defaults.json` after the validation export (uses `write_json_file`, same as `validation.json`).
- **workflow** — uploads it as a release asset (how xcsh fetches it) and excludes it from the `domains/` zip subdir.
- **committed artifact** — covers the 30 kinds currently in `discovered_defaults.yaml`; coverage grows as that config grows (consumers tolerate gaps — an uncovered kind exports everything).

## Contract (consumed by `@f5xc-salesdemos/pi-resource-management`)

```json
{ "version": "<spec-version>",
  "resources": { "<kind>": {
    "serverDefaultFields": ["spec.loadbalancer_algorithm", ...],
    "fieldDefaults": { "spec.loadbalancer_algorithm": "ROUND_ROBIN", ... },
    "minimumConfigFields": ["spec.origin_servers", ...],
    "fieldConflicts": { "spec.round_robin": ["least_active", "random"] } } } }
```

## Verification

- New unit tests (`tests/test_minimal_defaults_exporter.py`): 7 pass — server-default collection, known-value defaults, minimum-config, conflicts, `spec.` prefixing, omission of marker-less / unmatched resources.
- Full suite: **2167 passed**, 3 skipped, 1 xfailed. ruff check + format clean.
- End-to-end: ran the real `pi-resource-management` generator against this artifact — `buildMinimalExportFilter` produces correct filters for origin_pool (17 defaults / 12 oneofs), http_loadbalancer (43 / 31), healthcheck (7 defaults + minimum-config), with nested `$ref` paths resolved.

Part of the cross-project minimum-settings export effort (upstream data PR). Pairs with xcsh#1506.

🤖 Generated with [Claude Code](https://claude.com/claude-code)