### PR TITLE
fix: exclude minimal-export-defaults.json from Spectral lint

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -249,8 +249,8 @@ def lint_all_specs(
     """
     stats = LintStats()
 
-    # Find all JSON spec files (exclude index.json which is metadata, not OpenAPI)
-    non_openapi_files = {"index.json", "validation.json"}
+    # Find all JSON spec files (exclude metadata/artifact files that are not OpenAPI)
+    non_openapi_files = {"index.json", "validation.json", "minimal-export-defaults.json"}
     spec_files = sorted(f for f in input_dir.glob("*.json") if f.name not in non_openapi_files)
     if not spec_files:
         console.print(f"[yellow]No specification files found in {input_dir}[/yellow]")


### PR DESCRIPTION
Closes #778

## Problem

The **Sync and Enrich** workflow fails at "Lint specifications with Spectral" and no new release is cut. `scripts/lint.py` globs every `*.json` in `docs/specifications/api/` and runs Spectral with `--fail-on-warning`; the `minimal-export-defaults.json` artifact (not an OpenAPI doc) emits 1 warning → exit 1.

The enrichment pipeline succeeds and the artifact is correct — only the lint step mis-targets it.

## Fix

One line: add `minimal-export-defaults.json` to the existing `non_openapi_files` exclusion set (alongside `index.json`, `validation.json`).

## Verification

- File-selection check confirms the artifact is no longer linted; the OpenAPI domain specs still are.
- `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)