### PR TITLE
fix: restrict unverified resources to system namespace

### DIFF
--- a/config/namespace_profile.yaml
+++ b/config/namespace_profile.yaml
@@ -1276,244 +1276,324 @@ resources:
       category: "infrastructure"
       multi_tenant_pattern: "none"
 
-  # Tenant-scoped (domain knowledge — uses default constraint)
+  # Restricted to system (conservative default — needs CRUD verification to unlock)
 
   ai_gateway:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   ai_policy:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   alert:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "observability"
       multi_tenant_pattern: "per-tenant"
 
   analytics_query:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   api_endpoint:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   api_rate_limit:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   audit_log:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "observability"
       multi_tenant_pattern: "per-tenant"
 
   authentication_policy:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   bigip_device:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   bigip_pool:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   blindfold_secret:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   bot_defense_instance:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   bucket:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   cdn_origin_pool:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   dashboard:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "observability"
       multi_tenant_pattern: "per-tenant"
 
   data_classification:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   data_export:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   ddos_mitigation_rule:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "networking"
       multi_tenant_pattern: "per-tenant"
 
   ddos_protection:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "networking"
       multi_tenant_pattern: "per-tenant"
 
   insight_query:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "observability"
       multi_tenant_pattern: "per-tenant"
 
   malicious_user_detection:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   marketplace_item:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   metrics_receiver:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "observability"
       multi_tenant_pattern: "per-tenant"
 
   mk8s_cluster:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "infrastructure"
       multi_tenant_pattern: "per-tenant"
 
   namespace_role:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "identity"
       multi_tenant_pattern: "per-tenant"
 
   nginx_config:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   nginx_upstream:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   object_store:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   pod_security_policy:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   policy_document:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   saved_query:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "observability"
       multi_tenant_pattern: "per-tenant"
 
   service_discovery:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "infrastructure"
       multi_tenant_pattern: "per-tenant"
 
   shape_app_firewall:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   static_asset:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   support_case:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   telemetry_receiver:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "observability"
       multi_tenant_pattern: "per-tenant"
 
   threat_campaign_policy:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   threat_category:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "security"
       multi_tenant_pattern: "per-tenant"
 
   ui_component:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
 
   user_role:
-    _verification: {status: assumed, method: domain_knowledge, date: "2026-06-28"}
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
     classification:
       category: "identity"
       multi_tenant_pattern: "per-tenant"
@@ -1567,3 +1647,320 @@ resources:
     classification:
       category: "application"
       multi_tenant_pattern: "per-tenant"
+
+  # ══════════════════════════════════════════════════════════════════════
+  # Tree-view resources without prior classification — restricted to
+  # system until CRUD-verified as tenant-scoped (2026-06-29)
+  # ══════════════════════════════════════════════════════════════════════
+
+  udp_loadbalancer:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  protected_application:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  api_group:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  enhanced_firewall_policy:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  securemesh_site_v2:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "infrastructure"
+      multi_tenant_pattern: "none"
+
+  v1_dns_monitor:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "observability"
+      multi_tenant_pattern: "none"
+
+  v1_http_monitor:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "observability"
+      multi_tenant_pattern: "none"
+
+  api_crawler:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  api_discovery:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  api_testing:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  discovered_service:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "infrastructure"
+      multi_tenant_pattern: "none"
+
+  bigip_irule:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "application"
+      multi_tenant_pattern: "none"
+
+  bigip_virtual_server:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "application"
+      multi_tenant_pattern: "none"
+
+  infraprotect_asn:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  infraprotect_firewall_rule:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  infraprotect_tunnel:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  infraprotect_asn_prefix:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  infraprotect_deny_list_rule:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  infraprotect_firewall_rule_group:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  infraprotect_firewall_ruleset:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  infraprotect_internet_prefix_advertisement:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  nginx_instance:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "application"
+      multi_tenant_pattern: "none"
+
+  nginx_server:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "application"
+      multi_tenant_pattern: "none"
+
+  nginx_csg:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "application"
+      multi_tenant_pattern: "none"
+
+  nginx_service_discovery:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "application"
+      multi_tenant_pattern: "none"
+
+  protected_domain:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  allowed_domain:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  mitigated_domain:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  bot_allowlist_policy:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  bot_endpoint_policy:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  bot_network_policy:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  shape_bot_defense_instance:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  bot_detection_rule:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  nat_policy:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  policy_based_routing:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "networking"
+      multi_tenant_pattern: "none"
+
+  secret_management_access:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  secret_policy_rule:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "security"
+      multi_tenant_pattern: "none"
+
+  lma_region:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "observability"
+      multi_tenant_pattern: "none"
+
+  flow_anomaly:
+    constraint:
+      allowed: ["system"]
+    _verification: {status: restricted, method: conservative_default, date: "2026-06-29"}
+    classification:
+      category: "observability"
+      multi_tenant_pattern: "none"

