### PR TITLE
Update downstream repo references for xcsh rebranding

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,7 +24,7 @@ Python-based OpenAPI enrichment pipeline for F5 Distributed Cloud. Downloads pre
 
 ## Upstream/Downstream
 - **Upstream**: f5xc-salesdemos/api-specs (pre-validated OpenAPI specs)
-- **Downstream**: f5xc-salesdemos/xcsh, f5xc-salesdemos/vscode-f5xc-tools
+- **Downstream**: f5xc-salesdemos/xcsh, f5xc-salesdemos/vscode-xcsh
 
 ## Environment Variables
 ```

--- a/config/branding.yaml
+++ b/config/branding.yaml
@@ -134,16 +134,16 @@ deprecations:
         Still live on registry with no deprecation notice.
         High risk of AI model recommendation due to training data prevalence.
     canonical:
-      registry: "registry.terraform.io/providers/f5xc-salesdemos/f5xc"
-      source: "f5xc-salesdemos/f5xc"
-      github: "github.com/f5xc-salesdemos/terraform-provider-f5xc"
-      docs: "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
-      llms_txt: "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/llms.txt"
+      registry: "registry.terraform.io/providers/f5xc-salesdemos/xcsh"
+      source: "f5xc-salesdemos/xcsh"
+      github: "github.com/f5xc-salesdemos/terraform-provider-xcsh"
+      docs: "https://f5xc-salesdemos.github.io/terraform-provider-xcsh/"
+      llms_txt: "https://f5xc-salesdemos.github.io/terraform-provider-xcsh/llms.txt"
     required_providers_block: |
       terraform {
         required_providers {
-          f5xc = {
-            source = "f5xc-salesdemos/f5xc"
+          xcsh = {
+            source = "f5xc-salesdemos/xcsh"
           }
         }
       }
@@ -160,4 +160,4 @@ deprecations:
         docs.cloud.f5.com references to Volterra provider point to the deprecated
         volterraedge/volterra registry.
     canonical:
-      url: "https://f5xc-salesdemos.github.io/terraform-provider-f5xc/"
+      url: "https://f5xc-salesdemos.github.io/terraform-provider-xcsh/"

--- a/config/downstream_repos.yaml
+++ b/config/downstream_repos.yaml
@@ -20,14 +20,14 @@ downstream_repositories:
 
   # VS Code F5 XC Tools - VS Code extension
   - owner: f5xc-salesdemos
-    repo: vscode-f5xc-tools
+    repo: vscode-xcsh
     event_type: enriched-specs-updated
     enabled: true
     description: VS Code extension for F5 XC development
 
   # Terraform Provider F5 XC - Terraform resource provider
   - owner: f5xc-salesdemos
-    repo: terraform-provider-f5xc
+    repo: terraform-provider-xcsh
     event_type: enriched-specs-updated
     enabled: true
     description: Terraform provider for F5 Distributed Cloud resources

--- a/config/extension_registry.yaml
+++ b/config/extension_registry.yaml
@@ -5,7 +5,7 @@
 # - F5 native extensions (x-ves-proto-*, x-displayname) - preserved unchanged
 # - OpenAPI standard fields - used when available
 #
-# Consumers: f5xc-api-mcp, f5xc-xcsh, vscode-f5xc-tools
+# Consumers: f5xc-api-mcp, f5xc-xcsh, vscode-xcsh
 #
 # Version: 2.1.0
 # Issue: #314
@@ -194,7 +194,7 @@ schema_level:
   x-f5xc-console:
     type: object
     purpose: Console UI navigation, routing, and form structure for this resource
-    consumers: [console-catalog, xcsh, vscode-f5xc-tools, browser-automation]
+    consumers: [console-catalog, xcsh, vscode-xcsh, browser-automation]
     added_in: "3.5.0"
     issue: "#679"
     properties:

--- a/docs/ar/extensions/catalog.md
+++ b/docs/ar/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: كتالوج امتداد الإثراء
 description: المرجع الأساسي لكل امتداد x-* في مواصفات OpenAPI المحسّنة
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/ar/extensions/catalog.md
+++ b/docs/ar/extensions/catalog.md
@@ -278,7 +278,7 @@ i18n:
 
 - **Applied at:** schema
 - **Purpose:** بيانات تنقل واجهة مستخدم وحدة التحكم والتوجيه وبنية النموذج لهذا المورد.
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/de/extensions/catalog.md
+++ b/docs/de/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Maßgebliche Referenz für jede x-*-Erweiterung in den angereicherten
   OpenAPI-Spezifikationen
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/de/extensions/catalog.md
+++ b/docs/de/extensions/catalog.md
@@ -280,7 +280,7 @@ solange der `### x-name`-Header vorhanden ist und das
 
 - **Applied at:** schema
 - **Purpose:** Konsolen-UI-Navigation, Routing und Formularstruktur für diese Ressource.
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/en/extensions/catalog.md
+++ b/docs/en/extensions/catalog.md
@@ -276,7 +276,7 @@ stubby as long as the `### x-name` header exists and the
 
 - **Applied at:** schema
 - **Purpose:** Console UI navigation, routing, and form structure for this resource.
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/es/extensions/catalog.md
+++ b/docs/es/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Fuente de verdad para cada extensión x-* en las especificaciones OpenAPI
   enriquecidas
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/es/extensions/catalog.md
+++ b/docs/es/extensions/catalog.md
@@ -280,7 +280,7 @@ siempre que exista el encabezado `### x-name` y el indicador
 
 - **Applied at:** schema
 - **Purpose:** Navegación de la UI de consola, enrutamiento y estructura de formularios para este recurso.
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/fr/extensions/catalog.md
+++ b/docs/fr/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Source de vérité pour chaque extension x-* dans les spécifications OpenAPI
   enrichies
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/fr/extensions/catalog.md
+++ b/docs/fr/extensions/catalog.md
@@ -280,7 +280,7 @@ l'indicateur `Pass-through from upstream:` soit présent avec la valeur `yes` ou
 
 - **Applied at:** schema
 - **Purpose:** Navigation dans l'interface console, routage et structure de formulaire pour cette ressource.
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/hi/extensions/catalog.md
+++ b/docs/hi/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: संवर्धन एक्सटेंशन कैटालॉग
 description: संवर्धित OpenAPI विनिर्देशों में प्रत्येक x-* एक्सटेंशन के लिए सत्य का स्रोत
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/hi/extensions/catalog.md
+++ b/docs/hi/extensions/catalog.md
@@ -267,7 +267,7 @@ i18n:
 
 - **Applied at:** schema
 - **Purpose:** इस संसाधन के लिए कंसोल UI नेविगेशन, रूटिंग और फ़ॉर्म संरचना।
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/it/extensions/catalog.md
+++ b/docs/it/extensions/catalog.md
@@ -280,7 +280,7 @@ minimale purché esista l'intestazione `### x-name` e il flag
 
 - **Applied at:** schema
 - **Purpose:** Navigazione nell'interfaccia utente della console, routing e struttura del form per questa risorsa.
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/it/extensions/catalog.md
+++ b/docs/it/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Fonte ufficiale di riferimento per ogni estensione x-* nelle specifiche
   OpenAPI arricchite
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/ja/extensions/catalog.md
+++ b/docs/ja/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: 拡充拡張機能カタログ
 description: 拡充 OpenAPI 仕様に含まれるすべての x-* 拡張機能の信頼できる情報源
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/ja/extensions/catalog.md
+++ b/docs/ja/extensions/catalog.md
@@ -270,7 +270,7 @@ i18n:
 
 - **Applied at:** schema
 - **Purpose:** このリソースのコンソール UI ナビゲーション、ルーティング、およびフォーム構造。
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/ko/extensions/catalog.md
+++ b/docs/ko/extensions/catalog.md
@@ -267,7 +267,7 @@ i18n:
 
 - **Applied at:** schema
 - **Purpose:** 이 리소스에 대한 콘솔 UI 탐색, 라우팅 및 폼 구조.
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/ko/extensions/catalog.md
+++ b/docs/ko/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: 강화 확장 카탈로그
 description: 강화된 OpenAPI 사양의 모든 x-* 확장에 대한 단일 진실 공급원
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/pt-br/extensions/catalog.md
+++ b/docs/pt-br/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Fonte oficial de todas as extensões x-* nas especificações OpenAPI
   enriquecidas
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/pt-br/extensions/catalog.md
+++ b/docs/pt-br/extensions/catalog.md
@@ -280,7 +280,7 @@ desde que o cabeçalho `### x-name` exista e o sinalizador
 
 - **Applied at:** schema
 - **Purpose:** Navegação da UI do console, roteamento e estrutura de formulário para este recurso.
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/th/extensions/catalog.md
+++ b/docs/th/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   แหล่งข้อมูลอ้างอิงหลักสำหรับ x-* extension ทุกรายการในข้อกำหนด OpenAPI
   ที่เพิ่มประสิทธิภาพ
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/th/extensions/catalog.md
+++ b/docs/th/extensions/catalog.md
@@ -280,7 +280,7 @@ i18n:
 
 - **Applied at:** schema
 - **Purpose:** การนำทาง Console UI, routing และโครงสร้างฟอร์มสำหรับ resource นี้
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/zh-cn/extensions/catalog.md
+++ b/docs/zh-cn/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: 扩展字段目录
 description: 富化 OpenAPI 规范中每个 x-* 扩展的权威来源
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/docs/zh-cn/extensions/catalog.md
+++ b/docs/zh-cn/extensions/catalog.md
@@ -267,7 +267,7 @@ i18n:
 
 - **Applied at:** schema
 - **Purpose:** 该资源的控制台 UI 导航、路由及表单结构。
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/zh-tw/extensions/catalog.md
+++ b/docs/zh-tw/extensions/catalog.md
@@ -272,7 +272,7 @@ i18n:
 
 - **Applied at:** schema
 - **Purpose:** 此資源的主控台 UI 導覽、路由及表單結構。
