### PR TITLE
fix: remove duplicate ruff.toml — keep .ruff.toml only

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,0 @@
-# Ruff configuration is in pyproject.toml under [tool.ruff].
-# This file exists so the super-linter CI workflow can find a config
-# at the path specified by PYTHON_RUFF_FORMAT_CONFIG_FILE.
-extend = "pyproject.toml"


### PR DESCRIPTION
Closes #833

Removes duplicate `ruff.toml` (identical to `.ruff.toml`). Fixes JSCPD lint failures caused by duplication exceeding the 10% threshold. Super-linter now uses `.ruff.toml` (docs-control #585).