### PR TITLE
fix: correct 4 page-not-found console routes

### DIFF
--- a/config/console_ui.yaml
+++ b/config/console_ui.yaml
@@ -1126,7 +1126,7 @@ resources:
     - Manage
     - Networking
     - Network Policies
-    route_pattern: /namespaces/{namespace}/manage/networking/network_policies
+    route_pattern: /namespaces/{namespace}/manage/network_policies/network_policies
     breadcrumbs:
     - Home
     - Distributed Apps
@@ -1354,7 +1354,7 @@ resources:
     - Shared Configuration
     - Manage
     - Virtual Sites
-    route_pattern: /namespaces/shared/manage/virtual_sites
+    route_pattern: /manage/virtual_sites
     breadcrumbs:
     - Home
     - Shared Configuration
@@ -1462,12 +1462,13 @@ resources:
       notes: Validated via URL probe against live staging console
   alert_receiver:
     namespace_scoped: false
-    workspace: audit-logs-and-alerts
+    workspace: multi-cloud-network-connect
     menu_path:
-    - Audit Logs & Alerts
+    - Multi-Cloud Network Connect
     - Manage
+    - Alerts Management
     - Alert Receivers
-    route_pattern: /namespaces/system/manage/alert_receivers
+    route_pattern: /manage/alert_config/alert_receivers
     breadcrumbs:
     - Home
     - Audit Logs & Alerts
@@ -1781,7 +1782,7 @@ resources:
     menu_path:
     - Manage
     - Container Registries
-    route_pattern: /namespaces/{namespace}/manage/container_registries
+    route_pattern: /namespaces/{namespace}/applications/container_registries
     breadcrumbs:
     - Home
     - Distributed Apps


### PR DESCRIPTION
Closes #819

Route-check sweep across all resources found 12 wrong routes; this fixes 4 (verified they now load). Unblocks create for these resources (R/U/D are generic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)