-- **Consumers:** console-catalog, xcsh, vscode-f5xc-tools, browser-automation
+- **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
 - **Injected by:** scripts/utils/console_ui_enricher.py

--- a/docs/zh-tw/extensions/catalog.md
+++ b/docs/zh-tw/extensions/catalog.md
@@ -2,7 +2,7 @@
 title: 擴充功能擴充目錄
 description: 已豐富化 OpenAPI 規格中每個 x-* 擴充功能的真實來源
 i18n:
-  sourceHash: 70e0912cf4b0
+  sourceHash: 395df1e3c471
   translator: machine
 ---
 

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -1810,7 +1810,7 @@ def run_pipeline(
                 console.print(f"[yellow]Warning: Failed to export validation spec: {e}[/yellow]")
 
             # Export minimal-export-defaults.json for downstream minimum-settings
-            # export (xcsh, vscode-f5xc-tools). Walks each covered SpecType schema
+            # export (xcsh, vscode-xcsh). Walks each covered SpecType schema
             # and emits the flat per-kind defaults table.
             try:
                 minimal_exporter = MinimalDefaultsExporter()

--- a/scripts/utils/console_ui_enricher.py
+++ b/scripts/utils/console_ui_enricher.py
@@ -7,7 +7,7 @@ Applies console UI metadata from config/console_ui.yaml to OpenAPI specs:
 - x-f5xc-console-field (property-level): Widget type, selector, visibility
 - x-f5xc-console-navigation (spec-level): Global navigation tree
 
-This enrichment enables downstream consumers (xcsh, vscode-f5xc-tools,
+This enrichment enables downstream consumers (xcsh, vscode-xcsh,
 console catalog) to derive console navigation and form metadata directly
 from the enriched API specs — the single source of truth.
 

--- a/scripts/utils/minimal_defaults_exporter.py
+++ b/scripts/utils/minimal_defaults_exporter.py
@@ -2,7 +2,7 @@
 
 """Emit ``minimal-export-defaults.json`` for downstream minimum-settings export.
 
-Downstream tools (xcsh, vscode-f5xc-tools) export F5XC resources with only the
+Downstream tools (xcsh, vscode-xcsh) export F5XC resources with only the
 settings that differ from server-applied defaults. Rather than have each tool
 re-walk the enriched OpenAPI, this exporter computes the per-kind defaults once
 here — the single source of truth — and publishes a flat artifact:


### PR DESCRIPTION
## Summary
- `downstream_repos.yaml`: `vscode-f5xc-tools` → `vscode-xcsh`, `terraform-provider-f5xc` → `terraform-provider-xcsh`
- `branding.yaml`: Terraform provider canonical refs updated to `f5xc-salesdemos/xcsh`
- `extension_registry.yaml`, `governance.json`, `CLAUDE.md`: cross-repo refs updated
- 13 docs catalog files and 3 script comments updated

## Context
Part of the cross-repo xcsh ecosystem rebranding. OpenAPI extensions (`x-f5xc-*`) and CLI tools (`f5xc-download/enrich/validate/merge`) are intentionally unchanged — they describe the F5 platform, not our tooling.

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)