--- a/docs/specifications/api/namespace_profiles.json
+++ b/docs/specifications/api/namespace_profiles.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.1.164",
-  "generated_at": "2026-06-29T02:39:32.157792+00:00",
+  "version": "0.0.0",
+  "generated_at": "2026-06-29T03:34:29.287098+00:00",
   "source": "api-specs-enriched/config/namespace_profile.yaml",
   "default": {
     "constraint": {
@@ -47,9 +47,7 @@
     "ai_gateway": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -64,16 +62,14 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "ai_policy": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -88,16 +84,14 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "alert": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -112,8 +106,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "alert_policy": {
@@ -184,12 +178,32 @@
         "method": ""
       }
     },
+    "allowed_domain": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
     "analytics_query": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -204,8 +218,30 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "api_crawler": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "api_credential": {
@@ -276,12 +312,32 @@
         "method": ""
       }
     },
+    "api_discovery": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
     "api_endpoint": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -296,16 +352,36 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "api_group": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "api_rate_limit": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -320,8 +396,30 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "api_testing": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "app_firewall": {
@@ -400,9 +498,7 @@
     "audit_log": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -417,16 +513,14 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "authentication_policy": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -441,8 +535,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "aws_tgw_site": {
@@ -580,9 +674,7 @@
     "bigip_device": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -597,16 +689,36 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "bigip_irule": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "bigip_pool": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -621,16 +733,36 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "bigip_virtual_server": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "blindfold_secret": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -645,8 +777,30 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "bot_allowlist_policy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "bot_defense_app_infrastructure": {
@@ -676,9 +830,7 @@
     "bot_defense_instance": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -693,16 +845,80 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "bot_detection_rule": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "bot_endpoint_policy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "bot_network_policy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "bucket": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -717,8 +933,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "ca_certificate": {
@@ -772,9 +988,7 @@
     "cdn_origin_pool": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -789,8 +1003,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "certificate": {
@@ -980,9 +1194,7 @@
     "dashboard": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -997,16 +1209,14 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "data_classification": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -1021,16 +1231,14 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "data_export": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -1045,8 +1253,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "data_group": {
@@ -1122,9 +1330,7 @@
     "ddos_mitigation_rule": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -1139,16 +1345,14 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "ddos_protection": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -1163,8 +1367,30 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "discovered_service": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "infrastructure",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "discovery": {
@@ -1345,6 +1571,28 @@
         "method": "crud"
       }
     },
+    "enhanced_firewall_policy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
     "fast_acl": {
       "constraint": {
         "allowed": [
@@ -1433,6 +1681,28 @@
         "explicit": true,
         "verification": "verified",
         "method": "crud"
+      }
+    },
+    "flow_anomaly": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "observability",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "forward_proxy_policy": {
@@ -1626,12 +1896,186 @@
         "method": ""
       }
     },
+    "infraprotect_asn": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "infraprotect_asn_prefix": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "infraprotect_deny_list_rule": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "infraprotect_firewall_rule": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "infraprotect_firewall_rule_group": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "infraprotect_firewall_ruleset": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "infraprotect_internet_prefix_advertisement": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "infraprotect_tunnel": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
     "insight_query": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -1646,8 +2090,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "interface": {
@@ -1833,6 +2277,28 @@
         "method": ""
       }
     },
+    "lma_region": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "observability",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
     "log_receiver": {
       "constraint": {
         "allowed": [
@@ -1858,9 +2324,7 @@
     "malicious_user_detection": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -1875,8 +2339,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "malicious_user_mitigation": {
@@ -1930,9 +2394,7 @@
     "marketplace_item": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -1947,16 +2409,14 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "metrics_receiver": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -1971,8 +2431,30 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "mitigated_domain": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "mitigation_policy": {
@@ -2002,9 +2484,7 @@
     "mk8s_cluster": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2019,8 +2499,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "namespace": {
@@ -2048,9 +2528,7 @@
     "namespace_role": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2065,8 +2543,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "namespace_role_binding": {
@@ -2089,6 +2567,28 @@
         "explicit": true,
         "verification": "unverified",
         "method": ""
+      }
+    },
+    "nat_policy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "network_connector": {
@@ -2228,9 +2728,7 @@
     "nginx_config": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2245,16 +2743,102 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "nginx_csg": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "nginx_instance": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "nginx_server": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "nginx_service_discovery": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "nginx_upstream": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2269,8 +2853,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "node_config": {
@@ -2298,9 +2882,7 @@
     "object_store": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2315,8 +2897,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "origin_pool": {
@@ -2390,9 +2972,7 @@
     "pod_security_policy": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2407,8 +2987,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "policer": {
@@ -2435,12 +3015,32 @@
         "method": ""
       }
     },
+    "policy_based_routing": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
     "policy_document": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2455,8 +3055,52 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "protected_application": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "protected_domain": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "protocol_inspection": {
@@ -2693,9 +3337,7 @@
     "saved_query": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2710,8 +3352,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "secret": {
@@ -2734,6 +3376,28 @@
         "explicit": true,
         "verification": "unverified",
         "method": ""
+      }
+    },
+    "secret_management_access": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "secret_policy": {
@@ -2760,6 +3424,28 @@
         "method": ""
       }
     },
+    "secret_policy_rule": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
     "securemesh_site": {
       "constraint": {
         "allowed": [
@@ -2780,6 +3466,28 @@
         "explicit": true,
         "verification": "unverified",
         "method": ""
+      }
+    },
+    "securemesh_site_v2": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "infrastructure",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "sensitive_data_policy": {
@@ -2831,9 +3539,7 @@
     "service_discovery": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2848,8 +3554,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "service_policy": {
@@ -2906,9 +3612,7 @@
     "shape_app_firewall": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -2923,8 +3627,30 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "shape_bot_defense_instance": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "security",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "shape_recognizer": {
@@ -3062,9 +3788,7 @@
     "static_asset": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -3079,8 +3803,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "subnet": {
@@ -3130,9 +3854,7 @@
     "support_case": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -3147,8 +3869,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "tcp_loadbalancer": {
@@ -3178,9 +3900,7 @@
     "telemetry_receiver": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -3195,8 +3915,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "tenant": {
@@ -3268,9 +3988,7 @@
     "threat_campaign_policy": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -3285,16 +4003,14 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "threat_category": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -3309,8 +4025,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "token": {
@@ -3381,12 +4097,32 @@
         "method": ""
       }
     },
+    "udp_loadbalancer": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "networking",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
     "ui_component": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -3401,8 +4137,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "upgrade_os": {
@@ -3520,9 +4256,7 @@
     "user_role": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
         "enforced": true
       },
@@ -3537,8 +4271,52 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "assumed",
-        "method": "domain_knowledge"
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "v1_dns_monitor": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "observability",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
+      }
+    },
+    "v1_http_monitor": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "observability",
+        "multi_tenant_pattern": "none"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "conservative_default"
       }
     },
     "views_advertise_policy": {
@@ -3915,12 +4693,9 @@
     }
   },
   "_coverage": {
-    "total_explicit": 168,
+    "total_explicit": 207,
     "verified": 19,
-    "assumed": 50,
-    "unverified": 99
-  },
-  "info": {
-    "version": "2.1.165"
+    "assumed": 10,
+    "unverified": 178
   }
 }


### PR DESCRIPTION
## Summary

- Restrict 78 unverified resource types to system-only namespace
- Reduces custom namespace tree from 67 resources / 16 categories to 28 resources / 10 categories
- Only CRUD-verified and shared-ref resources appear in custom namespaces
- Resources marked `_verification: {status: restricted}` can be unlocked after CRUD verification

## Test plan
- [x] All 2166 pytest tests pass
- [x] Downstream vscode-xcsh: all 1170 tests pass
- [x] Custom namespace tree verified: 28 resources across 10 categories

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)