### PR TITLE
feat: secret/Blindfold configurable field handler

### DIFF
--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -2339,6 +2339,10 @@ resources:
       label: Password
       required: true
       form_section: password
+      secret: true
+      description: 'Secret field: click Configure (a link), enter the value in the
+        secret TEXTAREA (Secret Type defaults are fine), then Apply. Verified live:
+        create 200.'
     spec.email:
       widget_type: textbox
       label: Email


### PR DESCRIPTION
Closes #831

container_registry password (Blindfold secret) now creates via the generated workflow (verified 200). Reusable secret-field handler for the catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)