### PR TITLE
fix: add .ruff.toml extending pyproject.toml

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,1 @@
+extend = "pyproject.toml"


### PR DESCRIPTION
Closes #851

## Summary

- Adds `.ruff.toml` with `extend = "pyproject.toml"` so super-linter's `PYTHON_RUFF_CONFIG_FILE: .ruff.toml` finds a valid config
- Ruff inherits all settings from `pyproject.toml` (`line-length = 100`, `target-version = py310`, lint rules, per-file-ignores)
- No config duplication — pyproject.toml remains the single source of truth

## Context

This repo is in docs-control's `.ruff.toml` skip_files list (intentionally, since it needs `line-length = 100` vs the managed default of 88). Without a `.ruff.toml` file, super-linter may not apply the correct ruff settings.