### PR TITLE
feat(export): publish authoritative namespace_profiles.json

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -250,7 +250,12 @@ def lint_all_specs(
     stats = LintStats()
 
     # Find all JSON spec files (exclude metadata/artifact files that are not OpenAPI)
-    non_openapi_files = {"index.json", "validation.json", "minimal-export-defaults.json"}
+    non_openapi_files = {
+        "index.json",
+        "validation.json",
+        "minimal-export-defaults.json",
+        "namespace_profiles.json",
+    }
     spec_files = sorted(f for f in input_dir.glob("*.json") if f.name not in non_openapi_files)
     if not spec_files:
         console.print(f"[yellow]No specification files found in {input_dir}[/yellow]")

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -129,6 +129,7 @@ from scripts.utils.extension_constants import (
 from scripts.utils.json_writer import write_json_file
 from scripts.utils.memory_profiler import MemoryProfiler
 from scripts.utils.minimal_defaults_exporter import MinimalDefaultsExporter
+from scripts.utils.namespace_profiles_exporter import NamespaceProfilesExporter
 from scripts.utils.server_variables import ServerVariableHelper
 
 console = Console()
@@ -381,8 +382,7 @@ def enrich_spec(spec: dict[str, Any], config: dict) -> tuple[dict[str, Any], dic
     return spec, {
         "field_count": field_count,
         "schemas_fixed": schema_stats.get("fixes_applied", 0),
-        "descriptions_generated": desc_stats.get("operations_generated", 0)
-        + desc_stats.get("schemas_generated", 0),
+        "descriptions_generated": desc_stats.get("operations_generated", 0) + desc_stats.get("schemas_generated", 0),
         "consistency_issues": consistency_stats.get("total_issues", 0),
         "domains_normalized": domain_normalize_count,
         "field_descriptions_added": field_desc_stats.get("descriptions_added", 0),
@@ -663,11 +663,7 @@ def _remove_empty_operations(spec: dict[str, Any]) -> tuple[dict[str, Any], int]
             del path_item[method]
             removed_count += 1
 
-        remaining = [
-            m
-            for m in ["get", "post", "put", "delete", "patch", "options", "head", "trace"]
-            if m in path_item
-        ]
+        remaining = [m for m in ["get", "post", "put", "delete", "patch", "options", "head", "trace"] if m in path_item]
         if not remaining:
             paths_to_remove.append(path)
 
@@ -853,8 +849,7 @@ def validate_upstream_spec(spec: dict[str, Any]) -> list[str]:
 
     if ops_without_tags:
         warnings.append(
-            f"Upstream regression: {len(ops_without_tags)} operations missing tags "
-            f"(first: {ops_without_tags[0]})"
+            f"Upstream regression: {len(ops_without_tags)} operations missing tags (first: {ops_without_tags[0]})"
         )
 
     def _has_script_tags(obj: Any) -> bool:
@@ -1121,17 +1116,14 @@ def merge_specs_by_domain(
             domain_specs["data_intelligence"].append((filename, spec))
 
         # Also add specs to threat_campaign domain if they contain threat_campaign/threat_mesh paths
-        has_threat_campaign_paths = any(
-            "/api/waf/threat_campaign" in p or "/threat_mesh" in p for p in paths
-        )
+        has_threat_campaign_paths = any("/api/waf/threat_campaign" in p or "/threat_mesh" in p for p in paths)
         if has_threat_campaign_paths and domain != "threat_campaign":
             domain_specs["threat_campaign"].append((filename, spec))
 
         # Also add specs to system domain if they contain credential management paths
         # Pattern-based detection for credential/token management under /api/web/
         has_credential_paths = any(
-            "/api/web/" in p
-            and ("/api_credentials" in p or "/service_credentials" in p or "/scim_token" in p)
+            "/api/web/" in p and ("/api_credentials" in p or "/service_credentials" in p or "/scim_token" in p)
             for p in paths
         )
         if has_credential_paths and domain != "authentication":
@@ -1239,9 +1231,7 @@ def merge_specs_by_domain(
                     continue
 
                 # Skip threat_campaign/threat_mesh paths if not merging into threat_campaign domain
-                if not is_threat_campaign_domain and (
-                    "/api/waf/threat_campaign" in path or "/threat_mesh" in path
-                ):
+                if not is_threat_campaign_domain and ("/api/waf/threat_campaign" in path or "/threat_mesh" in path):
                     continue
 
                 # Skip data-intelligence paths if not merging into data_intelligence domain
@@ -1255,9 +1245,7 @@ def merge_specs_by_domain(
                 # Skip credential management paths if not merging into authentication domain
                 # Pattern-based: /api/web/ + (api_credentials|service_credentials|scim_token)
                 is_credential_path = "/api/web/" in path and (
-                    "/api_credentials" in path
-                    or "/service_credentials" in path
-                    or "/scim_token" in path
+                    "/api_credentials" in path or "/service_credentials" in path or "/scim_token" in path
                 )
                 if not is_auth_domain and is_credential_path:
                     continue
@@ -1276,9 +1264,7 @@ def merge_specs_by_domain(
                         if method not in merged_spec["paths"][path]:
                             merged_spec["paths"][path][method] = operation
                             stats["paths"] += 1
-                        elif isinstance(operation, dict) and isinstance(
-                            merged_spec["paths"][path].get(method), dict
-                        ):
+                        elif isinstance(operation, dict) and isinstance(merged_spec["paths"][path].get(method), dict):
                             existing = merged_spec["paths"][path][method]
                             for k, v in operation.items():
                                 if k not in existing:
@@ -1826,6 +1812,23 @@ def run_pipeline(
                 )
             except Exception as e:
                 console.print(f"[yellow]Warning: Failed to export minimal defaults: {e}[/yellow]")
+
+            # Export namespace_profiles.json — the authoritative resource->namespace
+            # scope map consumed by downstream tree filtering (vscode-xcsh, xcsh).
+            # Rides alongside the domain specs (like validation.json) and is read by
+            # the consumer via an explicit path, not parsed as a domain spec.
+            try:
+                np_profiles_exporter = NamespaceProfilesExporter()
+                np_profiles_artifact = np_profiles_exporter.export(
+                    output_dir / "namespace_profiles.json",
+                    version=version,
+                )
+                console.print(
+                    f"[green]Exported namespace_profiles.json: "
+                    f"{len(np_profiles_artifact['resources'])} resource overrides + default[/green]",
+                )
+            except Exception as e:
+                console.print(f"[yellow]Warning: Failed to export namespace profiles: {e}[/yellow]")
 
             console.print(f"[green]Created {len(domain_specs)} domain specs + master spec[/green]")
 

--- a/scripts/utils/namespace_profiles_exporter.py
+++ b/scripts/utils/namespace_profiles_exporter.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Namespace Profiles Exporter.
+
+Exports the authoritative resource->namespace-profile map to a standalone JSON
+artifact (``namespace_profiles.json``) for downstream consumers (vscode-xcsh, xcsh).
+
+This artifact is the single source of truth the extension consumes to decide which
+resource types may exist in which namespaces (built-in vs custom). It is built from
+``config/namespace_profile.yaml`` via :class:`NamespaceProfileEnricher`, reusing the
+exact same merge logic that embeds ``x-f5xc-namespace-profile`` into the specs, so the
+flat map and the per-spec extensions can never drift apart.
+
+Usage:
+    python -m scripts.utils.namespace_profiles_exporter
+    python -m scripts.utils.namespace_profiles_exporter --output path/to/output.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts.utils.json_writer import write_json_file
+from scripts.utils.namespace_profile_enricher import NamespaceProfileEnricher
+
+
+class NamespaceProfilesExporter:
+    """Export the resource->namespace-profile map to standalone JSON.
+
+    Reads ``config/namespace_profile.yaml`` (via the enricher) and emits a flat,
+    self-contained map: a ``default`` profile plus one fully merged profile per
+    resource override. Downstream consumers resolve a resource as
+    ``resources[key]`` falling back to ``default``.
+    """
+
+    def __init__(self, config_path: Path | None = None) -> None:
+        """Initialize with the namespace profile configuration.
+
+        Args:
+            config_path: Path to ``namespace_profile.yaml``. Defaults to the
+                enricher's own default (``config/namespace_profile.yaml``).
+        """
+        self.enricher = NamespaceProfileEnricher(config_path=config_path)
+
+    def build(self, version: str | None = None) -> dict[str, Any]:
+        """Build the namespace profiles artifact dictionary.
+
+        Args:
+            version: Pipeline version to stamp into the artifact.
+
+        Returns:
+            The artifact with ``default`` and per-resource merged profiles.
+        """
+        config = self.enricher.config
+        resource_keys = config.get("resources", {})
+
+        resources: dict[str, Any] = {}
+        for name in sorted(resource_keys):
+            # Fully merged (default + override) profile, identical to what the
+            # enricher embeds as x-f5xc-namespace-profile for this resource.
+            resources[name] = self.enricher.get_profile_for_resource(name)
+
+        return {
+            "version": version or "0.0.0",
+            "generated_at": datetime.now(tz=timezone.utc).isoformat(),
+            "source": "api-specs-enriched/config/namespace_profile.yaml",
+            "default": config["default_profile"],
+            "resources": resources,
+        }
+
+    def export(self, output_path: Path, version: str | None = None) -> dict[str, Any]:
+        """Build the artifact and write it to ``output_path``.
+
+        Delegates to :func:`write_json_file` so formatting matches Biome
+        expectations (same as the other downstream JSON artifacts).
+
+        Args:
+            output_path: Destination JSON path.
+            version: Pipeline version to stamp into the artifact.
+
+        Returns:
+            The artifact dictionary that was written.
+        """
+        artifact = self.build(version=version)
+        write_json_file(artifact, output_path, indent=2, ensure_ascii=False)
+        return artifact
+
+
+def main() -> int:
+    """Main entry point for standalone namespace profiles export."""
+    parser = argparse.ArgumentParser(
+        description="Export the F5 XC resource->namespace-profile map to standalone JSON",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help="Path to namespace_profile.yaml (defaults to config/namespace_profile.yaml)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("docs/specifications/api/namespace_profiles.json"),
+        help="Output path for namespace_profiles.json",
+    )
+    parser.add_argument(
+        "--version",
+        type=str,
+        default=None,
+        help="Version string to stamp into the artifact",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print output to stdout without writing a file",
+    )
+
+    args = parser.parse_args()
+
+    try:
+        exporter = NamespaceProfilesExporter(config_path=args.config)
+
+        if args.dry_run:
+            artifact = exporter.build(version=args.version)
+            print(json.dumps(artifact, indent=2, ensure_ascii=False))
+        else:
+            artifact = exporter.export(args.output, version=args.version)
+            print(
+                f"Namespace profiles exported to: {args.output} "
+                f"({len(artifact['resources'])} resource overrides + default)",
+            )
+        return 0
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error exporting namespace profiles: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #848

## Summary
Emit an authoritative `namespace_profiles.json` so downstream consumers (vscode-xcsh, xcsh) have a single source of truth for which resource types may live in which namespaces.

- **New** `scripts/utils/namespace_profiles_exporter.py` — builds `{ version, default, resources }` from `config/namespace_profile.yaml` via `NamespaceProfileEnricher.get_profile_for_resource` (same merge logic that embeds `x-f5xc-namespace-profile`), so the flat map and per-spec extensions cannot drift. 105 resource overrides + default.
- `scripts/pipeline.py` — export wired alongside `validation.json` (writes `docs/specifications/api/namespace_profiles.json`).
- `scripts/lint.py` — allowlisted as a non-OpenAPI artifact.

## Packaging
No workflow change needed: the release loop in `sync-and-enrich.yml` already copies non-excluded `docs/specifications/api/*.json` into the zip's `domains/`, so `namespace_profiles.json` ships alongside `validation.json`.

## Verification
- `python3 -m scripts.utils.namespace_profiles_exporter --dry-run` → 105 resources + default; spot-checks match the YAML (`aws_vpc_site`/`dns_zone` → `["system"]`, `namespace_role_binding` → `["shared"]`, default → `["custom","default","shared"]`).
- `ruff check` clean.

## Rollout
Land + release this first; the vscode-xcsh consumer PR depends on the released map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)