### PR TITLE
fix: correct waf_exclusion_policy + global_log_receiver routes

### DIFF
--- a/config/console_ui.yaml
+++ b/config/console_ui.yaml
@@ -416,7 +416,7 @@ resources:
     - Manage
     - App Firewall
     - WAF Exclusion Rules
-    route_pattern: /namespaces/{namespace}/manage/app_firewall/waf_exclusion_rules
+    route_pattern: /namespaces/{namespace}/manage/shared_objects/waf_exclusion_policy
     breadcrumbs:
     - Home
     - Web App & API Protection
@@ -1500,12 +1500,13 @@ resources:
       notes: Validated via URL probe against live staging console
   global_log_receiver:
     namespace_scoped: false
-    workspace: audit-logs-and-alerts
+    workspace: multi-cloud-network-connect
     menu_path:
-    - Audit Logs & Alerts
+    - Multi-Cloud Network Connect
     - Manage
-    - Global Log Receivers
-    route_pattern: /namespaces/system/manage/global_log_receivers
+    - Log Management
+    - Log Receivers
+    route_pattern: /manage/log_management/log_receivers
     breadcrumbs:
     - Home
     - Audit Logs & Alerts


### PR DESCRIPTION
Closes #822

2 more page-not-found routes fixed via nav discovery (verified load). Brings route fixes to 6 of 12 wrong routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)