### PR TITLE
fix: correct console routes for forward_proxy/alert/secret policies

### DIFF
--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -1552,9 +1552,21 @@ resources:
       label: Description
       form_section: metadata
     spec.receivers:
-      widget_type: configurable
-      label: Receivers
+      widget_type: resource-selector
+      label: Alert Receivers
+      required: true
       form_section: basic
+      resource_type: alert_receiver
+      description: 'Server-required: at least one Alert Receiver reference. Depends on
+        an existing alert_receiver object (create one first).'
+    spec.routes:
+      widget_type: nested-resource-list
+      label: Policy Rules
+      required: true
+      add_action: Add Item
+      form_section: basic
+      description: 'Server-required: at least one alert policy rule (Field Policy Rules
+        in Spec is required).'
   secret_policy:
     metadata.name:
       widget_type: textbox

--- a/config/console_ui.yaml
+++ b/config/console_ui.yaml
@@ -736,13 +736,13 @@ resources:
       discovered_at: '2026-06-15'
       console_version: '2025.06'
   forward_proxy_policy:
-    workspace: multi-cloud-app-connect
+    workspace: multi-cloud-network-connect
     menu_path:
-    - Multi-Cloud App Connect
+    - Multi-Cloud Network Connect
     - Manage
-    - Security
+    - Firewall
     - Forward Proxy Policies
-    route_pattern: /namespaces/{namespace}/manage/security/forward_proxy_policies
+    route_pattern: /manage/firewall/forward_proxy_policy
     breadcrumbs:
     - Home
     - Multi-Cloud App Connect
@@ -1386,12 +1386,13 @@ resources:
       notes: Validated via URL probe against live staging console
   alert_policy:
     namespace_scoped: false
-    workspace: shared-configuration
+    workspace: multi-cloud-network-connect
     menu_path:
-    - Shared Configuration
+    - Multi-Cloud Network Connect
     - Manage
+    - Alerts Management
     - Alert Policies
-    route_pattern: /namespaces/shared/manage/alert_policies
+    route_pattern: /manage/alert_config/alert_policies
     breadcrumbs:
     - Home
     - Shared Configuration
@@ -1423,12 +1424,13 @@ resources:
       notes: Validated via URL probe against live staging console
   secret_policy:
     namespace_scoped: false
-    workspace: shared-configuration
+    workspace: multi-cloud-network-connect
     menu_path:
-    - Shared Configuration
+    - Multi-Cloud Network Connect
     - Manage
+    - Secrets
     - Secret Policies
-    route_pattern: /namespaces/shared/manage/secret_policies
+    route_pattern: /manage/secrets/secret_policies
     breadcrumbs:
     - Home
     - Shared Configuration


### PR DESCRIPTION
Closes #807

Live nav discovery corrected 3 page-not-found routes to multi-cloud-network-connect. forward_proxy_policy + secret_policy create verified live (in list). alert_policy navigation fixed + enriched with its 2 server-required fields (Alert Receivers, Policy Rules). 

🤖 Generated with [Claude Code](https://claude.com/claude-code)