### PR TITLE
feat: spec determinism enrichment — x-f5xc-references + x-f5xc-field-examples (DRY)

### DIFF
--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -84,6 +84,32 @@ rules:
       functionOptions:
         notMatch: "^(my|test|foo|demo|sample)-[a-z]"
 
+  # x-f5xc-references descriptor validation (resource-reference dependency metadata)
+  x-f5xc-references-valid-type:
+    description: "x-f5xc-references must be an array"
+    message: "x-f5xc-references must be an array of reference descriptors, got {{type}}"
+    severity: error
+    given: "$..['x-f5xc-references']"
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: array
+
+  x-f5xc-references-descriptor-shape:
+    description: "Each x-f5xc-references entry must have resource_kind + field_path"
+    message: "x-f5xc-references entry missing required fields (resource_kind, field_path)"
+    severity: warn
+    given: "$..['x-f5xc-references'][*]"
+    then:
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          required:
+            - resource_kind
+            - field_path
+
   # placeholder-check removed: requires custom function definition not bundled with spectral:oas
 
 overrides:

--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -1095,6 +1095,15 @@ resources:
       label: WAF
       form_section: waf
       resource_type: app_firewall
+    spec.origin_pool:
+      widget_type: configurable
+      label: CDN Origin Pool
+      required: true
+      default_state: Not configured
+      configure_action: Configure
+      form_section: cdn-origin-pool
+      description: CDN Origin Pool configuration — required. Click Configure to set origin servers.
+      notes: Inline sub-form (not a reference to a separate resource). The UI shows "Field CDN Origin Pool in Spec is required" when not configured.
   aws_vpc_site:
     metadata.name:
       widget_type: textbox

--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -2769,6 +2769,10 @@ resources:
       label: Fleet Label Value
       required: true
       form_section: fleet-configuration
+      default: test-fleet-label
+      validation:
+        pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+        max_length: 64
     spec.outside_site_local_virtual_network:
       widget_type: listbox
       label: Outside (Site Local) Virtual Network

--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -171,7 +171,7 @@ resources:
       mutually_exclusive_with:
       - spec.disable_bot_defense
     spec.bot_defense_advanced:
-      widget_type: configurable
+      widget_type: listbox
       label: Bot Defense Advanced
       required: false
       form_section: bot-protection
@@ -187,7 +187,7 @@ resources:
       - spec.bot_defense
       - spec.bot_defense_advanced
     spec.api_specification:
-      widget_type: configurable
+      widget_type: listbox
       label: API Definition
       required: false
       form_section: api-protection
@@ -337,7 +337,7 @@ resources:
       - Custom
       form_section: dos-settings
     spec.captcha_challenge:
-      widget_type: configurable
+      widget_type: listbox
       label: Captcha Challenge
       required: false
       form_section: dos-settings
@@ -346,7 +346,7 @@ resources:
       - spec.no_challenge
       - spec.policy_based_challenge
     spec.js_challenge:
-      widget_type: configurable
+      widget_type: listbox
       label: JavaScript Challenge
       required: false
       form_section: dos-settings
@@ -365,7 +365,7 @@ resources:
       - spec.js_challenge
       - spec.policy_based_challenge
     spec.policy_based_challenge:
-      widget_type: configurable
+      widget_type: listbox
       label: Policy-Based Challenge
       required: false
       form_section: dos-settings
@@ -374,7 +374,7 @@ resources:
       - spec.js_challenge
       - spec.no_challenge
     spec.enable_challenge:
-      widget_type: configurable
+      widget_type: listbox
       label: Challenge Settings
       required: false
       form_section: dos-settings
@@ -389,7 +389,7 @@ resources:
       - spec.active_service_policies
       - spec.no_service_policies
     spec.active_service_policies:
-      widget_type: configurable
+      widget_type: listbox
       label: Service Policies
       required: false
       form_section: common-security-controls
@@ -542,7 +542,7 @@ resources:
       - spec.advertise_custom
       - spec.do_not_advertise
     spec.advertise_custom:
-      widget_type: configurable
+      widget_type: listbox
       label: VIP Advertisement
       form_section: other-settings
       notes: Custom advertisement configuration
@@ -595,7 +595,7 @@ resources:
       - spec.source_ip_stickiness
       - spec.cookie_stickiness
     spec.ring_hash:
-      widget_type: configurable
+      widget_type: listbox
       label: LB Algorithm
       form_section: other-settings
       notes: Ring hash with configurable hash policy
@@ -617,7 +617,7 @@ resources:
       - spec.ring_hash
       - spec.cookie_stickiness
     spec.cookie_stickiness:
-      widget_type: configurable
+      widget_type: listbox
       label: LB Algorithm
       form_section: other-settings
       notes: Cookie-based stickiness with configurable cookie
@@ -637,7 +637,7 @@ resources:
       mutually_exclusive_with:
       - spec.enable_trust_client_ip_headers
     spec.enable_trust_client_ip_headers:
-      widget_type: configurable
+      widget_type: listbox
       label: Trusted Client IP Headers
       required: false
       form_section: other-settings
@@ -664,7 +664,7 @@ resources:
       mutually_exclusive_with:
       - spec.single_lb_app
     spec.single_lb_app:
-      widget_type: configurable
+      widget_type: listbox
       label: Single-LB Application
       form_section: other-settings
       notes: Single load balancer application settings
@@ -677,7 +677,7 @@ resources:
       default: Default
       notes: Empty object sentinel — use system default timeout values
     spec.malware_protection_settings:
-      widget_type: configurable
+      widget_type: listbox
       label: Malware Protection
       form_section: malware-protection
       disabled: true
@@ -693,7 +693,7 @@ resources:
       mutually_exclusive_with:
       - spec.malware_protection_settings
     spec.client_side_defense:
-      widget_type: configurable
+      widget_type: listbox
       label: Client-Side Defense
       form_section: client-side-defense
       disabled: true
@@ -810,7 +810,7 @@ resources:
       required: false
       form_section: health-checks
     spec.use_tls:
-      widget_type: configurable
+      widget_type: listbox
       label: TLS
       form_section: tls
       nested_properties: 13
@@ -920,7 +920,7 @@ resources:
       widget_type: listbox
   healthcheck:
     http_health_check:
-      widget_type: configurable
+      widget_type: listbox
       label: HTTP HealthCheck
       form_section: health-check-parameters
       mutually_exclusive_with:
@@ -975,7 +975,7 @@ resources:
       - spec.server_name_matcher
       - spec.server_selector
     spec.rule_list:
-      widget_type: configurable
+      widget_type: listbox
       label: Custom Rule List
       form_section: rules
       mutually_exclusive_with:
@@ -1024,7 +1024,7 @@ resources:
       required: true
       description: 'Server-required: Must be SMA_PROXY or UDP_PROXY'
     spec.tls_parameters:
-      widget_type: configurable
+      widget_type: listbox
       label: TLS Parameters
       form_section: tls
       notes: Downstream TLS configuration
@@ -1220,7 +1220,7 @@ resources:
       label: Description
       form_section: metadata
     spec.primary:
-      widget_type: configurable
+      widget_type: listbox
       label: Primary DNS Zone
       form_section: zone-type
     spec.domain:
@@ -1306,7 +1306,7 @@ resources:
       label: Description
       form_section: metadata
     spec.cluster_wide_app_list:
-      widget_type: configurable
+      widget_type: listbox
       label: Cluster-Wide Apps
       form_section: basic
   v1_http_monitor:
@@ -1728,7 +1728,7 @@ resources:
       label: Description
       form_section: metadata
     spec.simple_static_route:
-      widget_type: configurable
+      widget_type: listbox
       label: Static Route
       form_section: basic
   address_allocator:
@@ -3135,7 +3135,7 @@ resources:
       default: Ethernet Interface
       form_section: interface-type
     spec.ethernet_interface:
-      widget_type: configurable
+      widget_type: listbox
       label: Ethernet Interface
       required: true
       form_section: interface-type

--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -989,7 +989,7 @@ resources:
       label: Rule Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
       console_preselected: true
   virtual_host:
     metadata.name:
@@ -1037,7 +1037,7 @@ resources:
       label: CSRF Policy
       form_section: security
     spec.waf_type:
-      widget_type: configurable
+      widget_type: listbox
       label: WAF Type
       form_section: security
     spec.buffer_policy:
@@ -1290,7 +1290,7 @@ resources:
       label: Log Type
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   k8s_cluster:
     metadata.name:
       widget_type: textbox
@@ -1547,7 +1547,7 @@ resources:
       label: Description
       form_section: metadata
     spec.rules:
-      widget_type: configurable
+      widget_type: listbox
       label: Data Type Rules
       form_section: basic
       required: true
@@ -1694,7 +1694,7 @@ resources:
       label: Bfd Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   ike_gateway:
     metadata.name:
       widget_type: textbox
@@ -1775,7 +1775,7 @@ resources:
       label: Address Allocation Scheme
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   advertise_policy:
     metadata.name:
       widget_type: textbox
@@ -1828,7 +1828,7 @@ resources:
       label: Port Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   api_credential:
     metadata.name:
       widget_type: textbox
@@ -1931,7 +1931,7 @@ resources:
       label: App Type Settings
       form_section: basic-configuration
       description: 'Server-required: Minimum items of 1'
-      widget_type: configurable
+      widget_type: listbox
   app_type:
     metadata.name:
       widget_type: textbox
@@ -2129,7 +2129,7 @@ resources:
       label: Certificate Url
       form_section: basic-configuration
       description: 'Server-required: Minimum bytes of 1'
-      widget_type: configurable
+      widget_type: listbox
   cloud_connect:
     metadata.name:
       widget_type: textbox
@@ -2542,7 +2542,7 @@ resources:
       label: Discovery Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   dns_domain:
     deprecated: true
     deprecated_reason: functionality removed from the F5 XC platform — delegated domain management is being decommissioned
@@ -2753,7 +2753,7 @@ resources:
       default: Site Type Regional Edge
       form_section: fast-acl-type
     spec.site_type_regional_edge:
-      widget_type: configurable
+      widget_type: listbox
       label: Site Type Regional Edge
       required: true
       form_section: fast-acl-type
@@ -2766,7 +2766,7 @@ resources:
       label: Site Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   fleet:
     namespace_scope: system
     metadata.name:
@@ -2978,7 +2978,7 @@ resources:
       label: Log Receiver Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   malicious_user_mitigation:
     metadata.name:
       widget_type: textbox
@@ -3037,7 +3037,7 @@ resources:
       label: Applies To Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   network_connector:
     metadata.name:
       widget_type: textbox
@@ -3081,7 +3081,7 @@ resources:
       label: Connector Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   network_firewall:
     metadata.name:
       widget_type: textbox
@@ -3181,7 +3181,7 @@ resources:
       label: Service Provider Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   openapi_file:
     metadata.name:
       widget_type: textbox
@@ -3297,7 +3297,7 @@ resources:
       default: Site or Virtual Site
       form_section: sites-or-virtual-sites
     spec.site_or_virtual_site:
-      widget_type: configurable
+      widget_type: listbox
       label: Site or Virtual Site
       required: true
       form_section: sites-or-virtual-sites
@@ -3324,7 +3324,7 @@ resources:
       label: Proxy Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   public_ip:
     metadata.name:
       widget_type: textbox
@@ -3550,7 +3550,7 @@ resources:
       label: Provider Choice
       form_section: basic-configuration
       description: 'Server-required: Field should be not nil'
-      widget_type: configurable
+      widget_type: listbox
   segment:
     metadata.name:
       widget_type: textbox
@@ -3650,7 +3650,7 @@ resources:
       default: Virtual Site
       form_section: advertise-policy
     spec.reference:
-      widget_type: configurable
+      widget_type: listbox
       label: Reference
       required: true
       form_section: spec
@@ -3692,7 +3692,7 @@ resources:
       label: Description
       form_section: metadata
     spec.site_subnet_parameters:
-      widget_type: configurable
+      widget_type: listbox
       label: Site Subnet Parameters
       required: true
       form_section: site-subnet-parameters
@@ -3706,7 +3706,7 @@ resources:
       label: Site Subnet Parameters
       form_section: basic-configuration
       description: 'Server-required: Minimum items of 1'
-      widget_type: configurable
+      widget_type: listbox
   third_party_application:
     metadata.name:
       widget_type: textbox

--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -2593,10 +2593,10 @@ resources:
       default: HTTP/1.
       form_section: health-check-type
     spec.health_check_port:
-      widget_type: listbox
+      widget_type: spinbutton
       label: Health Check Port
       required: true
-      default: '0'
+      default: 80
       form_section: health-check-type
     spec.health_check_secondary_port:
       widget_type: listbox

--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -33,14 +33,14 @@ resources:
       required: true
       default: HTTPS with Automatic Certificate
       options:
-        - HTTP
-        - HTTPS with Automatic Certificate
-        - HTTPS with Custom Certificate
+      - HTTP
+      - HTTPS with Automatic Certificate
+      - HTTPS with Custom Certificate
       form_section: domains-and-lb-type
       notes: Selects between spec.http, spec.https, and spec.https_auto_cert
       mutually_exclusive_with:
-        - spec.http
-        - spec.https
+      - spec.http
+      - spec.https
     spec.http:
       widget_type: listbox
       label: Load Balancer Type
@@ -48,8 +48,8 @@ resources:
       hidden: true
       notes: Active when LB Type is HTTP; mutually exclusive with https variants
       mutually_exclusive_with:
-        - spec.https_auto_cert
-        - spec.https
+      - spec.https_auto_cert
+      - spec.https
     spec.https:
       widget_type: listbox
       label: Load Balancer Type
@@ -57,8 +57,8 @@ resources:
       hidden: true
       notes: Active when LB Type is HTTPS with Custom Certificate
       mutually_exclusive_with:
-        - spec.https_auto_cert
-        - spec.http
+      - spec.https_auto_cert
+      - spec.http
     spec.default_route_pools:
       widget_type: nested-resource-list
       label: Origin Pools
@@ -66,12 +66,14 @@ resources:
       add_action: Add Item
       nested_resource: origin_pool
       form_section: origins
+      resource_type: origin_pool
     spec.default_pool:
       widget_type: resource-selector
       label: Default Pool
       required: false
       form_section: origins
       notes: Alternative to default_route_pools for single pool
+      resource_type: origin_pool
     spec.default_pool_list:
       widget_type: nested-resource-list
       label: Default Pool List
@@ -98,8 +100,8 @@ resources:
       required: false
       default: Disable
       options:
-        - Disable
-        - Enable
+      - Disable
+      - Enable
       form_section: cdn
       notes: Empty object sentinel — presence means caching is disabled
     spec.app_firewall:
@@ -110,7 +112,7 @@ resources:
       form_section: waf
       notes: Enable WAF by selecting an App Firewall resource
       mutually_exclusive_with:
-        - spec.disable_waf
+      - spec.disable_waf
     spec.disable_waf:
       widget_type: listbox
       label: WAF
@@ -118,15 +120,15 @@ resources:
       form_section: waf
       notes: Empty object sentinel — presence means WAF is disabled
       mutually_exclusive_with:
-        - spec.app_firewall
+      - spec.app_firewall
     spec.waf_exclusion:
       widget_type: listbox
       label: WAF Exclusion
       required: false
       default: Inline Rules
       options:
-        - Inline Rules
-        - Custom Rules
+      - Inline Rules
+      - Custom Rules
       form_section: waf
       depends_on: spec.app_firewall
     spec.data_guard_rules:
@@ -163,11 +165,11 @@ resources:
       required: false
       default: Disable
       options:
-        - Disable
-        - Enable
+      - Disable
+      - Enable
       form_section: bot-protection
       mutually_exclusive_with:
-        - spec.disable_bot_defense
+      - spec.disable_bot_defense
     spec.bot_defense_advanced:
       widget_type: configurable
       label: Bot Defense Advanced
@@ -182,8 +184,8 @@ resources:
       form_section: bot-protection
       notes: Empty object sentinel — presence means bot defense is disabled
       mutually_exclusive_with:
-        - spec.bot_defense
-        - spec.bot_defense_advanced
+      - spec.bot_defense
+      - spec.bot_defense_advanced
     spec.api_specification:
       widget_type: configurable
       label: API Definition
@@ -191,7 +193,7 @@ resources:
       form_section: api-protection
       notes: Upload or reference an API spec for schema enforcement
       mutually_exclusive_with:
-        - spec.disable_api_definition
+      - spec.disable_api_definition
     spec.disable_api_definition:
       widget_type: listbox
       label: API Definition
@@ -199,7 +201,7 @@ resources:
       form_section: api-protection
       notes: Empty object sentinel — presence means API definition is disabled
       mutually_exclusive_with:
-        - spec.api_specification
+      - spec.api_specification
     spec.api_protection_rules:
       widget_type: configurable
       label: API Protection Rules
@@ -221,11 +223,11 @@ resources:
       required: false
       default: Disable
       options:
-        - Disable
-        - Enable
+      - Disable
+      - Enable
       form_section: api-protection
       mutually_exclusive_with:
-        - spec.disable_api_discovery
+      - spec.disable_api_discovery
     spec.disable_api_discovery:
       widget_type: listbox
       label: API Discovery
@@ -233,18 +235,18 @@ resources:
       form_section: api-protection
       notes: Empty object sentinel — presence means API discovery is disabled
       mutually_exclusive_with:
-        - spec.enable_api_discovery
+      - spec.enable_api_discovery
     spec.sensitive_data_policy:
       widget_type: listbox
       label: Sensitive Data Discovery
       required: false
       default: Default
       options:
-        - Default
-        - Custom
+      - Default
+      - Custom
       form_section: api-protection
       mutually_exclusive_with:
-        - spec.default_sensitive_data_policy
+      - spec.default_sensitive_data_policy
     spec.default_sensitive_data_policy:
       widget_type: listbox
       label: Sensitive Data Discovery
@@ -252,7 +254,7 @@ resources:
       form_section: api-protection
       notes: Empty object sentinel — uses default sensitive data policy
       mutually_exclusive_with:
-        - spec.sensitive_data_policy
+      - spec.sensitive_data_policy
     spec.api_rate_limit:
       widget_type: configurable
       label: API Rate Limit
@@ -266,11 +268,11 @@ resources:
       required: false
       default: Disable
       options:
-        - Disable
-        - Enable
+      - Disable
+      - Enable
       form_section: api-protection
       mutually_exclusive_with:
-        - spec.disable_api_testing
+      - spec.disable_api_testing
     spec.disable_api_testing:
       widget_type: listbox
       label: API Testing
@@ -278,7 +280,7 @@ resources:
       form_section: api-protection
       notes: Empty object sentinel — presence means API testing is disabled
       mutually_exclusive_with:
-        - spec.api_testing
+      - spec.api_testing
     spec.sensitive_data_disclosure_rules:
       widget_type: configurable
       label: Sensitive Data Exposure Rules
@@ -299,8 +301,8 @@ resources:
       form_section: dos-settings
       notes: Empty object sentinel — block mitigation action
       mutually_exclusive_with:
-        - spec.l7_ddos_action_default
-        - spec.l7_ddos_action_js_challenge
+      - spec.l7_ddos_action_default
+      - spec.l7_ddos_action_js_challenge
     spec.l7_ddos_action_default:
       widget_type: listbox
       label: Mitigation Action
@@ -308,16 +310,16 @@ resources:
       form_section: dos-settings
       notes: Empty object sentinel — no mitigation action
       mutually_exclusive_with:
-        - spec.l7_ddos_action_block
-        - spec.l7_ddos_action_js_challenge
+      - spec.l7_ddos_action_block
+      - spec.l7_ddos_action_js_challenge
     spec.l7_ddos_action_js_challenge:
       widget_type: listbox
       label: Mitigation Action
       default: JavaScript Challenge
       form_section: dos-settings
       mutually_exclusive_with:
-        - spec.l7_ddos_action_block
-        - spec.l7_ddos_action_default
+      - spec.l7_ddos_action_block
+      - spec.l7_ddos_action_default
     spec.ddos_mitigation_rules:
       widget_type: configurable
       label: DDoS Mitigation Rules
@@ -331,8 +333,8 @@ resources:
       required: false
       default: Default
       options:
-        - Default
-        - Custom
+      - Default
+      - Custom
       form_section: dos-settings
     spec.captcha_challenge:
       widget_type: configurable
@@ -340,18 +342,18 @@ resources:
       required: false
       form_section: dos-settings
       mutually_exclusive_with:
-        - spec.js_challenge
-        - spec.no_challenge
-        - spec.policy_based_challenge
+      - spec.js_challenge
+      - spec.no_challenge
+      - spec.policy_based_challenge
     spec.js_challenge:
       widget_type: configurable
       label: JavaScript Challenge
       required: false
       form_section: dos-settings
       mutually_exclusive_with:
-        - spec.captcha_challenge
-        - spec.no_challenge
-        - spec.policy_based_challenge
+      - spec.captcha_challenge
+      - spec.no_challenge
+      - spec.policy_based_challenge
     spec.no_challenge:
       widget_type: listbox
       label: Client-Side Challenge
@@ -359,18 +361,18 @@ resources:
       form_section: dos-settings
       notes: Empty object sentinel — no client-side challenge
       mutually_exclusive_with:
-        - spec.captcha_challenge
-        - spec.js_challenge
-        - spec.policy_based_challenge
+      - spec.captcha_challenge
+      - spec.js_challenge
+      - spec.policy_based_challenge
     spec.policy_based_challenge:
       widget_type: configurable
       label: Policy-Based Challenge
       required: false
       form_section: dos-settings
       mutually_exclusive_with:
-        - spec.captcha_challenge
-        - spec.js_challenge
-        - spec.no_challenge
+      - spec.captcha_challenge
+      - spec.js_challenge
+      - spec.no_challenge
     spec.enable_challenge:
       widget_type: configurable
       label: Challenge Settings
@@ -384,8 +386,8 @@ resources:
       form_section: common-security-controls
       notes: Empty object sentinel — applies namespace-level service policies
       mutually_exclusive_with:
-        - spec.active_service_policies
-        - spec.no_service_policies
+      - spec.active_service_policies
+      - spec.no_service_policies
     spec.active_service_policies:
       widget_type: configurable
       label: Service Policies
@@ -393,27 +395,27 @@ resources:
       form_section: common-security-controls
       notes: Apply specified service policies
       mutually_exclusive_with:
-        - spec.service_policies_from_namespace
-        - spec.no_service_policies
+      - spec.service_policies_from_namespace
+      - spec.no_service_policies
     spec.no_service_policies:
       widget_type: listbox
       label: Service Policies
       form_section: common-security-controls
       notes: Empty object sentinel — do not apply service policies
       mutually_exclusive_with:
-        - spec.service_policies_from_namespace
-        - spec.active_service_policies
+      - spec.service_policies_from_namespace
+      - spec.active_service_policies
     spec.enable_ip_reputation:
       widget_type: listbox
       label: IP Reputation
       required: false
       default: Disable
       options:
-        - Disable
-        - Enable
+      - Disable
+      - Enable
       form_section: common-security-controls
       mutually_exclusive_with:
-        - spec.disable_ip_reputation
+      - spec.disable_ip_reputation
     spec.disable_ip_reputation:
       widget_type: listbox
       label: IP Reputation
@@ -421,18 +423,18 @@ resources:
       form_section: common-security-controls
       notes: Empty object sentinel — IP reputation disabled
       mutually_exclusive_with:
-        - spec.enable_ip_reputation
+      - spec.enable_ip_reputation
     spec.enable_threat_mesh:
       widget_type: listbox
       label: Threat Mesh
       required: false
       default: Disable
       options:
-        - Disable
-        - Enable
+      - Disable
+      - Enable
       form_section: common-security-controls
       mutually_exclusive_with:
-        - spec.disable_threat_mesh
+      - spec.disable_threat_mesh
     spec.disable_threat_mesh:
       widget_type: listbox
       label: Threat Mesh
@@ -440,7 +442,7 @@ resources:
       form_section: common-security-controls
       notes: Empty object sentinel — threat mesh disabled
       mutually_exclusive_with:
-        - spec.enable_threat_mesh
+      - spec.enable_threat_mesh
     spec.user_id_client_ip:
       widget_type: listbox
       label: User Identifier
@@ -449,7 +451,7 @@ resources:
       form_section: common-security-controls
       notes: Empty object sentinel — use client IP as user identifier
       mutually_exclusive_with:
-        - spec.user_identification
+      - spec.user_identification
     spec.user_identification:
       widget_type: resource-selector
       label: User Identifier
@@ -457,18 +459,19 @@ resources:
       form_section: common-security-controls
       notes: Custom user identification policy (TLS fingerprint or custom)
       mutually_exclusive_with:
-        - spec.user_id_client_ip
+      - spec.user_id_client_ip
+      resource_type: user_identification
     spec.enable_malicious_user_detection:
       widget_type: listbox
       label: Malicious User Detection
       required: false
       default: Disable
       options:
-        - Disable
-        - Enable
+      - Disable
+      - Enable
       form_section: common-security-controls
       mutually_exclusive_with:
-        - spec.disable_malicious_user_detection
+      - spec.disable_malicious_user_detection
     spec.disable_malicious_user_detection:
       widget_type: listbox
       label: Malicious User Detection
@@ -476,7 +479,7 @@ resources:
       form_section: common-security-controls
       notes: Empty object sentinel — malicious user detection disabled
       mutually_exclusive_with:
-        - spec.enable_malicious_user_detection
+      - spec.enable_malicious_user_detection
     spec.rate_limit:
       widget_type: configurable
       label: Rate Limiting
@@ -485,7 +488,7 @@ resources:
       form_section: common-security-controls
       notes: Enable and configure rate limiting rules
       mutually_exclusive_with:
-        - spec.disable_rate_limit
+      - spec.disable_rate_limit
     spec.disable_rate_limit:
       widget_type: listbox
       label: Rate Limiting
@@ -493,7 +496,7 @@ resources:
       form_section: common-security-controls
       notes: Empty object sentinel — rate limiting disabled
       mutually_exclusive_with:
-        - spec.rate_limit
+      - spec.rate_limit
     spec.trusted_clients:
       widget_type: configurable
       label: Trusted Client Rules
@@ -521,41 +524,41 @@ resources:
       required: false
       default: Internet
       options:
-        - Internet
-        - Internet with VIP on RE
-        - Custom
+      - Internet
+      - Internet with VIP on RE
+      - Custom
       form_section: other-settings
       mutually_exclusive_with:
-        - spec.advertise_on_public_default_vip
-        - spec.advertise_custom
-        - spec.do_not_advertise
+      - spec.advertise_on_public_default_vip
+      - spec.advertise_custom
+      - spec.do_not_advertise
     spec.advertise_on_public_default_vip:
       widget_type: listbox
       label: VIP Advertisement
       form_section: other-settings
       notes: Empty object sentinel — advertise on public with default VIP
       mutually_exclusive_with:
-        - spec.advertise_on_public
-        - spec.advertise_custom
-        - spec.do_not_advertise
+      - spec.advertise_on_public
+      - spec.advertise_custom
+      - spec.do_not_advertise
     spec.advertise_custom:
       widget_type: configurable
       label: VIP Advertisement
       form_section: other-settings
       notes: Custom advertisement configuration
       mutually_exclusive_with:
-        - spec.advertise_on_public
-        - spec.advertise_on_public_default_vip
-        - spec.do_not_advertise
+      - spec.advertise_on_public
+      - spec.advertise_on_public_default_vip
+      - spec.do_not_advertise
     spec.do_not_advertise:
       widget_type: listbox
       label: VIP Advertisement
       form_section: other-settings
       notes: Empty object sentinel — do not advertise
       mutually_exclusive_with:
-        - spec.advertise_on_public
-        - spec.advertise_on_public_default_vip
-        - spec.advertise_custom
+      - spec.advertise_on_public
+      - spec.advertise_on_public_default_vip
+      - spec.advertise_custom
     spec.round_robin:
       widget_type: listbox
       label: LB Algorithm
@@ -564,66 +567,66 @@ resources:
       form_section: other-settings
       notes: Empty object sentinel — round-robin load balancing
       mutually_exclusive_with:
-        - spec.least_active
-        - spec.random
-        - spec.ring_hash
-        - spec.source_ip_stickiness
-        - spec.cookie_stickiness
+      - spec.least_active
+      - spec.random
+      - spec.ring_hash
+      - spec.source_ip_stickiness
+      - spec.cookie_stickiness
     spec.least_active:
       widget_type: listbox
       label: LB Algorithm
       form_section: other-settings
       notes: Empty object sentinel — least active request
       mutually_exclusive_with:
-        - spec.round_robin
-        - spec.random
-        - spec.ring_hash
-        - spec.source_ip_stickiness
-        - spec.cookie_stickiness
+      - spec.round_robin
+      - spec.random
+      - spec.ring_hash
+      - spec.source_ip_stickiness
+      - spec.cookie_stickiness
     spec.random:
       widget_type: listbox
       label: LB Algorithm
       form_section: other-settings
       notes: Empty object sentinel — random selection
       mutually_exclusive_with:
-        - spec.round_robin
-        - spec.least_active
-        - spec.ring_hash
-        - spec.source_ip_stickiness
-        - spec.cookie_stickiness
+      - spec.round_robin
+      - spec.least_active
+      - spec.ring_hash
+      - spec.source_ip_stickiness
+      - spec.cookie_stickiness
     spec.ring_hash:
       widget_type: configurable
       label: LB Algorithm
       form_section: other-settings
       notes: Ring hash with configurable hash policy
       mutually_exclusive_with:
-        - spec.round_robin
-        - spec.least_active
-        - spec.random
-        - spec.source_ip_stickiness
-        - spec.cookie_stickiness
+      - spec.round_robin
+      - spec.least_active
+      - spec.random
+      - spec.source_ip_stickiness
+      - spec.cookie_stickiness
     spec.source_ip_stickiness:
       widget_type: listbox
       label: LB Algorithm
       form_section: other-settings
       notes: Empty object sentinel — source IP stickiness
       mutually_exclusive_with:
-        - spec.round_robin
-        - spec.least_active
-        - spec.random
-        - spec.ring_hash
-        - spec.cookie_stickiness
+      - spec.round_robin
+      - spec.least_active
+      - spec.random
+      - spec.ring_hash
+      - spec.cookie_stickiness
     spec.cookie_stickiness:
       widget_type: configurable
       label: LB Algorithm
       form_section: other-settings
       notes: Cookie-based stickiness with configurable cookie
       mutually_exclusive_with:
-        - spec.round_robin
-        - spec.least_active
-        - spec.random
-        - spec.ring_hash
-        - spec.source_ip_stickiness
+      - spec.round_robin
+      - spec.least_active
+      - spec.random
+      - spec.ring_hash
+      - spec.source_ip_stickiness
     spec.disable_trust_client_ip_headers:
       widget_type: listbox
       label: Trusted Client IP Headers
@@ -632,7 +635,7 @@ resources:
       form_section: other-settings
       notes: Empty object sentinel — trusted client IP headers disabled
       mutually_exclusive_with:
-        - spec.enable_trust_client_ip_headers
+      - spec.enable_trust_client_ip_headers
     spec.enable_trust_client_ip_headers:
       widget_type: configurable
       label: Trusted Client IP Headers
@@ -640,7 +643,7 @@ resources:
       form_section: other-settings
       notes: Configure which headers to trust for client IP
       mutually_exclusive_with:
-        - spec.disable_trust_client_ip_headers
+      - spec.disable_trust_client_ip_headers
     spec.add_location:
       widget_type: checkbox
       label: Add Location
@@ -659,14 +662,14 @@ resources:
       form_section: other-settings
       notes: Empty object sentinel — multi load balancer application mode
       mutually_exclusive_with:
-        - spec.single_lb_app
+      - spec.single_lb_app
     spec.single_lb_app:
       widget_type: configurable
       label: Single-LB Application
       form_section: other-settings
       notes: Single load balancer application settings
       mutually_exclusive_with:
-        - spec.multi_lb_app
+      - spec.multi_lb_app
     spec.system_default_timeouts:
       widget_type: listbox
       label: Timeouts
@@ -680,7 +683,7 @@ resources:
       disabled: true
       disabled_reason: Upgrade required
       mutually_exclusive_with:
-        - spec.disable_malware_protection
+      - spec.disable_malware_protection
     spec.disable_malware_protection:
       widget_type: listbox
       label: Malware Protection
@@ -688,7 +691,7 @@ resources:
       disabled: true
       disabled_reason: Upgrade required
       mutually_exclusive_with:
-        - spec.malware_protection_settings
+      - spec.malware_protection_settings
     spec.client_side_defense:
       widget_type: configurable
       label: Client-Side Defense
@@ -696,7 +699,7 @@ resources:
       disabled: true
       disabled_reason: Upgrade required
       mutually_exclusive_with:
-        - spec.disable_client_side_defense
+      - spec.disable_client_side_defense
     spec.disable_client_side_defense:
       widget_type: listbox
       label: Client-Side Defense
@@ -704,7 +707,7 @@ resources:
       disabled: true
       disabled_reason: Upgrade required
       mutually_exclusive_with:
-        - spec.client_side_defense
+      - spec.client_side_defense
   origin_pool:
     metadata.name:
       widget_type: textbox
@@ -737,63 +740,63 @@ resources:
         public_name:
           label: Public DNS Name
           fields:
-            - dns_name
-            - refresh_interval
+          - dns_name
+          - refresh_interval
         public_ip:
           label: Public IP
           fields:
-            - ip
+          - ip
         private_ip:
           label: Private IP
           fields:
-            - ip
-            - site_locator
-            - inside_network
-            - outside_network
-            - segment
-            - snat_pool
+          - ip
+          - site_locator
+          - inside_network
+          - outside_network
+          - segment
+          - snat_pool
         private_name:
           label: Private DNS Name
           fields:
-            - dns_name
-            - refresh_interval
-            - site_locator
-            - inside_network
-            - outside_network
-            - segment
-            - snat_pool
+          - dns_name
+          - refresh_interval
+          - site_locator
+          - inside_network
+          - outside_network
+          - segment
+          - snat_pool
         k8s_service:
           label: K8s Service
           fields:
-            - service_name
-            - site_locator
-            - inside_network
-            - outside_network
-            - protocol
-            - snat_pool
-            - vk8s_networks
+          - service_name
+          - site_locator
+          - inside_network
+          - outside_network
+          - protocol
+          - snat_pool
+          - vk8s_networks
         consul_service:
           label: Consul Service
           fields:
-            - service_name
-            - site_locator
-            - inside_network
-            - outside_network
-            - snat_pool
+          - service_name
+          - site_locator
+          - inside_network
+          - outside_network
+          - snat_pool
         custom_endpoint_object:
           label: Custom Endpoint
           fields:
-            - endpoint
+          - endpoint
         vn_private_ip:
           label: Virtual Network Private IP
           fields:
-            - ip
-            - virtual_network
+          - ip
+          - virtual_network
         vn_private_name:
           label: Virtual Network Private Name
           fields:
-            - dns_name
-            - private_network
+          - dns_name
+          - private_network
     spec.port:
       widget_type: spinbutton
       label: Port
@@ -844,8 +847,8 @@ resources:
       required: true
       default: Blocking
       options:
-        - Monitoring
-        - Blocking
+      - Monitoring
+      - Blocking
       form_section: enforcement-mode
     spec.detection_settings:
       widget_type: configurable
@@ -866,7 +869,7 @@ resources:
       required: true
       add_item_first: true
       form_section: basic-configuration
-      description: 'TCP LB Domains table starts EMPTY (0 items) — needs Add Item click before filling. Fills via ngx-datatable grid real-typing after row creation.'
+      description: TCP LB Domains table starts EMPTY (0 items) — needs Add Item click before filling. Fills via ngx-datatable grid real-typing after row creation.
     listen_port:
       widget_type: spinbutton
       label: Listen Port (value)
@@ -877,7 +880,7 @@ resources:
       label: No SNI
       form_section: basic-configuration
       mutually_exclusive_with:
-        - sni
+      - sni
     origin_pools_weights:
       widget_type: nested-resource-list
       label: Origin Pools
@@ -894,8 +897,8 @@ resources:
       default: TCP
       form_section: load-balancing-control
       mutually_exclusive_with:
-        - tcp_proxy
-        - sni_based
+      - tcp_proxy
+      - sni_based
     round_robin:
       widget_type: listbox
       label: Round Robin
@@ -911,9 +914,9 @@ resources:
       form_section: basic-configuration
       default: Listen Port
       options:
-        - Listen Port
-        - Custom Port
-      description: 'vsui listbox choice (Listen Port | Custom Port). Verified from docs/form-discovery/tcp_loadbalancer.yaml.'
+      - Listen Port
+      - Custom Port
+      description: vsui listbox choice (Listen Port | Custom Port). Verified from docs/form-discovery/tcp_loadbalancer.yaml.
       widget_type: listbox
   healthcheck:
     http_health_check:
@@ -921,7 +924,7 @@ resources:
       label: HTTP HealthCheck
       form_section: health-check-parameters
       mutually_exclusive_with:
-        - tcp_health_check
+      - tcp_health_check
     timeout:
       widget_type: spinbutton
       label: Timeout
@@ -968,18 +971,18 @@ resources:
       default: Any Server
       form_section: servers
       mutually_exclusive_with:
-        - spec.server_name
-        - spec.server_name_matcher
-        - spec.server_selector
+      - spec.server_name
+      - spec.server_name_matcher
+      - spec.server_selector
     spec.rule_list:
       widget_type: configurable
       label: Custom Rule List
       form_section: rules
       mutually_exclusive_with:
-        - spec.allow_all_requests
-        - spec.deny_all_requests
-        - spec.allow_list
-        - spec.deny_list
+      - spec.allow_all_requests
+      - spec.deny_all_requests
+      - spec.allow_list
+      - spec.deny_list
       notes: Opens nested rule editor with match conditions and actions
     spec.rule_choice:
       required: true
@@ -1091,6 +1094,7 @@ resources:
       widget_type: resource-selector
       label: WAF
       form_section: waf
+      resource_type: app_firewall
   aws_vpc_site:
     metadata.name:
       widget_type: textbox
@@ -1115,6 +1119,7 @@ resources:
       label: AWS Credentials
       required: true
       form_section: basic
+      resource_type: cloud_credentials
     spec.instance_type:
       widget_type: listbox
       label: Instance Type
@@ -1149,6 +1154,7 @@ resources:
       label: Azure Credentials
       required: true
       form_section: basic
+      resource_type: cloud_credentials
     spec.machine_type:
       widget_type: listbox
       label: Machine Type
@@ -1178,6 +1184,7 @@ resources:
       label: GCP Credentials
       required: true
       form_section: basic
+      resource_type: cloud_credentials
     spec.gcp_region:
       widget_type: listbox
       label: GCP Region
@@ -1244,7 +1251,7 @@ resources:
       sub_select_label: Pool
       sub_resource_type: dns_lb_pool
       form_section: load-balancing-rules
-      description: 'At least one Load Balancing Rule. Each rule selects a Pool (references an existing dns_lb_pool — dependency; create one first).'
+      description: At least one Load Balancing Rule. Each rule selects a Pool (references an existing dns_lb_pool — dependency; create one first).
   global_log_receiver:
     namespace_scope: system
     metadata.name:
@@ -1564,8 +1571,8 @@ resources:
       required: true
       description: 'Required: Site Type (RE = Regional Edge, CE = Customer Edge). Select from the listbox.'
       options:
-        - RE
-        - CE
+      - RE
+      - CE
       default: RE
   alert_policy:
     metadata.name:
@@ -1587,8 +1594,7 @@ resources:
       required: true
       form_section: basic
       resource_type: alert_receiver
-      description: 'Server-required: at least one Alert Receiver reference. Depends on an existing alert_receiver object (create
-        one first).'
+      description: 'Server-required: at least one Alert Receiver reference. Depends on an existing alert_receiver object (create one first).'
     spec.routes:
       widget_type: nested-resource-list
       label: Policy Rules
@@ -1655,7 +1661,7 @@ resources:
       required: true
       add_action: Add Item
       sub_field_label: Public IP
-      description: 'Pool Members is a nested-resource-list (Add Item, NOT Configure — verified from live form). Default A record member needs a Public IP.'
+      description: Pool Members is a nested-resource-list (Add Item, NOT Configure — verified from live form). Default A record member needs a Public IP.
   site_mesh_group:
     metadata.name:
       widget_type: textbox
@@ -1891,9 +1897,8 @@ resources:
       required: true
       form_section: api-endpoints
       resource_type: http_loadbalancer
-      description: 'Server-required (feedback loop: "Field HTTP Load Balancer is required"). A direct listbox that selects
-        an EXISTING http_loadbalancer — dependency, create an http-lb first. (Removed the duplicate spec.http_load_balancer:
-        the real API field is http_loadbalancer, and the console form shows a single listbox, not a resource-selector.)'
+      description: 'Server-required (feedback loop: "Field HTTP Load Balancer is required"). A direct listbox that selects an EXISTING http_loadbalancer — dependency, create an http-lb first. (Removed the
+        duplicate spec.http_load_balancer: the real API field is http_loadbalancer, and the console form shows a single listbox, not a resource-selector.)'
   app_setting:
     metadata.name:
       widget_type: textbox
@@ -1936,7 +1941,7 @@ resources:
       widget_type: table
       label: AI/ML Feature Type
       form_section: features
-      description: 'Not a top-level required field — the AI/ML Feature Type listbox lives inside the App Type Settings Add Item sub-form (see spec.app_type_settings).'
+      description: Not a top-level required field — the AI/ML Feature Type listbox lives inside the App Type Settings Add Item sub-form (see spec.app_type_settings).
     spec.learn_from_traffic_with_redirect_response:
       widget_type: listbox
       label: Learn from Traffic with Redirect Response
@@ -1952,14 +1957,14 @@ resources:
       widget_type: nested-resource-list
       add_action: Add Item
       form_section: app-type-settings
-      description: 'Optional advanced settings. The required AI/ML Feature Type is the Features-row listbox (spec.feature_type), which ships with one row — no Add Item needed.'
+      description: Optional advanced settings. The required AI/ML Feature Type is the Features-row listbox (spec.feature_type), which ships with one row — no Add Item needed.
     spec.feature_type:
       required: true
       label: AI/ML Feature Type
       widget_type: listbox
       resource_type: ai_feature_type
       form_section: features
-      description: 'Required Select-item listbox in the Features section (ships with one row). Verified from live form screenshot.'
+      description: Required Select-item listbox in the Features section (ships with one row). Verified from live form screenshot.
   authorization_server:
     metadata.name:
       widget_type: textbox
@@ -2046,8 +2051,7 @@ resources:
       label: AS Numbers
       form_section: spec
       required: true
-      description: List of AS Numbers — a row pre-exists with value 0; fill it with a valid ASN (e.g. 64512). Uses ngx-datatable
-        input.
+      description: List of AS Numbers — a row pre-exists with value 0; fill it with a valid ASN (e.g. 64512). Uses ngx-datatable input.
       add_action: Add Item
       default: null
   bigip_virtual_server: null
@@ -2076,7 +2080,7 @@ resources:
       required: true
       add_item_first: true
       form_section: cache-rule
-      description: 'Expressions table starts empty — needs Add Item before filling the inline cell.'
+      description: Expressions table starts empty — needs Add Item before filling the inline cell.
     spec.cache_actions:
       widget_type: listbox
       label: Cache Actions
@@ -2351,7 +2355,7 @@ resources:
       required: true
       form_section: integration-data
       resource_type: code_base
-      description: 'A vsui "Select item" listbox (not a configurable). Selects an existing code-base integration. Verified from live form screenshot.'
+      description: A vsui "Select item" listbox (not a configurable). Selects an existing code-base integration. Verified from live form screenshot.
   container_registry:
     metadata.name:
       widget_type: textbox
@@ -2382,8 +2386,7 @@ resources:
       required: true
       form_section: password
       secret: true
-      description: 'Secret field: click Configure (a link), enter the value in the secret TEXTAREA (Secret Type defaults are
-        fine), then Apply. Verified live: create 200.'
+      description: 'Secret field: click Configure (a link), enter the value in the secret TEXTAREA (Secret Type defaults are fine), then Apply. Verified live: create 200.'
     spec.email:
       widget_type: textbox
       label: Email
@@ -2533,7 +2536,7 @@ resources:
       widget_type: configurable
   dns_domain:
     deprecated: true
-    deprecated_reason: "functionality removed from the F5 XC platform — delegated domain management is being decommissioned"
+    deprecated_reason: functionality removed from the F5 XC platform — delegated domain management is being decommissioned
     metadata.domain_name:
       widget_type: textbox
       label: Domain Name
@@ -2656,7 +2659,7 @@ resources:
       required: true
       resource_type: virtual_site
       form_section: spec
-      description: 'vsui autocomplete dropdown (VSUI-AUTOCOMPLETE-DROPDOWN) selecting a virtual-site, site, or network. Dependency resource.'
+      description: vsui autocomplete dropdown (VSUI-AUTOCOMPLETE-DROPDOWN) selecting a virtual-site, site, or network. Dependency resource.
     spec.network_type:
       widget_type: listbox
       label: Network Type
@@ -2777,7 +2780,7 @@ resources:
       form_section: fleet-configuration
       default: test-fleet-label
       validation:
-        pattern: "^[a-z][a-z0-9-]*[a-z0-9]$"
+        pattern: ^[a-z][a-z0-9-]*[a-z0-9]$
         max_length: 64
     spec.outside_site_local_virtual_network:
       widget_type: listbox
@@ -3249,8 +3252,9 @@ resources:
       add_action: Add Item
       sub_select_label: Policer
       sub_resource_type: policer
-      description: 'At least one protocol policer entry required. The nested Add Item sub-form requires selecting an existing
-        Policer (feedback loop: "Field Policer is required") — a policer object must exist first.'
+      description: 'At least one protocol policer entry required. The nested Add Item sub-form requires selecting an existing Policer (feedback loop: "Field Policer is required") — a policer object must
+        exist first.'
+      resource_type: protocol_policer
   proxy:
     metadata.name:
       widget_type: textbox

--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -1189,6 +1189,7 @@ resources:
       description: 'Server-required: Field should be not nil'
       widget_type: configurable
   dns_zone:
+    namespace_scope: system
     metadata.name:
       widget_type: textbox
       label: Name
@@ -1212,6 +1213,7 @@ resources:
       required: true
       form_section: basic
   dns_load_balancer:
+    namespace_scope: system
     metadata.name:
       widget_type: textbox
       label: Name
@@ -1244,6 +1246,7 @@ resources:
       form_section: load-balancing-rules
       description: 'At least one Load Balancing Rule. Each rule selects a Pool (references an existing dns_lb_pool — dependency; create one first).'
   global_log_receiver:
+    namespace_scope: system
     metadata.name:
       widget_type: textbox
       label: Name
@@ -1631,6 +1634,7 @@ resources:
       required: true
       form_section: basic
   dns_lb_pool:
+    namespace_scope: system
     metadata.name:
       widget_type: textbox
       label: Name
@@ -2554,6 +2558,7 @@ resources:
       label: DNSSEC Mode
       form_section: dnssec-mode
   dns_lb_health_check:
+    namespace_scope: system
     metadata.name:
       widget_type: textbox
       label: Name
@@ -2751,6 +2756,7 @@ resources:
       description: 'Server-required: Field should be not nil'
       widget_type: configurable
   fleet:
+    namespace_scope: system
     metadata.name:
       widget_type: textbox
       label: Name
@@ -3881,6 +3887,7 @@ resources:
       label: Default Workload Flavor
       form_section: default-workload-flavor
   virtual_network:
+    namespace_scope: system
     metadata.name:
       widget_type: textbox
       label: Name

--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -2249,6 +2249,8 @@ resources:
       widget_type: table
       label: Bring Your Own Connections
       required: true
+      add_item_first: true
+      add_action: Add Item
       form_section: cloud-option
     spec.account_credential:
       widget_type: listbox

--- a/config/console_field_metadata.yaml
+++ b/config/console_field_metadata.yaml
@@ -2528,6 +2528,8 @@ resources:
       description: 'Server-required: Field should be not nil'
       widget_type: configurable
   dns_domain:
+    deprecated: true
+    deprecated_reason: "functionality removed from the F5 XC platform — delegated domain management is being decommissioned"
     metadata.domain_name:
       widget_type: textbox
       label: Domain Name

--- a/config/extension_registry.yaml
+++ b/config/extension_registry.yaml
@@ -328,6 +328,22 @@ property_level:
     issue: "#494"
     note: "Enables downstream tools to validate conflicts at schema level rather than runtime"
 
+  x-f5xc-references:
+    type: array
+    items: object
+    purpose: Declares resource references (ObjectRefType fields) to other resources that must exist first — enables deterministic CRUD ordering
+    consumers: [terraform, cli, mcp, ide, ai-assistants]
+    source: "Derived from ObjectRefType allOf refs + curated config/resource_references.yaml (F5 specs do not carry the target kind); oneOf gating from x-ves-oneof-field-*"
+    example:
+      - resource_kind: app_firewall
+        field_path: app_firewall
+        gated_by: { choice: waf_choice }
+        required: false
+        cardinality: single
+    added_in: "3.5.0"
+    issue: "#TBD"
+    note: "resource_kind null = unresolved (curate in resource_references.yaml, never guessed). The coarse resource_dependency_graph.json is a projection of these."
+
   x-f5xc-constraints:
     type: object
     purpose: Comprehensive constraint metadata for deterministic AI generation and validation

--- a/config/resource_dependency_graph.json
+++ b/config/resource_dependency_graph.json
@@ -1,0 +1,158 @@
+{
+  "description": "Resource dependency graph derived from OpenAPI ObjectRefType annotations. Resources that reference other resources must be created AFTER their dependencies.",
+  "source": "api-specs-enriched/docs/specifications/api (allOf \u2192 ObjectRefType/RefSelector)",
+  "total_resources": 100,
+  "resources_with_dependencies": 14,
+  "edges": {
+    "aws-tgw-site": [
+      "log-receiver"
+    ],
+    "aws-vpc-site": [
+      "log-receiver"
+    ],
+    "azure-vnet-site": [
+      "log-receiver"
+    ],
+    "cdn-loadbalancer": [
+      "app-firewall",
+      "user-identification"
+    ],
+    "cloud-connect": [
+      "segment"
+    ],
+    "fast-acl": [
+      "protocol-policer"
+    ],
+    "fleet": [
+      "dc-cluster-group",
+      "log-receiver",
+      "usb-policy"
+    ],
+    "forward-proxy-policy": [
+      "network-connector"
+    ],
+    "gcp-vpc-site": [
+      "cloud-credentials",
+      "log-receiver"
+    ],
+    "http-load-balancer": [
+      "app-firewall",
+      "user-identification"
+    ],
+    "network-policy-rule": [
+      "ip-prefix-set"
+    ],
+    "securemesh-site": [
+      "log-receiver"
+    ],
+    "securemesh-site-v2": [
+      "log-receiver"
+    ],
+    "voltstack-site": [
+      "k8s-cluster",
+      "log-receiver",
+      "usb-policy"
+    ]
+  },
+  "leaves": [
+    "address-allocator",
+    "advertise-policy",
+    "alert-policy",
+    "alert-receiver",
+    "api-credential",
+    "api-definition",
+    "api-discovery",
+    "app-api-group",
+    "app-firewall",
+    "app-setting",
+    "app-type",
+    "authorization-server",
+    "bgp",
+    "bgp-asn-set",
+    "bigip-virtual-server",
+    "cdn-cache-rule",
+    "certificate",
+    "cloud-credentials",
+    "cloud-elastic-ip",
+    "cloud-link",
+    "cluster",
+    "code-base-integration",
+    "container-registry",
+    "crl",
+    "data-type",
+    "dc-cluster-group",
+    "demos",
+    "discovery",
+    "dns-domain",
+    "dns-lb-health-check",
+    "dns-lb-pool",
+    "dns-load-balancer",
+    "dns-zone",
+    "endpoint",
+    "enhanced-firewall-policy",
+    "external-connector",
+    "geo-location-set",
+    "global-log-receiver",
+    "health-check",
+    "ike-gateway",
+    "ip-prefix-set",
+    "k8s-cluster",
+    "log-receiver",
+    "malicious-user-mitigation",
+    "mcn-secret-policy-rule",
+    "namespace",
+    "nat-policy",
+    "network-connector",
+    "network-firewall",
+    "network-interface",
+    "network-policy",
+    "nfv-service",
+    "openapi-file",
+    "origin-pool",
+    "policer",
+    "protocol-policer",
+    "proxy",
+    "public-ip",
+    "rate-limiter",
+    "rate-limiter-policy",
+    "role",
+    "route-object",
+    "secret-policy",
+    "segment",
+    "segment-connection",
+    "sensitive-data-policy",
+    "service-credential",
+    "service-policy",
+    "service-policy-rule",
+    "shared-advertise-policy",
+    "site-mesh-group",
+    "subnet",
+    "tcp-load-balancer",
+    "third-party-application",
+    "tunnel",
+    "udp-loadbalancer",
+    "usb-policy",
+    "user-identification",
+    "v1-dns-monitor",
+    "v1-http-monitor",
+    "virtual-host",
+    "virtual-k8s",
+    "virtual-network",
+    "virtual-site",
+    "waf-exclusion-policy",
+    "workload-flavor"
+  ],
+  "prerequisites": [
+    "app-firewall",
+    "cloud-credentials",
+    "dc-cluster-group",
+    "ip-prefix-set",
+    "k8s-cluster",
+    "log-receiver",
+    "network-connector",
+    "protocol-policer",
+    "segment",
+    "usb-policy",
+    "user-identification"
+  ]
+}

--- a/config/resource_dependency_graph.json
+++ b/config/resource_dependency_graph.json
@@ -4,55 +4,20 @@
   "total_resources": 100,
   "resources_with_dependencies": 14,
   "edges": {
-    "aws-tgw-site": [
-      "log-receiver"
-    ],
-    "aws-vpc-site": [
-      "log-receiver"
-    ],
-    "azure-vnet-site": [
-      "log-receiver"
-    ],
-    "cdn-loadbalancer": [
-      "app-firewall",
-      "user-identification"
-    ],
-    "cloud-connect": [
-      "segment"
-    ],
-    "fast-acl": [
-      "protocol-policer"
-    ],
-    "fleet": [
-      "dc-cluster-group",
-      "log-receiver",
-      "usb-policy"
-    ],
-    "forward-proxy-policy": [
-      "network-connector"
-    ],
-    "gcp-vpc-site": [
-      "cloud-credentials",
-      "log-receiver"
-    ],
-    "http-load-balancer": [
-      "app-firewall",
-      "user-identification"
-    ],
-    "network-policy-rule": [
-      "ip-prefix-set"
-    ],
-    "securemesh-site": [
-      "log-receiver"
-    ],
-    "securemesh-site-v2": [
-      "log-receiver"
-    ],
-    "voltstack-site": [
-      "k8s-cluster",
-      "log-receiver",
-      "usb-policy"
-    ]
+    "aws-tgw-site": ["log-receiver"],
+    "aws-vpc-site": ["log-receiver"],
+    "azure-vnet-site": ["log-receiver"],
+    "cdn-loadbalancer": ["app-firewall", "user-identification"],
+    "cloud-connect": ["segment"],
+    "fast-acl": ["protocol-policer"],
+    "fleet": ["dc-cluster-group", "log-receiver", "usb-policy"],
+    "forward-proxy-policy": ["network-connector"],
+    "gcp-vpc-site": ["cloud-credentials", "log-receiver"],
+    "http-load-balancer": ["app-firewall", "user-identification"],
+    "network-policy-rule": ["ip-prefix-set"],
+    "securemesh-site": ["log-receiver"],
+    "securemesh-site-v2": ["log-receiver"],
+    "voltstack-site": ["k8s-cluster", "log-receiver", "usb-policy"]
   },
   "leaves": [
     "address-allocator",

--- a/config/resource_references.yaml
+++ b/config/resource_references.yaml
@@ -44,26 +44,32 @@ references:
   "viewsOriginPoolListType.pools": origin_pool
   "viewsDefaultRoutePoolAdvanced.pool": origin_pool
 
-# Fields whose referred kind could not be derived from the field name.
-# Curate each (add to references: above) — leaving it here = resource_kind:null.
+# Site/virtual-site selectors (RefSelector — WHERE to deploy, not a single resource)
+  "advertise_policyCreateSpecType.where": virtual_site
+  "bgpCreateSpecType.where": site
+  "discoveryCreateSpecType.where": site
+  "schemaendpointCreateSpecType.where": virtual_site
+  "secret_management_accessCreateSpecType.where": site
+  # DC cluster group variants (same kind, different placement)
+  "schemafleetCreateSpecType.dc_cluster_group_inside": dc_cluster_group
+  "viewssecuremesh_site_v2CreateSpecType.dc_cluster_group_sli": dc_cluster_group
+  "viewssecuremesh_site_v2CreateSpecType.dc_cluster_group_slo": dc_cluster_group
+  # Cloud credentials
+  "viewsaws_vpc_siteCreateSpecType.aws_cred": cloud_credentials
+  "viewsazure_vnet_siteCreateSpecType.azure_cred": cloud_credentials
+  # DNS
+  "schemadns_load_balancerCreateSpecType.fallback_pool": dns_lb_pool
+  # Sites
+  "external_connectorCreateSpecType.ce_site_reference": site
+  # Workloads
+  "virtual_k8sCreateSpecType.default_flavor_ref": workload_flavor
+
+# Remaining: platform-internal or uncommon references (resource_kind: null until curated)
 _needs_review:
-  # - "addon_subscriptionCreateSpecType.addon_service"
-  # - "advertise_policyCreateSpecType.where"
-  # - "bgpCreateSpecType.where"
-  # - "discoveryCreateSpecType.where"
-  # - "external_connectorCreateSpecType.ce_site_reference"
-  # - "infraprotect_asn_prefixCreateSpecType.asn"
-  # - "infraprotect_tunnelCreateSpecType.firewall_rule_group"
-  # - "k8s_clusterCreateSpecType.use_custom_pod_security_admission"
-  # - "schemadns_load_balancerCreateSpecType.fallback_pool"
-  # - "schemaendpointCreateSpecType.where"
-  # - "schemafleetCreateSpecType.dc_cluster_group_inside"
-  # - "secret_management_accessCreateSpecType.where"
-  # - "tenant_managementchild_tenantCreateSpecType.child_tenant_manager"
-  # - "tenant_managementchild_tenant_managerCreateSpecType.tenant_owner_group"
-  # - "tenant_profileCreateSpecType.plan"
-  # - "viewsaws_vpc_siteCreateSpecType.aws_cred"
-  # - "viewsazure_vnet_siteCreateSpecType.azure_cred"
-  # - "viewssecuremesh_site_v2CreateSpecType.dc_cluster_group_sli"
-  # - "viewssecuremesh_site_v2CreateSpecType.dc_cluster_group_slo"
-  # - "virtual_k8sCreateSpecType.default_flavor_ref"
+  # - "addon_subscriptionCreateSpecType.addon_service"         # addon_service (platform-internal)
+  # - "infraprotect_asn_prefixCreateSpecType.asn"              # infraprotect ASN
+  # - "infraprotect_tunnelCreateSpecType.firewall_rule_group"  # infraprotect firewall rules
+  # - "k8s_clusterCreateSpecType.use_custom_pod_security_admission"  # PSA config
+  # - "tenant_managementchild_tenantCreateSpecType.child_tenant_manager"  # tenant mgmt
+  # - "tenant_managementchild_tenant_managerCreateSpecType.tenant_owner_group"  # tenant mgmt
+  # - "tenant_profileCreateSpecType.plan"                      # tenant plan

--- a/config/resource_references.yaml
+++ b/config/resource_references.yaml
@@ -1,0 +1,64 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+#
+# Curated referred-kind map for ObjectRefType reference fields.
+# F5 specs do NOT carry the target resource kind (ObjectRefType is generic),
+# so this committed+reviewed map is the deterministic source consumed by
+# references_enricher.py to stamp x-f5xc-references.resource_kind.
+#
+# Keyed by <SchemaName>.<field>. high-confidence entries below were seeded
+# from field-name == known-resource-kind and are safe; the _needs_review
+# list at the bottom must be curated by hand (do NOT guess).
+
+references:
+  "certificateCreateSpecType.certificate_chain": certificate_chain
+  "fast_acl_ruleCreateSpecType.ip_prefix_set": ip_prefix_set
+  "forwarding_classCreateSpecType.policer": policer
+  "k8s_cluster_role_bindingCreateSpecType.k8s_cluster_role": k8s_cluster_role
+  "network_policy_ruleCreateSpecType.ip_prefix_set": ip_prefix_set
+  "schemacdn_purge_commandCreateSpecType.virtual_host": virtual_host
+  "schemacloud_connectCreateSpecType.segment": segment
+  "schemadns_proxyCreateSpecType.protocol_inspection": protocol_inspection
+  "schemafast_aclCreateSpecType.protocol_policer": protocol_policer
+  "schemafleetCreateSpecType.dc_cluster_group": dc_cluster_group
+  "schemafleetCreateSpecType.log_receiver": log_receiver
+  "schemafleetCreateSpecType.usb_policy": usb_policy
+  "tenant_managementchild_tenantCreateSpecType.tenant_profile": tenant_profile
+  "viewsaws_tgw_siteCreateSpecType.log_receiver": log_receiver
+  "viewsaws_vpc_siteCreateSpecType.log_receiver": log_receiver
+  "viewsazure_vnet_siteCreateSpecType.log_receiver": log_receiver
+  "viewscdn_loadbalancerCreateSpecType.app_firewall": app_firewall
+  "viewscdn_loadbalancerCreateSpecType.user_identification": user_identification
+  "viewsforward_proxy_policyCreateSpecType.network_connector": network_connector
+  "viewsgcp_vpc_siteCreateSpecType.cloud_credentials": cloud_credentials
+  "viewsgcp_vpc_siteCreateSpecType.log_receiver": log_receiver
+  "viewshttp_loadbalancerCreateSpecType.app_firewall": app_firewall
+  "viewshttp_loadbalancerCreateSpecType.user_identification": user_identification
+  "viewssecuremesh_siteCreateSpecType.log_receiver": log_receiver
+  "viewssecuremesh_site_v2CreateSpecType.log_receiver": log_receiver
+  "viewsvoltstack_siteCreateSpecType.k8s_cluster": k8s_cluster
+  "viewsvoltstack_siteCreateSpecType.log_receiver": log_receiver
+  "viewsvoltstack_siteCreateSpecType.usb_policy": usb_policy
+
+# Fields whose referred kind could not be derived from the field name.
+# Curate each (add to references: above) — leaving it here = resource_kind:null.
+_needs_review:
+  # - "addon_subscriptionCreateSpecType.addon_service"
+  # - "advertise_policyCreateSpecType.where"
+  # - "bgpCreateSpecType.where"
+  # - "discoveryCreateSpecType.where"
+  # - "external_connectorCreateSpecType.ce_site_reference"
+  # - "infraprotect_asn_prefixCreateSpecType.asn"
+  # - "infraprotect_tunnelCreateSpecType.firewall_rule_group"
+  # - "k8s_clusterCreateSpecType.use_custom_pod_security_admission"
+  # - "schemadns_load_balancerCreateSpecType.fallback_pool"
+  # - "schemaendpointCreateSpecType.where"
+  # - "schemafleetCreateSpecType.dc_cluster_group_inside"
+  # - "secret_management_accessCreateSpecType.where"
+  # - "tenant_managementchild_tenantCreateSpecType.child_tenant_manager"
+  # - "tenant_managementchild_tenant_managerCreateSpecType.tenant_owner_group"
+  # - "tenant_profileCreateSpecType.plan"
+  # - "viewsaws_vpc_siteCreateSpecType.aws_cred"
+  # - "viewsazure_vnet_siteCreateSpecType.azure_cred"
+  # - "viewssecuremesh_site_v2CreateSpecType.dc_cluster_group_sli"
+  # - "viewssecuremesh_site_v2CreateSpecType.dc_cluster_group_slo"
+  # - "virtual_k8sCreateSpecType.default_flavor_ref"

--- a/config/resource_references.yaml
+++ b/config/resource_references.yaml
@@ -64,6 +64,107 @@ references:
   # Workloads
   "virtual_k8sCreateSpecType.default_flavor_ref": workload_flavor
 
+# Field-name-level defaults: when <schema>.<field> isn't in `references:` above,
+# try just the field name. Covers the 1100+ sub-schema repetitions (the same field
+# name "site", "app_firewall" etc. appears across dozens of inline wrapper types).
+# DRY: one entry covers all occurrences.
+field_defaults:
+  site: site
+  virtual_site: virtual_site
+  log_receiver: log_receiver
+  dc_cluster_group: dc_cluster_group
+  dc_cluster_group_inside_vn: dc_cluster_group
+  dc_cluster_group_outside_vn: dc_cluster_group
+  dc_cluster_group_inside: dc_cluster_group
+  dc_cluster_group_sli: dc_cluster_group
+  dc_cluster_group_slo: dc_cluster_group
+  app_firewall: app_firewall
+  ip_prefix_set: ip_prefix_set
+  k8s_cluster: k8s_cluster
+  segment: segment
+  virtual_network: virtual_network
+  trusted_ca: certificate
+  waf_exclusion_policy: waf_exclusion_policy
+  user_identification: user_identification
+  api_definition: api_definition
+  public_ip: public_ip
+  usb_policy: usb_policy
+  policer: policer
+  pool: origin_pool
+  origin_pool: origin_pool
+  origin_pools: origin_pool
+  default_origin_pools: origin_pool
+  default_pool: origin_pool
+  fallback_pool: dns_lb_pool
+  health_check: health_check
+  healthcheck: health_check
+  protocol_policer: protocol_policer
+  certificate: certificate
+  certificate_chain: certificate
+  k8s_cluster_role: k8s_cluster_role
+  cluster: cluster
+  aws_cred: cloud_credentials
+  azure_cred: cloud_credentials
+  gcp_cred: cloud_credentials
+  cred: cloud_credentials
+  workload_flavor: workload_flavor
+  default_flavor_ref: workload_flavor
+  where: virtual_site
+  ref_value: virtual_site
+  ref_rate_limiter: rate_limiter
+  ref_user_id: user_identification
+  discovery_object: discovery
+  crl: crl
+  malicious_user_mitigation: malicious_user_mitigation
+  http_loadbalancer: http_load_balancer
+  sensitive_data_policy_ref: sensitive_data_policy
+  api_discovery_ref: api_discovery
+  code_base_integration: code_base_integration
+  service_discovery: discovery
+  report_config: global_log_receiver
+  asn: bgp_asn_set
+  firewall_rule_group: fast_acl
+  # Additional field-name defaults for full coverage
+  tunnel: tunnel
+  tcp_loadbalancer: tcp_load_balancer
+  http_load_balancer: http_load_balancer
+  cdn_loadbalancer: cdn_loadbalancer
+  bigip_virtual_server: bigip_virtual_server
+  geo_location_set: geo_location_set
+  endpoint: endpoint
+  virtual_host: virtual_host
+  virtual_host_ref: virtual_host
+  advertise_policy: advertise_policy
+  network_connector: network_connector
+  network_interface: network_interface
+  site_mesh_group: site_mesh_group
+  container_registry: container_registry
+  cloud_connect: cloud_connect
+  cloud_credentials: cloud_credentials
+  cloud_link: cloud_link
+  nfv_service: nfv_service
+  protocol_inspection: protocol_inspection
+  private_network: virtual_network
+  global_vn: virtual_network
+  route_ref: route_object
+  destination_ip_prefix_set: ip_prefix_set
+  source_ip_prefix_set: ip_prefix_set
+  dst_ip_prefix_set: ip_prefix_set
+  dst_asn_set: bgp_asn_set
+  custom_rate_limiter: rate_limiter
+  custom_data_type_ref: data_type
+  custom_flavor: workload_flavor
+  app_firewall_on_cache_miss: app_firewall
+  edge_site: site
+  bare_metal_site: site
+  aws_tgw_site: aws_tgw_site
+  ce_site_reference: site
+  hub_mesh_group: site_mesh_group
+  interface: network_interface
+  policy: service_policy
+  # System-internal (excluded from CRUD dependency graph — not stamped)
+  # owner_view: (system read-only ref × 435 — not a CRUD dep, intentionally null)
+
 # Remaining: platform-internal or uncommon references (resource_kind: null until curated)
 _needs_review:
   # - "addon_subscriptionCreateSpecType.addon_service"         # addon_service (platform-internal)

--- a/config/resource_references.yaml
+++ b/config/resource_references.yaml
@@ -38,6 +38,11 @@ references:
   "viewsvoltstack_siteCreateSpecType.k8s_cluster": k8s_cluster
   "viewsvoltstack_siteCreateSpecType.log_receiver": log_receiver
   "viewsvoltstack_siteCreateSpecType.usb_policy": usb_policy
+  # Nested references (inside sub-schemas, not top-level CreateSpecType)
+  "viewsOriginPoolWithWeight.pool": origin_pool
+  "viewsOriginPoolWithWeight.cluster": cluster
+  "viewsOriginPoolListType.pools": origin_pool
+  "viewsDefaultRoutePoolAdvanced.pool": origin_pool
 
 # Fields whose referred kind could not be derived from the field name.
 # Curate each (add to references: above) — leaving it here = resource_kind:null.

--- a/docs/ar/extensions/catalog.md
+++ b/docs/ar/extensions/catalog.md
@@ -1,34 +1,34 @@
 ---
 title: كتالوج امتدادات الإثراء
-description: المرجع الرئيسي لكل امتداد x-* في مواصفات OpenAPI المحسّنة
+description: المرجع المعتمد لكل امتداد x-* في مواصفات OpenAPI المحسّنة
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
 # كتالوج امتدادات الإثراء
 
-المرجع الرئيسي لكل امتداد `x-*` يظهر في
-`docs/specifications/api/*.json`. يتم التحقق من التوافق مع
+المرجع المعتمد لكل امتداد `x-*` يظهر في
+`docs/specifications/api/*.json`. يُفرض التوافق مع
 `scripts/utils/extension_constants.py` عبر
 `tests/test_extension_catalog.py`.
 
-يتم توثيق ثلاث فئات من الامتدادات هنا:
+ثلاث فئات من الامتدادات موثّقة هنا:
 
-- **مُحقنة هنا** — الامتدادات التي تضيفها عمليات الإثراء لدينا (`x-f5xc-*` و
-  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / متغيرات
-  الاستكشاف). هذه هي الامتدادات التي ينبغي للأدوات التابعة استهلاكها.
-- **مُمررة من المصدر** — الامتدادات التي تُصدرها F5 في المواصفات المصدرية
+- **مُضافة هنا** — الامتدادات التي تضيفها أدوات الإثراء لدينا (`x-f5xc-*` و
+  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / متغيرات الاكتشاف).
+  وهي الامتدادات التي يجب أن تستهلكها الأدوات اللاحقة.
+- **مُمرَّرة من المصدر الأصلي** — الامتدادات التي تُصدرها F5 في المواصفات المصدرية
   ونحتفظ بها دون تغيير (`x-ves-proto-*`، `x-displayname`، إلخ).
-  موثقة للشفافية ولكن لا يتحكم بها هذا المستودع.
-- **مُحقنة مستقبلاً** — لم تُصدر بعد؛ توثق هنا في اللحظة التي يبدأ
-  فيها أحد عمليات الإثراء بإنتاجها (لا ينطبق عند التعبئة الأولية).
+  موثّقة للشفافية لكنها غير مُتحكَّم بها من هذا المستودع.
+- **مُضافة مستقبلاً** — لم تُصدَر بعد؛ توثّق هنا فور أن يبدأ أحد أدوات الإثراء
+  بإنتاجها (لا ينطبق عند التعبئة الأولية).
 
-## مخطط المدخل
+## مخطط الإدخال
 
-كل مدخل أدناه له هذا الشكل بالضبط. يتحمل اختبار التوافق في
-`tests/test_extension_catalog.py` أن يكون محتوى القسم موجزًا طالما أن
-رأس `### x-name` موجود وعلامة `Pass-through from upstream:` حاضرة
+لكل إدخال أدناه هذا الشكل بالضبط. يتسامح اختبار التوافق في
+`tests/test_extension_catalog.py` مع كون نص القسم مختصراً طالما أن
+ترويسة `### x-name` موجودة وعلامة `Pass-through from upstream:` حاضرة
 بقيمة `yes` أو `no`.
 
     ### x-<name>
@@ -42,12 +42,12 @@ i18n:
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## مُحقنة — على مستوى المواصفات (قسم info)
+## مُضاف — على مستوى المواصفة (قسم info)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** يحدد بادئة نطاق CLI (مثل `http_loadbalancer`) لمواصفة محسّنة.
+- **Purpose:** يحدد الاسم المختصر لنطاق CLI (مثال: `http_loadbalancer`) لمواصفة محسّنة.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -59,7 +59,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** كتلة بيانات تعريفية شاملة لـ CLI (اسم الأداة، تلميحات الإصدار، تجميع النطاق).
+- **Purpose:** كتلة بيانات تعريفية على مستوى CLI (اسم الأداة، تلميحات الإصدار، تجميع النطاق).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -71,7 +71,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** طابع زمني للمواصفة المصدرية التي بُني منها الملف المحسّن.
+- **Purpose:** الطابع الزمني لمواصفة المصدر الأصلي التي بُني منها الملف المحسّن.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -83,7 +83,7 @@ i18n:
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag لأصل إصدار المواصفة المصدرية.
+- **Purpose:** ETag لأصل إصدار مواصفة المصدر الأصلي.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -95,7 +95,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** إصدار دلالي مُختوم على المواصفة المحسّنة بواسطة خط الأنابيب.
+- **Purpose:** إصدار دلالي مختوم على المواصفة المحسّنة بواسطة خط الأنابيب.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -107,7 +107,7 @@ i18n:
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** كتلة مسرد للعلامات التجارية/المصطلحات المطبقة على كل مواصفة نطاق.
+- **Purpose:** كتلة مسرد المصطلحات والعلامات التجارية المطبّقة على كل مواصفة نطاق.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -119,7 +119,7 @@ i18n:
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** الطابع الزمني لتنفيذ مرور اكتشاف API المباشر.
+- **Purpose:** الطابع الزمني عند تنفيذ تمريرة اكتشاف الـ API المباشر.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -131,7 +131,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** عنوان URL الأساسي للـ API المباشر الذي تم استطلاعه أثناء الاكتشاف.
+- **Purpose:** عنوان URL الأساسي للـ API المباشر الذي جرى فحصه أثناء الاكتشاف.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -155,7 +155,7 @@ i18n:
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** وقت الاستجابة الملاحَظ (بالميلي ثانية) للـ API المستطلع أثناء الاكتشاف.
+- **Purpose:** وقت الاستجابة المرصود (بالملي ثانية) للـ API الذي جرى فحصه أثناء الاكتشاف.
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -179,7 +179,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** سير عمل خطوة بخطوة مُسمّاة لإنجاز المهام الشائعة في نطاق معين.
+- **Purpose:** سير عمل مسمّاة خطوة بخطوة لإنجاز المهام الشائعة في نطاق معين.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -191,7 +191,7 @@ i18n:
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** جدول توسيع الاختصارات لكل نطاق.
+- **Purpose:** جدول توسعة الاختصارات لكل نطاق.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -203,7 +203,7 @@ i18n:
 ### x-f5xc-console-navigation
 
 - **Applied at:** spec info
-- **Purpose:** شجرة التنقل الشاملة في وحدة التحكم — مساحة العمل والتسلسل الهرمي للقوائم.
+- **Purpose:** شجرة التنقل العامة في وحدة التحكم — مساحة العمل وتسلسل القوائم.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
@@ -212,12 +212,12 @@ i18n:
 - **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
 - **Pass-through from upstream:** no
 
-## مُحقنة — على مستوى المخطط (مخططات المكونات)
+## مُضاف — على مستوى المخطط (مخططات المكونات)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** الحد الأدنى من مجموعة الحقول المطلوبة لنجاح عملية POST/PUT لهذا المورد.
+- **Purpose:** الحد الأدنى من الحقول المطلوبة لنجاح عملية POST/PUT لهذا المورد.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -229,7 +229,7 @@ i18n:
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** يوفر البيانات التعريفية للقيد والتوصية والتصنيف لمساحة الاسم الخاصة بمورد معين.
+- **Purpose:** يوفر بيانات تعريفية تتعلق بقيد مساحة الاسم وتوصيتها وتصنيفها لمورد معين.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -241,7 +241,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** الترتيب المقترح للخصائص لعرضها في واجهة المستخدم/CLI.
+- **Purpose:** الترتيب المقترح للخصائص لعرضها في واجهة المستخدم أو CLI.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -253,7 +253,7 @@ i18n:
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** اسم نوع مورد Terraform الذي يُعيَّن إلى هذا المخطط.
+- **Purpose:** اسم نوع مورد Terraform الذي يرتبط بهذا المخطط.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -265,7 +265,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** اسم عرض قابل للقراءة البشرية لمخطط المورد (يتجاوز التوليد التلقائي).
+- **Purpose:** اسم عرض مقروء للبشر لمخطط مورد (يتجاوز التوليد التلقائي).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -277,7 +277,7 @@ i18n:
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** بيانات تعريفية لتنقل واجهة وحدة التحكم والتوجيه وبنية النموذج لهذا المورد.
+- **Purpose:** تنقل واجهة وحدة التحكم والتوجيه وبنية النموذج لهذا المورد.
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -286,12 +286,12 @@ i18n:
 - **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
 - **Pass-through from upstream:** no
 
-## مُحقنة — على مستوى الخاصية
+## مُضاف — على مستوى الخاصية
 
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** وصف خاصية مُثرى يُكمل `description` المصدرية.
+- **Purpose:** وصف خاصية محسّن يُكمّل الـ `description` الأصلي.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -303,7 +303,7 @@ i18n:
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** قواعد التحقق التصريحية المستمدة من `ves.io.schema.rules` في protobuf المصدري.
+- **Purpose:** قواعد التحقق التصريحية المستخلصة من `ves.io.schema.rules` في protobuf الأصلي.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -315,7 +315,7 @@ i18n:
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** قيم أمثلة توضيحية متعددة لخاصية معينة.
+- **Purpose:** قيم مثال توضيحية متعددة لخاصية معينة.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -327,7 +327,7 @@ i18n:
 ### x-f5xc-example
 
 - **Applied at:** schema property
-- **Purpose:** قيمة مثال معيارية واحدة.
+- **Purpose:** قيمة مثال أساسية واحدة.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -339,7 +339,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** تلميحات إكمال الصدفة (enum ثابت أو أمر ديناميكي).
+- **Purpose:** تلميحات إكمال الصدفة (تعداد ثابت أو أمر ديناميكي).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -351,7 +351,7 @@ i18n:
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** القيمة (القيم) الافتراضية لعرضها في الوثائق وواجهات المستخدم المُولَّدة.
+- **Purpose:** القيمة الافتراضية أو القيم الافتراضية لعرضها في المستندات المُولَّدة وواجهات المستخدم.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -375,7 +375,7 @@ i18n:
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** يسرد مجموعات الميزات المُسمّاة التي تتطلب هذه الخاصية.
+- **Purpose:** يسرد مجموعات الميزات المسمّاة التي تتطلب هذه الخاصية.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -387,7 +387,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** المتطلبات الشرطية (مثل: مطلوب عندما يساوي حقل شقيق قيمة X).
+- **Purpose:** المتطلبات الشرطية (مثال: مطلوب عندما تساوي حقل شقيق قيمة X).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -399,7 +399,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** إشعار الإيقاف مع توجيهات الاستبدال.
+- **Purpose:** إشعار الإهمال مع إرشادات الاستبدال.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -411,7 +411,7 @@ i18n:
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** القيمة الافتراضية التي يُعيّنها الخادم عندما يحذف العميل الخاصية.
+- **Purpose:** القيمة الافتراضية التي يعيّنها الخادم عند إغفال العميل للخاصية.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -423,7 +423,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** القيمة الإنتاجية الموصى بها لحقل يكون فيه الافتراضي الخاصي بالخادم غير مثالي.
+- **Purpose:** القيمة الموصى بها في الإنتاج لحقل تكون قيمة الخادم الافتراضية له دون المستوى الأمثل.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -456,10 +456,34 @@ i18n:
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** يُعلن عن نوع مورد حقل ObjectRefType المُشار إليه (المورد الذي يشير إليه ويجب أن يوجد مسبقاً)، مع تحديد اختيار oneOf، والمتطلب عند الإنشاء، والعدديّة — البُعد المرجعي للموارد في نموذج الاعتمادية.
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** قيم مثال الحقول عند الإنشاء لكل حقل (خريطة مسطحة من مسار الحقل إلى القيمة) مستخلصة من x-f5xc-minimum-configuration.example_yaml — المصدر الوحيد الحتمي لقيم الإنشاء المستخدمة في توليد النماذج وسير العمل اللاحقة.
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** يوثق تبعيات الحقول المتقاطعة حيث يتطلب حقل واحد تعيين حقل آخر.
+- **Purpose:** يوثّق التبعيات عبر الحقول حيث يتطلب حقل ما أن يكون حقل آخر محدداً.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -471,7 +495,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** القيود الرقمية/النصية المستمدة من استطلاع API المباشر أو الأنماط الثابتة.
+- **Purpose:** قيود رقمية أو نصية مستخلصة من فحص الـ API المباشر أو الأنماط الثابتة.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -483,7 +507,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** يُعلن ما إذا كان الحقل يجب أن يكون فريدًا ضمن نطاقه.
+- **Purpose:** يُعلن ما إذا كان الحقل يجب أن يكون فريداً ضمن نطاقه.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -495,7 +519,7 @@ i18n:
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** بيانات تعريفية لأداة النموذج في وحدة التحكم لخاصية API هذه.
+- **Purpose:** بيانات تعريفية لعنصر نموذج وحدة التحكم لهذه الخاصية في الـ API.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -504,12 +528,12 @@ i18n:
 - **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
 - **Pass-through from upstream:** no
 
-## مُحقنة — على مستوى العملية
+## مُضاف — على مستوى العملية
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** يُسمّي حقول نص العملية التي يجب توفيرها لتحقيق النجاح.
+- **Purpose:** يسمّي حقول نص العملية التي يجب توفيرها لنجاح التنفيذ.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -521,7 +545,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** يُصنّف نطاق تأثير العملية (منخفض/متوسط/عالٍ/حرج).
+- **Purpose:** يصنّف نطاق تأثير العملية (منخفض/متوسط/مرتفع/حرج).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -533,7 +557,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** ما إذا كان يجب على CLI/واجهة المستخدم مطالبة المستخدم بالتأكيد قبل التنفيذ.
+- **Purpose:** ما إذا كان CLI أو واجهة المستخدم يجب أن يطلب من المستخدم التأكيد قبل التنفيذ.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -545,7 +569,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** يسرد الآثار الجانبية القابلة للملاحظة للعملية (إعادة التشغيل، إعادة التهيئة، إلخ).
+- **Purpose:** يسرد الآثار الجانبية الملحوظة للعملية (إعادة التشغيل، إعادة الضبط، إلخ).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -557,7 +581,7 @@ i18n:
 ### x-f5xc-discovered-response-time
 
 - **Applied at:** operation
-- **Purpose:** وقت الاستجابة المقاس تجريبيًا لهذه العملية أثناء الاكتشاف.
+- **Purpose:** وقت الاستجابة المقاس تجريبياً لهذه العملية أثناء الاكتشاف.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -569,7 +593,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** ترويسات/سلوك تحديد المعدل الملاحَظة المستخرجة من API المباشر.
+- **Purpose:** حدود المعدل المرصودة / السلوك المرصود من الـ API المباشر.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -581,7 +605,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** كتالوج استجابات الأخطاء الملاحظة أثناء الاكتشاف المباشر، مع عينات من الحمولات.
+- **Purpose:** كتالوج استجابات الأخطاء المرصودة أثناء الاكتشاف المباشر، مع عيّنات من البيانات.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -590,12 +614,12 @@ i18n:
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## مُحقنة — على مستوى الفهرس (بيانات تعريفية للنطاق)
+## مُضاف — على مستوى الفهرس (بيانات تعريفية للنطاق)
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** فئة التجميع عالية المستوى لـ CLI / واجهة المستخدم / الوثائق / Terraform لنطاق معين.
+- **Purpose:** فئة التجميع العليا لـ CLI / واجهة المستخدم / المستندات / Terraform لنطاق معين.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -607,7 +631,7 @@ i18n:
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** قائمة بأنواع الموارد الأساسية التي تُعرّف النطاق.
+- **Purpose:** قائمة أنواع الموارد الرئيسية التي تُعرّف النطاق.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -619,7 +643,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** الموارد التي تتطلب عناية خاصة (حرجة في الإنتاج).
+- **Purpose:** الموارد التي تستلزم عناية خاصة (حرجة للإنتاج).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -631,7 +655,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** وصف قصير للنطاق (~60 حرفًا). ينطبق أيضًا على مستوى الخاصية للأوصاف الطويلة.
+- **Purpose:** وصف مختصر للنطاق (~60 حرفاً). ينطبق أيضاً على مستوى الخاصية للأوصاف الطويلة.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -643,7 +667,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** وصف متوسط للنطاق (~150 حرفًا). ينطبق أيضًا على مستوى الخاصية.
+- **Purpose:** وصف متوسط للنطاق (~150 حرفاً). ينطبق أيضاً على مستوى الخاصية.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -691,7 +715,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** يُعلّم نطاقًا باعتباره ميزة معاينة/تجريبية.
+- **Purpose:** يضع علامة على النطاق باعتباره ميزة معاينة / تجريبية.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -703,7 +727,7 @@ i18n:
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** حالات الاستخدام المُسمّاة التي يدعمها هذا النطاق.
+- **Purpose:** حالات الاستخدام المسمّاة التي يدعمها هذا النطاق.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -715,7 +739,7 @@ i18n:
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** معرّف الأيقونة المستخدم عند تقديم هذا النطاق في واجهة مستخدم.
+- **Purpose:** معرّف الأيقونة المستخدمة عند عرض هذا النطاق في واجهة المستخدم.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -727,7 +751,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** SVG مُدمج (أو مسار) لشعار علامة تجارية يمثل النطاق.
+- **Purpose:** SVG مضمّن (أو مسار) لشعار علامة تجارية يمثّل النطاق.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -739,7 +763,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** روابط متقاطعة لنطاقات أخرى تُستخدم عادةً مع هذا النطاق.
+- **Purpose:** روابط تقاطع مع نطاقات أخرى تُستخدم عادةً معاً مع هذا النطاق.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -751,7 +775,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** قسم الوثائق / بادئة تجميع التنقل للوثائق المُقدَّمة.
+- **Purpose:** الاسم المختصر لقسم التوثيق / مجموعة التنقل في المستندات المُصيَّرة.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -760,12 +784,12 @@ i18n:
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## مُمررة من المصدر
+## مُمرَّر من المصدر الأصلي
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة F5 المصدرية.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -777,7 +801,7 @@ i18n:
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة F5 المصدرية.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -789,7 +813,7 @@ i18n:
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة F5 المصدرية.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -801,7 +825,7 @@ i18n:
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة F5 المصدرية.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -813,7 +837,7 @@ i18n:
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة F5 المصدرية.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -825,7 +849,7 @@ i18n:
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة F5 المصدرية.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -837,35 +861,35 @@ i18n:
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة F5 المصدرية.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** راجع وثائق F5 المصدرية.
+- **Example:** راجع وثائق F5 الأصلية.
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة F5 المصدرية.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** راجع وثائق F5 المصدرية.
+- **Example:** راجع وثائق F5 الأصلية.
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** محفوظة دون تغيير من مواصفة F5 المصدرية.
+- **Purpose:** محفوظ دون تغيير من مواصفة F5 الأصلية.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** راجع وثائق F5 المصدرية.
+- **Example:** راجع وثائق F5 الأصلية.
 - **Pass-through from upstream:** yes

--- a/docs/de/extensions/catalog.md
+++ b/docs/de/extensions/catalog.md
@@ -1,37 +1,38 @@
 ---
-title: Anreicherungserweiterungskatalog
+title: Anreicherungserweiterungs-Katalog
 description: >-
-  Maßgebliche Referenz für jede x-*-Erweiterung in den angereicherten
+  Maßgebliche Referenz für jede x-* Erweiterung in den erweiterten
   OpenAPI-Spezifikationen
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
-# Anreicherungserweiterungskatalog
+# Anreicherungserweiterungs-Katalog
 
 Maßgebliche Referenz für jede `x-*`-Erweiterung, die in
 `docs/specifications/api/*.json` vorkommt. Die Parität mit
 `scripts/utils/extension_constants.py` wird durch
-`tests/test_extension_catalog.py` sichergestellt.
+`tests/test_extension_catalog.py` erzwungen.
 
 Drei Klassen von Erweiterungen sind hier dokumentiert:
 
-- **Hier eingefügt** — Erweiterungen, die unsere Anreicherungsskripte hinzufügen (`x-f5xc-*` und
-  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / Erkennung
-  Varianten). Diese sind die Erweiterungen, die nachgelagerte Werkzeuge verwenden sollten.
-- **Upstream-Durchleitung** — Erweiterungen, die F5 in den Quellspezifikationen ausgibt
-  und die wir unverändert übernehmen (`x-ves-proto-*`, `x-displayname` usw.).
+- **Hier eingefügt** — Erweiterungen, die unsere Anreicherungsprozesse hinzufügen (`x-f5xc-*` und
+  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / Discovery-
+  Varianten). Diese sind diejenigen, die nachgelagerte Werkzeuge konsumieren sollen.
+- **Upstream-Durchleitung** — Erweiterungen, die F5 in den Quellspezifikationen
+  ausgibt und die wir unverändert weitergeben (`x-ves-proto-*`, `x-displayname` usw.).
   Aus Transparenzgründen dokumentiert, aber nicht von diesem Repository gesteuert.
-- **Zukünftig eingefügt** — noch nicht ausgegeben; wird hier dokumentiert, sobald
-  ein Anreicherungsskript beginnt, sie zu erzeugen (bei der Erstbefüllung nicht zutreffend).
+- **Zukünftig eingefügt** — Noch nicht ausgegeben; hier dokumentiert in dem Moment,
+  in dem ein Anreicherungsprozess beginnt, diese zu erzeugen (gilt nicht für die erste
+  Befüllung).
 
 ## Eintragsschema
 
 Jeder Eintrag unten hat genau diese Form. Der Paritätstest in
-`tests/test_extension_catalog.py` toleriert, dass der Abschnittsinhalt kurz ist,
+`tests/test_extension_catalog.py` toleriert, dass der Abschnittskörper kurz ist,
 solange der `### x-name`-Header vorhanden ist und das
-`Pass-through from upstream:`-Flag mit dem Wert `yes` oder `no` gesetzt ist.
+`Pass-through from upstream:`-Kennzeichen mit dem Wert `yes` oder `no` vorhanden ist.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -73,7 +74,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** Zeitstempel der Upstream-Quellspezifikation, aus der die angereicherte Datei erstellt wurde.
+- **Purpose:** Zeitstempel der vorgelagerten Quellspezifikation, aus der die angereicherte Datei erstellt wurde.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -85,7 +86,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag des Release-Assets der Upstream-Quellspezifikation.
+- **Purpose:** ETag des Release-Assets der vorgelagerten Quellspezifikation.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -109,7 +110,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** Branding-/Terminologieglossar-Block, der auf jede Domain-Spezifikation angewendet wird.
+- **Purpose:** Marken-/Terminologie-Glossarblock, der auf jede Domain-Spezifikation angewendet wird.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -121,7 +122,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** Zeitstempel, wann der Live-API-Erkennungsdurchlauf ausgeführt wurde.
+- **Purpose:** Zeitstempel, wann der Live-API-Discovery-Durchlauf ausgeführt wurde.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -133,7 +134,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** Basis-URL der Live-API, die während der Erkennung untersucht wurde.
+- **Purpose:** Basis-URL der Live-API, die während der Discovery geprüft wurde.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -157,7 +158,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** Beobachtete Antwortzeit (ms) für die untersuchte API während der Erkennung.
+- **Purpose:** Beobachtete Antwortzeit (ms) für die geprüfte API während der Discovery.
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -169,7 +170,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** Kuratierte Best-Practice-Leitlinien für eine Domain.
+- **Purpose:** Kuratierte Best-Practice-Anleitungen für eine Domain.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -181,7 +182,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** Benannte Schritt-für-Schritt-Workflows zur Erledigung häufiger Aufgaben in einer Domain.
+- **Purpose:** Benannte schrittweise Workflows zur Erledigung häufiger Aufgaben in einer Domain.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -193,7 +194,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** Domain-spezifische Akronym-Erweiterungstabelle.
+- **Purpose:** Domain-spezifische Akronym-Auflösungstabelle.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -219,7 +220,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** Minimaler Feldsatz, der für ein erfolgreiches POST/PUT dieser Ressource erforderlich ist.
+- **Purpose:** Minimaler lebensfähiger Feldsatz, der erforderlich ist, um diese Ressource erfolgreich per POST/PUT zu übertragen.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -255,7 +256,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** Name des Terraform-Ressourcentyps, der diesem Schema zugeordnet ist.
+- **Purpose:** Terraform-Ressourcentypname, der diesem Schema zugeordnet ist.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -267,7 +268,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** Menschenlesbarer Anzeigename für ein Ressourcenschema (überschreibt die automatische Generierung).
+- **Purpose:** Lesbarer Anzeigename für ein Ressourcenschema (überschreibt die automatische Generierung).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -293,7 +294,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** Angereicherte Eigenschaftsbeschreibung, die die Upstream-`description` ergänzt.
+- **Purpose:** Angereicherte Eigenschaftsbeschreibung, die die vorgelagerte `description` ergänzt.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -305,7 +306,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** Deklarative Validierungsregeln, abgeleitet aus den Upstream-Protobuf-`ves.io.schema.rules`.
+- **Purpose:** Deklarative Validierungsregeln, abgeleitet aus den vorgelagerten Protobuf-`ves.io.schema.rules`.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -317,7 +318,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** Mehrere illustrative Beispielwerte für eine Eigenschaft.
+- **Purpose:** Mehrere veranschaulichende Beispielwerte für eine Eigenschaft.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -389,7 +390,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** Bedingte Anforderungen (z. B. erforderlich, wenn ein benachbartes Feld gleich X ist).
+- **Purpose:** Bedingte Anforderungen (z. B. erforderlich, wenn ein Geschwisterfeld gleich X ist).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -401,7 +402,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** Veraltungshinweis mit Hinweisen zur Ersetzung.
+- **Purpose:** Veraltungshinweis mit Ersetzungsanleitung.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -425,7 +426,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** Empfohlener Produktionswert für ein Feld, bei dem der Serverstandard suboptimal ist.
+- **Purpose:** Empfohlener Produktionswert für ein Feld, bei dem der Server-Standard suboptimal ist.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -437,7 +438,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-recommended-oneof-variant
 
 - **Applied at:** schema property
-- **Purpose:** Gibt bei `oneOf`-Blöcken an, welche Variante empfohlen wird.
+- **Purpose:** Gibt für `oneOf`-Blöcke an, welche Variante empfohlen wird.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -449,13 +450,37 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** Listet benachbarte Eigenschaften auf, die nicht zusammen mit dieser gesetzt werden können.
+- **Purpose:** Listet Geschwistereigenschaften auf, die nicht zusammen mit dieser gesetzt werden können.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
 - **Injected by:** scripts/utils/conflicts_with_enricher.py
 - **Driven by config:** hardcoded
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** Deklariert die referenzierte Ressourcenart eines ObjectRefType-Feldes (die Ressource, auf die es zeigt und die zuerst vorhanden sein muss), mit oneOf-Auswahlsteuerung, Pflichtangabe bei der Erstellung und Kardinalität — die ressourcenreferenz-Dimension des Abhängigkeitsmodells.
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** Feldspezifische Erstellungsbeispielpielwerte (flache Zuordnung von Feldpfad zu Wert), abgeleitet aus x-f5xc-minimum-configuration.example_yaml — die einzige Quelle der Wahrheit für deterministische Erstellungswerte für die nachgelagerte Formular-/Workflow-Generierung.
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-requires
@@ -473,7 +498,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Numerische/Zeichenketten-Einschränkungen, abgeleitet aus Live-API-Prüfungen oder statischen Mustern.
+- **Purpose:** Numerische/String-Einschränkungen, abgeleitet aus Live-API-Prüfungen oder statischen Mustern.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -511,7 +536,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** Benennt die Operationsrumpf-Felder, die für einen Erfolg angegeben werden müssen.
+- **Purpose:** Benennt die Felder des Operationskörpers, die für den Erfolg bereitgestellt werden müssen.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -523,7 +548,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** Klassifiziert den Wirkungsradius einer Operation (niedrig/mittel/hoch/kritisch).
+- **Purpose:** Klassifiziert den Wirkungsbereich einer Operation (niedrig/mittel/hoch/kritisch).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -535,7 +560,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Gibt an, ob CLI/UI den Benutzer zur Bestätigung auffordern soll, bevor die Ausführung erfolgt.
+- **Purpose:** Gibt an, ob CLI/UI den Benutzer vor der Ausführung zur Bestätigung auffordern soll.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -559,7 +584,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-discovered-response-time
 
 - **Applied at:** operation
-- **Purpose:** Empirisch gemessene Antwortzeit für diese Operation während der Erkennung.
+- **Purpose:** Empirisch gemessene Antwortzeit für diese Operation während der Discovery.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -583,7 +608,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** Katalog der während der Live-Erkennung beobachteten Fehlerantworten mit Beispiel-Payloads.
+- **Purpose:** Katalog der während der Live-Discovery beobachteten Fehlerantworten mit Beispiel-Payloads.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -681,7 +706,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** Mindest-F5-XC-Abonnementstufe, die erforderlich ist.
+- **Purpose:** Minimale erforderliche F5 XC-Abonnementstufe.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -717,7 +742,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** Symbol-Bezeichner, der beim Rendern dieser Domain in einer Benutzeroberfläche verwendet wird.
+- **Purpose:** Symbolkennung, die beim Rendern dieser Domain in einer Benutzeroberfläche verwendet werden soll.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -753,7 +778,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** Dokumentationsabschnitt-/Navigationsgruppierungs-Slug für gerenderte Dokumentation.
+- **Purpose:** Dokumentationsabschnitt-/Navigationsgruppen-Slug für gerenderte Dokumentation.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -767,7 +792,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** Unverändert aus der F5-Upstream-Spezifikation übernommen.
+- **Purpose:** Unverändert aus der vorgelagerten F5-Spezifikation übernommen.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -779,7 +804,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** Unverändert aus der F5-Upstream-Spezifikation übernommen.
+- **Purpose:** Unverändert aus der vorgelagerten F5-Spezifikation übernommen.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -791,7 +816,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** Unverändert aus der F5-Upstream-Spezifikation übernommen.
+- **Purpose:** Unverändert aus der vorgelagerten F5-Spezifikation übernommen.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -803,7 +828,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** Unverändert aus der F5-Upstream-Spezifikation übernommen.
+- **Purpose:** Unverändert aus der vorgelagerten F5-Spezifikation übernommen.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -815,7 +840,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** Unverändert aus der F5-Upstream-Spezifikation übernommen.
+- **Purpose:** Unverändert aus der vorgelagerten F5-Spezifikation übernommen.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -827,7 +852,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** Unverändert aus der F5-Upstream-Spezifikation übernommen.
+- **Purpose:** Unverändert aus der vorgelagerten F5-Spezifikation übernommen.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -839,7 +864,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** Unverändert aus der F5-Upstream-Spezifikation übernommen.
+- **Purpose:** Unverändert aus der vorgelagerten F5-Spezifikation übernommen.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -851,7 +876,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** Unverändert aus der F5-Upstream-Spezifikation übernommen.
+- **Purpose:** Unverändert aus der vorgelagerten F5-Spezifikation übernommen.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -863,7 +888,7 @@ solange der `### x-name`-Header vorhanden ist und das
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** Unverändert aus der F5-Upstream-Spezifikation übernommen.
+- **Purpose:** Unverändert aus der vorgelagerten F5-Spezifikation übernommen.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A

--- a/docs/en/extensions/catalog.md
+++ b/docs/en/extensions/catalog.md
@@ -454,6 +454,30 @@ stubby as long as the `### x-name` header exists and the
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** Declares an ObjectRefType field's referred resource-kind (the resource it points to, which must exist first), with oneOf choice-gating, required-for-create, and cardinality — the resource-reference dimension of the dependency model.
+- **Consumers:** terraform, cli, mcp, ide, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** Per-field create example values (flat field_path to value map) derived from x-f5xc-minimum-configuration.example_yaml — the single source of deterministic create values for downstream form/workflow generation.
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property

--- a/docs/en/extensions/catalog.md
+++ b/docs/en/extensions/catalog.md
@@ -458,7 +458,7 @@ stubby as long as the `### x-name` header exists and the
 
 - **Applied at:** schema property
 - **Purpose:** Declares an ObjectRefType field's referred resource-kind (the resource it points to, which must exist first), with oneOf choice-gating, required-for-create, and cardinality — the resource-reference dimension of the dependency model.
-- **Consumers:** terraform, cli, mcp, ide, ai-assistants
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
 - **Injected by:** scripts/utils/references_enricher.py

--- a/docs/es/extensions/catalog.md
+++ b/docs/es/extensions/catalog.md
@@ -4,7 +4,7 @@ description: >-
   Fuente de verdad para cada extensión x-* en las especificaciones OpenAPI
   enriquecidas
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
@@ -12,25 +12,25 @@ i18n:
 
 Fuente de verdad para cada extensión `x-*` que aparece en
 `docs/specifications/api/*.json`. La paridad con
-`scripts/utils/extension_constants.py` es aplicada por
+`scripts/utils/extension_constants.py` es verificada por
 `tests/test_extension_catalog.py`.
 
 Aquí se documentan tres clases de extensiones:
 
-- **Inyectadas aquí** — extensiones que nuestros enriquecedores añaden (`x-f5xc-*` y
-  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / variantes de descubrimiento).
-  Estas son las que las herramientas descendentes deben consumir.
-- **Transferencia desde upstream** — extensiones que F5 emite en las especificaciones fuente
+- **Inyectadas aquí** — extensiones que añaden nuestros enriquecedores (`x-f5xc-*` y
+  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / variantes de
+  descubrimiento). Estas son las que deben consumir las herramientas posteriores.
+- **Transmisión desde upstream** — extensiones que F5 emite en las especificaciones fuente
   y que preservamos sin cambios (`x-ves-proto-*`, `x-displayname`, etc.).
   Documentadas por transparencia, pero no controladas por este repositorio.
 - **Inyección futura** — aún no emitidas; documentadas aquí en el momento en que
-  un enriquecedor comience a producirlas (no aplica en la población inicial).
+  un enriquecedor comienza a producirlas (no aplica en la población inicial).
 
-## Esquema de entradas
+## Esquema de entrada
 
 Cada entrada a continuación tiene exactamente esta forma. La prueba de paridad en
 `tests/test_extension_catalog.py` tolera que el cuerpo de la sección sea
-mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
+escueto, siempre que exista el encabezado `### x-name` y el indicador
 `Pass-through from upstream:` esté presente con el valor `yes` o `no`.
 
     ### x-<name>
@@ -49,7 +49,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** Identifica el slug del dominio CLI (p. ej., `http_loadbalancer`) para una especificación enriquecida.
+- **Purpose:** Identifica el slug de dominio de la CLI (p. ej. `http_loadbalancer`) para una especificación enriquecida.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -61,7 +61,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** Bloque de metadatos de CLI (nombre de la herramienta, sugerencias de versión, agrupación de dominio).
+- **Purpose:** Bloque de metadatos globales de la CLI (nombre de herramienta, sugerencias de versión, agrupación de dominio).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -85,7 +85,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag del activo de la versión de la especificación fuente upstream.
+- **Purpose:** ETag del activo de lanzamiento de la especificación fuente upstream.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -109,7 +109,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** Bloque de glosario de marca/terminología aplicado a cada especificación de dominio.
+- **Purpose:** Bloque de glosario de terminología y marca aplicado a cada especificación de dominio.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -121,7 +121,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** Marca de tiempo de cuando se ejecutó el paso de descubrimiento de la API en vivo.
+- **Purpose:** Marca de tiempo de cuándo se ejecutó el paso de descubrimiento de la API en vivo.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -145,7 +145,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL a la página de documentación de referencia de API alojada para este dominio.
+- **Purpose:** URL a la página de documentación de referencia de la API alojada para este dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -181,7 +181,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** Flujos de trabajo paso a paso con nombre para realizar tareas comunes en un dominio.
+- **Purpose:** Flujos de trabajo paso a paso con nombre para llevar a cabo tareas comunes en un dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -205,7 +205,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-console-navigation
 
 - **Applied at:** spec info
-- **Purpose:** Árbol de navegación global de la consola — jerarquía de espacios de trabajo y menús.
+- **Purpose:** Árbol de navegación global de la consola — jerarquía de espacio de trabajo y menú.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
@@ -219,7 +219,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** Conjunto mínimo de campos requerido para realizar con éxito un POST/PUT de este recurso.
+- **Purpose:** Conjunto mínimo de campos necesarios para hacer un POST/PUT exitoso de este recurso.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -243,7 +243,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** Orden sugerido de propiedades para la presentación en UI/CLI.
+- **Purpose:** Ordenamiento sugerido de propiedades para la presentación en UI/CLI.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -255,7 +255,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** Nombre del tipo de recurso de Terraform que se corresponde con este esquema.
+- **Purpose:** Nombre del tipo de recurso Terraform que se mapea a este esquema.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -267,7 +267,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** Nombre para mostrar legible por humanos para un esquema de recurso (anula la generación automática).
+- **Purpose:** Nombre de presentación legible por humanos para un esquema de recurso (reemplaza la generación automática).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -279,7 +279,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** Navegación, enrutamiento y estructura de formulario de la UI de la consola para este recurso.
+- **Purpose:** Navegación de la interfaz de usuario de la consola, enrutamiento y estructura de formularios para este recurso.
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -305,7 +305,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** Reglas de validación declarativas derivadas de `ves.io.schema.rules` de protobuf upstream.
+- **Purpose:** Reglas de validación declarativas derivadas de las `ves.io.schema.rules` de protobuf upstream.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -341,7 +341,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** Sugerencias de autocompletado de shell (enumeración estática o comando dinámico).
+- **Purpose:** Sugerencias de completado de shell (enumeración estática o comando dinámico).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -353,7 +353,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** Valor(es) predeterminado(s) para mostrar en la documentación generada y en las interfaces de usuario.
+- **Purpose:** Valor(es) predeterminado(s) para mostrar en documentación y UIs generadas.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -377,7 +377,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** Lista las combinaciones de características con nombre que requieren esta propiedad.
+- **Purpose:** Lista las combinaciones de funcionalidades nombradas que requieren esta propiedad.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -389,7 +389,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** Requisitos condicionales (p. ej., requerido cuando un campo hermano es igual a X).
+- **Purpose:** Requisitos condicionales (p. ej. requerido cuando un campo hermano es igual a X).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -401,7 +401,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** Aviso de obsolescencia con orientación sobre el reemplazo.
+- **Purpose:** Aviso de deprecación con orientación sobre el reemplazo.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -425,7 +425,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** Valor de producción recomendado para un campo donde el valor predeterminado del servidor es subóptimo.
+- **Purpose:** Valor recomendado para producción en un campo donde el valor predeterminado del servidor no es óptimo.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -437,7 +437,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-recommended-oneof-variant
 
 - **Applied at:** schema property
-- **Purpose:** Para bloques `oneOf`, indica cuál variante es la recomendada.
+- **Purpose:** Para bloques `oneOf`, indica qué variante se recomienda.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -458,10 +458,34 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** Declara el tipo de recurso referenciado por un campo ObjectRefType (el recurso al que apunta, que debe existir previamente), con limitación de elección oneOf, requerido para creación y cardinalidad — la dimensión de referencia de recurso del modelo de dependencias.
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** Valores de ejemplo de creación por campo (mapa plano de field_path a valor) derivados de x-f5xc-minimum-configuration.example_yaml — la única fuente de verdad de valores de creación deterministas para la generación de formularios y flujos de trabajo posteriores.
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** Documenta las dependencias entre campos donde un campo requiere que otro esté configurado.
+- **Purpose:** Documenta dependencias entre campos donde un campo requiere que otro esté definido.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -473,7 +497,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Restricciones numéricas/de cadena derivadas del sondeo de la API en vivo o de patrones estáticos.
+- **Purpose:** Restricciones numéricas / de cadena derivadas del sondeo de la API en vivo o de patrones estáticos.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -497,7 +521,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** Metadatos del widget de formulario de la consola para esta propiedad de API.
+- **Purpose:** Metadatos del widget de formulario de consola para esta propiedad de API.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -535,7 +559,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Indica si el CLI/UI debe solicitar confirmación al usuario antes de ejecutar.
+- **Purpose:** Indica si la CLI/UI debe solicitar confirmación al usuario antes de ejecutar.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -571,7 +595,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** Encabezados/comportamiento de límite de tasa observados desde la API en vivo.
+- **Purpose:** Encabezados / comportamiento de límite de tasa observados desde la API en vivo.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -583,7 +607,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** Catálogo de respuestas de error observadas durante el descubrimiento en vivo, con cargas de muestra.
+- **Purpose:** Catálogo de respuestas de error observadas durante el descubrimiento en vivo, con cargas útiles de muestra.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -621,7 +645,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** Recursos que requieren cuidado especial (críticos para producción).
+- **Purpose:** Recursos que requieren especial cuidado (críticos para producción).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -633,7 +657,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** Descripción corta del dominio (~60 caracteres). También aplica a nivel de propiedad para descripciones largas.
+- **Purpose:** Descripción de dominio corta (~60 caracteres). También aplica a nivel de propiedad para descripciones largas.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -645,7 +669,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** Descripción media del dominio (~150 caracteres). También aplica a nivel de propiedad.
+- **Purpose:** Descripción de dominio media (~150 caracteres). También aplica a nivel de propiedad.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -657,7 +681,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** Descripción larga del dominio (~500 caracteres).
+- **Purpose:** Descripción de dominio larga (~500 caracteres).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -669,7 +693,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** Nivel de complejidad relativa para la creación de configuraciones en este dominio.
+- **Purpose:** Nivel de complejidad relativa para la autoría de configuraciones en este dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -681,7 +705,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** Nivel mínimo de suscripción de F5 XC requerido.
+- **Purpose:** Nivel mínimo de suscripción a F5 XC requerido.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -693,7 +717,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** Marca un dominio como característica de vista previa / beta.
+- **Purpose:** Marca un dominio como funcionalidad en versión preliminar / beta.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -705,7 +729,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** Casos de uso con nombre que admite este dominio.
+- **Purpose:** Casos de uso nombrados que admite este dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -717,7 +741,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** Identificador de icono para usar al renderizar este dominio en una interfaz de usuario.
+- **Purpose:** Identificador de icono a usar al renderizar este dominio en una UI.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -741,7 +765,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** Vínculos cruzados hacia otros dominios comúnmente utilizados junto con este.
+- **Purpose:** Vínculos cruzados a otros dominios comúnmente usados junto con este.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -753,7 +777,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** Sección de documentación / slug de agrupación de navegación para la documentación renderizada.
+- **Purpose:** Slug de sección de documentación / agrupación de navegación para los documentos renderizados.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -762,12 +786,12 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## Transferencia desde upstream
+## Transmisión desde upstream
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservado sin cambios de la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -779,7 +803,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservado sin cambios de la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -791,7 +815,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservado sin cambios de la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -803,7 +827,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservado sin cambios de la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -815,7 +839,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservado sin cambios de la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -827,7 +851,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservado sin cambios de la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -839,7 +863,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservado sin cambios de la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -851,7 +875,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservado sin cambios de la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -863,7 +887,7 @@ mínimo, siempre que exista el encabezado `### x-nombre` y el indicador
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sin cambios desde la especificación upstream de F5.
+- **Purpose:** Preservado sin cambios de la especificación upstream de F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A

--- a/docs/fr/extensions/catalog.md
+++ b/docs/fr/extensions/catalog.md
@@ -4,44 +4,44 @@ description: >-
   Source de vérité pour chaque extension x-* dans les spécifications OpenAPI
   enrichies
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
 # Catalogue des extensions d'enrichissement
 
-Source de vérité pour chaque extension `x-*` apparaissant dans
+Source de vérité pour chaque extension `x-*` qui apparaît dans
 `docs/specifications/api/*.json`. La parité avec
 `scripts/utils/extension_constants.py` est vérifiée par
 `tests/test_extension_catalog.py`.
 
-Trois catégories d'extensions sont documentées ici :
+Trois classes d'extensions sont documentées ici :
 
 - **Injectées ici** — extensions ajoutées par nos enrichisseurs (`x-f5xc-*` et
-  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / variantes de
-  découverte). Ce sont celles que les outils en aval doivent consommer.
-- **Transmises depuis l'amont** — extensions émises par F5 dans les spécifications sources
-  et préservées sans modification (`x-ves-proto-*`, `x-displayname`, etc.).
-  Documentées par transparence mais non contrôlées par ce dépôt.
-- **À injecter ultérieurement** — pas encore émises ; documentées ici dès qu'un
+  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / variantes de découverte).
+  Ce sont celles que les outils en aval doivent consommer.
+- **Transmission en amont** — extensions émises par F5 dans les spécifications sources
+  et préservées à l'identique (`x-ves-proto-*`, `x-displayname`, etc.).
+  Documentées par souci de transparence, mais non contrôlées par ce dépôt.
+- **Injectées ultérieurement** — pas encore émises ; documentées ici dès qu'un
   enrichisseur commence à les produire (non applicable lors de la population initiale).
 
 ## Schéma d'entrée
 
 Chaque entrée ci-dessous possède exactement cette forme. Le test de parité dans
-`tests/test_extension_catalog.py` tolère que le corps de section soit sommaire,
+`tests/test_extension_catalog.py` tolère que le corps de section soit succinct,
 à condition que l'en-tête `### x-name` existe et que l'indicateur
 `Pass-through from upstream:` soit présent avec la valeur `yes` ou `no`.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
-    - **Purpose:** <one sentence>
+    - **Purpose:** <une phrase>
     - **Consumers:** <CLI | VSCode | Terraform | Web UI | multiple | N/A>
     - **Value type:** <string | number | boolean | object | array>
-    - **Value schema:** <JSON Schema snippet, or N/A>
-    - **Injected by:** <scripts/utils/<enricher>.py, or "upstream">
-    - **Driven by config:** <config/<file>.yaml, or "hardcoded", or "upstream">
-    - **Example:** <short snippet>
+    - **Value schema:** <extrait JSON Schema, ou N/A>
+    - **Injected by:** <scripts/utils/<enricher>.py, ou "upstream">
+    - **Driven by config:** <config/<file>.yaml, ou "hardcoded", ou "upstream">
+    - **Example:** <extrait court>
     - **Pass-through from upstream:** <yes/no>
 
 ## Injectées — niveau spec (section info)
@@ -61,7 +61,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** Bloc de métadonnées globales CLI (nom de l'outil, indications de version, groupement de domaine).
+- **Purpose:** Bloc de métadonnées CLI global (nom de l'outil, indications de version, regroupement de domaine).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -73,7 +73,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** Horodatage de la spec source amont à partir de laquelle le fichier enrichi a été construit.
+- **Purpose:** Horodatage de la spec source en amont à partir de laquelle le fichier enrichi a été construit.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -85,7 +85,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag de la ressource de publication de la spec source amont.
+- **Purpose:** ETag de la ressource de version de la spec source en amont.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -121,7 +121,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** Horodatage de l'exécution de la passe de découverte de l'API en direct.
+- **Purpose:** Horodatage indiquant quand la passe de découverte de l'API en direct a été exécutée.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -133,7 +133,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** URL de base de l'API en direct qui a été sondée lors de la découverte.
+- **Purpose:** URL de base de l'API en direct sondée lors de la découverte.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -145,7 +145,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL vers la page de documentation de référence API hébergée pour ce domaine.
+- **Purpose:** URL de la page de documentation de référence API hébergée pour ce domaine.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -157,7 +157,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** Temps de réponse observé (en ms) pour l'API sondée lors de la découverte.
+- **Purpose:** Temps de réponse observé (ms) pour l'API sondée lors de la découverte.
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -169,7 +169,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** Guide de bonnes pratiques sélectionné pour un domaine.
+- **Purpose:** Recommandations de bonnes pratiques pour un domaine.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -181,7 +181,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** Workflows guidés nommés, étape par étape, pour accomplir des tâches courantes dans un domaine.
+- **Purpose:** Workflows nommés, pas à pas, pour accomplir des tâches courantes dans un domaine.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -219,7 +219,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** Ensemble minimal de champs requis pour réussir un POST/PUT de cette ressource.
+- **Purpose:** Ensemble minimal de champs requis pour effectuer avec succès un POST/PUT de cette ressource.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -231,7 +231,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** Fournit les métadonnées de contrainte, de recommandation et de classification de l'espace de noms pour une ressource.
+- **Purpose:** Fournit des métadonnées de contrainte, de recommandation et de classification de namespace pour une ressource.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -243,7 +243,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** Ordre suggéré des propriétés pour la présentation dans l'interface UI/CLI.
+- **Purpose:** Ordre suggéré des propriétés pour la présentation dans l'interface utilisateur/CLI.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -255,7 +255,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** Nom du type de ressource Terraform associé à ce schéma.
+- **Purpose:** Nom du type de ressource Terraform correspondant à ce schéma.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -279,7 +279,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** Navigation dans l'interface console, routage et structure de formulaire pour cette ressource.
+- **Purpose:** Navigation dans la console, routage et structure du formulaire pour cette ressource.
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -293,7 +293,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** Description de propriété enrichie qui complète la `description` amont.
+- **Purpose:** Description de propriété enrichie qui complète la `description` en amont.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -305,7 +305,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** Règles de validation déclaratives dérivées des `ves.io.schema.rules` protobuf amont.
+- **Purpose:** Règles de validation déclaratives dérivées des `ves.io.schema.rules` protobuf en amont.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -317,7 +317,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** Plusieurs exemples de valeurs illustratives pour une propriété.
+- **Purpose:** Plusieurs valeurs d'exemple illustratives pour une propriété.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -353,7 +353,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** Valeur(s) par défaut à afficher dans la documentation générée et les interfaces.
+- **Purpose:** Valeur(s) par défaut à afficher dans la documentation générée et les interfaces utilisateur.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -365,7 +365,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** Liste les opérations HTTP (POST/PUT/...) qui requièrent cette propriété.
+- **Purpose:** Liste les opérations HTTP (POST/PUT/...) qui nécessitent cette propriété.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -377,7 +377,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** Liste les combinaisons de fonctionnalités nommées qui requièrent cette propriété.
+- **Purpose:** Liste les combinaisons de fonctionnalités nommées qui nécessitent cette propriété.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -401,7 +401,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** Avis de dépréciation avec des conseils de remplacement.
+- **Purpose:** Avis de dépréciation avec des conseils sur le remplacement.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -425,7 +425,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** Valeur de production recommandée pour un champ dont la valeur par défaut du serveur est sous-optimale.
+- **Purpose:** Valeur recommandée en production pour un champ dont la valeur par défaut du serveur est sous-optimale.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -449,7 +449,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** Liste les propriétés sœurs qui ne peuvent pas être définies en même temps que celle-ci.
+- **Purpose:** Liste les propriétés frères qui ne peuvent pas être définies conjointement avec celle-ci.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -458,10 +458,34 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** Déclare le type de ressource référencé par un champ ObjectRefType (la ressource vers laquelle il pointe et qui doit exister préalablement), avec gestion des choix oneOf, obligation à la création et cardinalité — la dimension de référence de ressource du modèle de dépendance.
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** Valeurs d'exemple par champ pour la création (map plate champ_path → valeur) dérivées de x-f5xc-minimum-configuration.example_yaml — source unique de valeurs de création déterministes pour la génération de formulaires/workflows en aval.
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** Documente les dépendances inter-champs où un champ en requiert un autre.
+- **Purpose:** Documente les dépendances inter-champs où un champ en requiert un autre d'être défini.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -473,7 +497,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Contraintes numériques / de chaîne dérivées du sondage de l'API en direct ou de patrons statiques.
+- **Purpose:** Contraintes numériques/de chaîne dérivées du sondage de l'API en direct ou de patterns statiques.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -485,7 +509,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** Déclare si un champ doit être unique dans sa portée.
+- **Purpose:** Déclare si un champ doit être unique dans son périmètre.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -497,7 +521,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** Métadonnées du widget de formulaire console pour cette propriété API.
+- **Purpose:** Métadonnées du widget de formulaire de la console pour cette propriété d'API.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -511,7 +535,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** Nomme les champs du corps de l'opération qui doivent être fournis pour réussir.
+- **Purpose:** Nomme les champs du corps d'opération qui doivent être fournis pour qu'elle réussisse.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -523,7 +547,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** Classe le rayon d'action d'une opération (faible/moyen/élevé/critique).
+- **Purpose:** Classifie le rayon d'impact d'une opération (low/medium/high/critical).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -535,7 +559,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Indique si le CLI/UI doit inviter l'utilisateur à confirmer avant l'exécution.
+- **Purpose:** Indique si la CLI/l'interface utilisateur doit demander une confirmation à l'utilisateur avant d'exécuter.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -547,7 +571,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** Liste les effets secondaires observables de l'opération (redémarrage, reconfiguration, etc.).
+- **Purpose:** Liste les effets de bord observables de l'opération (redémarrage, reconfiguration, etc.).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -571,7 +595,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** En-têtes / comportements de limite de débit observés depuis l'API en direct.
+- **Purpose:** En-têtes de limite de débit / comportement observés depuis l'API en direct.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -583,7 +607,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** Catalogue des réponses d'erreur observées lors de la découverte en direct, avec des exemples de charge utile.
+- **Purpose:** Catalogue des réponses d'erreur observées lors de la découverte en direct, avec des exemples de charges utiles.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -597,7 +621,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** Catégorie de regroupement CLI / UI / docs / Terraform de premier niveau pour un domaine.
+- **Purpose:** Catégorie de regroupement de premier niveau pour CLI / interface utilisateur / documentation / Terraform d'un domaine.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -633,7 +657,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** Description courte du domaine (~60 caractères). S'applique également au niveau des propriétés pour les descriptions longues.
+- **Purpose:** Description courte (~60 caractères) du domaine. S'applique également au niveau propriété pour les descriptions longues.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -645,7 +669,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** Description moyenne du domaine (~150 caractères). S'applique également au niveau des propriétés.
+- **Purpose:** Description moyenne (~150 caractères) du domaine. S'applique également au niveau propriété.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -657,7 +681,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** Description longue du domaine (~500 caractères).
+- **Purpose:** Description longue (~500 caractères) du domaine.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -693,7 +717,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** Signale un domaine comme fonctionnalité en aperçu / bêta.
+- **Purpose:** Marque un domaine comme fonctionnalité en aperçu / bêta.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -705,7 +729,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** Cas d'utilisation nommés que ce domaine prend en charge.
+- **Purpose:** Cas d'usage nommés que ce domaine prend en charge.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -717,7 +741,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** Identifiant d'icône à utiliser lors du rendu de ce domaine dans une interface.
+- **Purpose:** Identifiant d'icône à utiliser lors du rendu de ce domaine dans une interface utilisateur.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -729,7 +753,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** SVG intégré (ou chemin) pour un logo de marque représentant le domaine.
+- **Purpose:** SVG inline (ou chemin) pour un logo de marque représentant le domaine.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -741,7 +765,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** Liens croisés vers d'autres domaines couramment utilisés avec celui-ci.
+- **Purpose:** Liens croisés vers d'autres domaines couramment utilisés conjointement avec celui-ci.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -753,7 +777,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** Section de documentation / slug de regroupement de navigation pour les docs rendus.
+- **Purpose:** Slug de section de documentation / regroupement de navigation pour les docs rendus.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -762,12 +786,12 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## Transmises depuis l'amont
+## Transmission en amont
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** Préservé sans modification depuis la spec amont F5.
+- **Purpose:** Préservé à l'identique depuis la spec F5 en amont.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -779,7 +803,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** Préservé sans modification depuis la spec amont F5.
+- **Purpose:** Préservé à l'identique depuis la spec F5 en amont.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -791,7 +815,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** Préservé sans modification depuis la spec amont F5.
+- **Purpose:** Préservé à l'identique depuis la spec F5 en amont.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -803,7 +827,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** Préservé sans modification depuis la spec amont F5.
+- **Purpose:** Préservé à l'identique depuis la spec F5 en amont.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -815,7 +839,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** Préservé sans modification depuis la spec amont F5.
+- **Purpose:** Préservé à l'identique depuis la spec F5 en amont.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -827,7 +851,7 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** Préservé sans modification depuis la spec amont F5.
+- **Purpose:** Préservé à l'identique depuis la spec F5 en amont.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -839,35 +863,35 @@ Chaque entrée ci-dessous possède exactement cette forme. Le test de parité da
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** Préservé sans modification depuis la spec amont F5.
+- **Purpose:** Préservé à l'identique depuis la spec F5 en amont.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** Voir la documentation amont F5.
+- **Example:** Voir la documentation F5 en amont.
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** Préservé sans modification depuis la spec amont F5.
+- **Purpose:** Préservé à l'identique depuis la spec F5 en amont.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** Voir la documentation amont F5.
+- **Example:** Voir la documentation F5 en amont.
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** Préservé sans modification depuis la spec amont F5.
+- **Purpose:** Préservé à l'identique depuis la spec F5 en amont.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** Voir la documentation amont F5.
+- **Example:** Voir la documentation F5 en amont.
 - **Pass-through from upstream:** yes

--- a/docs/hi/extensions/catalog.md
+++ b/docs/hi/extensions/catalog.md
@@ -1,24 +1,24 @@
 ---
 title: संवर्धन एक्सटेंशन कैटलॉग
-description: संवर्धित OpenAPI विनिर्देशों में प्रत्येक x-* एक्सटेंशन का सत्य स्रोत
+description: संवर्धित OpenAPI विनिर्देशों में प्रत्येक x-* एक्सटेंशन का सत्य का स्रोत
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
 # संवर्धन एक्सटेंशन कैटलॉग
 
-`docs/specifications/api/*.json` में प्रकट होने वाले प्रत्येक `x-*` एक्सटेंशन का सत्य स्रोत। `scripts/utils/extension_constants.py` के साथ समानता `tests/test_extension_catalog.py` द्वारा सुनिश्चित की जाती है।
+`docs/specifications/api/*.json` में प्रकट होने वाले प्रत्येक `x-*` एक्सटेंशन का सत्य का स्रोत। `scripts/utils/extension_constants.py` के साथ समानता `tests/test_extension_catalog.py` द्वारा लागू की जाती है।
 
-यहाँ एक्सटेंशन की तीन श्रेणियाँ दस्तावेज़ीकृत हैं:
+यहाँ एक्सटेंशन की तीन श्रेणियाँ प्रलेखित हैं:
 
-- **यहाँ इंजेक्ट किए गए** — वे एक्सटेंशन जो हमारे एनरिचर जोड़ते हैं (`x-f5xc-*` और `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / डिस्कवरी वेरिएंट)। ये वे हैं जिन्हें डाउनस्ट्रीम उपकरणों को उपभोग करना चाहिए।
-- **अपस्ट्रीम पास-थ्रू** — वे एक्सटेंशन जो F5 स्रोत स्पेक्स में उत्सर्जित करता है और हम अपरिवर्तित रखते हैं (`x-ves-proto-*`, `x-displayname`, आदि)। पारदर्शिता के लिए दस्तावेज़ीकृत हैं लेकिन इस रेपो द्वारा नियंत्रित नहीं हैं।
-- **भविष्य में इंजेक्ट किए जाने वाले** — अभी तक उत्सर्जित नहीं हुए; किसी एनरिचर द्वारा उत्पन्न करना शुरू करते ही यहाँ दस्तावेज़ीकृत किए जाएंगे (प्रारंभिक पॉप्युलेशन पर लागू नहीं)।
+- **यहाँ इंजेक्ट किए गए** — एक्सटेंशन जो हमारे एनरिचर जोड़ते हैं (`x-f5xc-*` और `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / डिस्कवरी वेरिएंट)। ये वे हैं जिन्हें डाउनस्ट्रीम उपकरणों को उपभोग करना चाहिए।
+- **अपस्ट्रीम पास-थ्रू** — एक्सटेंशन जो F5 स्रोत स्पेक्स में उत्सर्जित करता है और हम अपरिवर्तित संरक्षित करते हैं (`x-ves-proto-*`, `x-displayname`, आदि)। पारदर्शिता के लिए प्रलेखित लेकिन इस रेपो द्वारा नियंत्रित नहीं।
+- **भविष्य में इंजेक्ट किए जाने वाले** — अभी तक उत्सर्जित नहीं; जिस क्षण कोई एनरिचर उन्हें उत्पन्न करना शुरू करता है उसी समय यहाँ प्रलेखित (प्रारंभिक जनसंख्या पर लागू नहीं)।
 
 ## प्रविष्टि स्कीमा
 
-नीचे दी गई प्रत्येक प्रविष्टि का आकार बिल्कुल यही है। `tests/test_extension_catalog.py` में पैरिटी परीक्षण सेक्शन बॉडी के स्टबी होने को सहन करता है जब तक `### x-name` हेडर मौजूद है और `Pass-through from upstream:` फ़्लैग `yes` या `no` मान के साथ उपस्थित है।
+नीचे प्रत्येक प्रविष्टि का ठीक यही आकार है। `tests/test_extension_catalog.py` में पैरिटी परीक्षण अनुभाग बॉडी के स्टब्बी होने को सहन करता है जब तक `### x-name` हेडर मौजूद हो और `Pass-through from upstream:` फ़्लैग `yes` या `no` मान के साथ उपस्थित हो।
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -31,12 +31,12 @@ i18n:
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## इंजेक्ट किए गए — स्पेक-स्तर (info सेक्शन)
+## इंजेक्ट किए गए — स्पेक-स्तर (info अनुभाग)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** किसी संवर्धित स्पेक के लिए CLI डोमेन स्लग (जैसे `http_loadbalancer`) की पहचान करता है।
+- **Purpose:** संवर्धित स्पेक के लिए CLI डोमेन स्लग (जैसे `http_loadbalancer`) पहचानता है।
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -48,7 +48,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** CLI-व्यापी मेटाडेटा ब्लॉक (टूल नाम, संस्करण संकेत, डोमेन ग्रुपिंग)।
+- **Purpose:** CLI-व्यापी मेटाडेटा ब्लॉक (टूल नाम, संस्करण संकेत, डोमेन समूहन)।
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -84,7 +84,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** पाइपलाइन द्वारा संवर्धित स्पेक पर स्टैम्प किया गया सेमांटिक संस्करण।
+- **Purpose:** पाइपलाइन द्वारा संवर्धित स्पेक पर अंकित सेमेंटिक संस्करण।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -108,7 +108,7 @@ i18n:
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** वह टाइमस्टैम्प जब लाइव-API डिस्कवरी पास निष्पादित हुई।
+- **Purpose:** टाइमस्टैम्प जब लाइव-API डिस्कवरी पास निष्पादित किया गया था।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -120,7 +120,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** उस लाइव API का बेस URL जिसे डिस्कवरी के दौरान प्रोब किया गया था।
+- **Purpose:** लाइव API का बेस URL जिसे डिस्कवरी के दौरान प्रोब किया गया था।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -132,7 +132,7 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** इस डोमेन के लिए होस्ट किए गए API संदर्भ दस्तावेज़ पृष्ठ का URL।
+- **Purpose:** इस डोमेन के लिए होस्ट किए गए API संदर्भ दस्तावेज़ीकरण पृष्ठ का URL।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -144,7 +144,7 @@ i18n:
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** डिस्कवरी के दौरान प्रोब की गई API के लिए अवलोकित प्रतिक्रिया समय (ms)।
+- **Purpose:** डिस्कवरी के दौरान प्रोब किए गए API के लिए अवलोकित प्रतिक्रिया समय (ms)।
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -180,7 +180,7 @@ i18n:
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** प्रति-डोमेन संक्षेपाक्षर विस्तार तालिका।
+- **Purpose:** प्रति-डोमेन संक्षिप्त नाम विस्तार तालिका।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -206,7 +206,7 @@ i18n:
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** इस संसाधन को सफलतापूर्वक POST/PUT करने के लिए आवश्यक न्यूनतम व्यावहारिक फ़ील्ड सेट।
+- **Purpose:** इस संसाधन को सफलतापूर्वक POST/PUT करने के लिए आवश्यक न्यूनतम व्यवहार्य फ़ील्ड सेट।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -230,7 +230,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** UI/CLI प्रस्तुति के लिए प्रॉपर्टीज़ का सुझाया गया क्रम।
+- **Purpose:** UI/CLI प्रस्तुति के लिए गुणों का सुझावित क्रम।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -254,7 +254,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** किसी संसाधन स्कीमा के लिए मानव-पठनीय प्रदर्शन नाम (ऑटो-जनरेशन को ओवरराइड करता है)।
+- **Purpose:** संसाधन स्कीमा के लिए मानव-पठनीय प्रदर्शन नाम (ऑटो-जनरेशन को ओवरराइड करता है)।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -266,7 +266,7 @@ i18n:
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** इस संसाधन के लिए कंसोल UI नेविगेशन, रूटिंग और फ़ॉर्म संरचना।
+- **Purpose:** इस संसाधन के लिए कंसोल UI नेविगेशन, रूटिंग और फॉर्म संरचना।
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -280,7 +280,7 @@ i18n:
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** संवर्धित प्रॉपर्टी विवरण जो अपस्ट्रीम `description` को पूरक बनाता है।
+- **Purpose:** संवर्धित प्रॉपर्टी विवरण जो अपस्ट्रीम `description` को पूरक करता है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -292,7 +292,7 @@ i18n:
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** अपस्ट्रीम protobuf `ves.io.schema.rules` से प्राप्त घोषणात्मक सत्यापन नियम।
+- **Purpose:** अपस्ट्रीम protobuf `ves.io.schema.rules` से व्युत्पन्न घोषणात्मक सत्यापन नियम।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -304,7 +304,7 @@ i18n:
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** किसी प्रॉपर्टी के लिए कई दृष्टांत उदाहरण मान।
+- **Purpose:** किसी प्रॉपर्टी के लिए अनेक उदाहरण मान।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -316,7 +316,7 @@ i18n:
 ### x-f5xc-example
 
 - **Applied at:** schema property
-- **Purpose:** एक एकल प्रामाणिक उदाहरण मान।
+- **Purpose:** एकल विहित उदाहरण मान।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -328,7 +328,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** शेल कम्प्लीशन संकेत (स्टैटिक enum या डायनामिक कमांड)।
+- **Purpose:** शेल कम्पलीशन संकेत (स्टैटिक enum या डायनेमिक कमांड)।
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -340,7 +340,7 @@ i18n:
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** जनरेटेड डॉक्स और UI में प्रदर्शित करने के लिए डिफ़ॉल्ट मान।
+- **Purpose:** जेनरेट किए गए दस्तावेज़ों और UI में प्रदर्शित करने के लिए डिफ़ॉल्ट मान।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -376,7 +376,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** सशर्त आवश्यकताएँ (जैसे जब सिब्लिंग फ़ील्ड X के बराबर हो तो आवश्यक)।
+- **Purpose:** सशर्त आवश्यकताएँ (जैसे जब सिब्लिंग फ़ील्ड X के बराबर हो तब आवश्यक)।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -388,7 +388,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** प्रतिस्थापन मार्गदर्शन के साथ अवमूल्यन सूचना।
+- **Purpose:** प्रतिस्थापन मार्गदर्शन के साथ अवमूल्यन नोटिस।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -400,7 +400,7 @@ i18n:
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** वह डिफ़ॉल्ट मान जो सर्वर तब असाइन करता है जब क्लाइंट प्रॉपर्टी को छोड़ देता है।
+- **Purpose:** डिफ़ॉल्ट मान जो सर्वर तब असाइन करता है जब क्लाइंट प्रॉपर्टी छोड़ देता है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -412,7 +412,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** किसी फ़ील्ड के लिए अनुशंसित उत्पादन मान जहाँ सर्वर डिफ़ॉल्ट इष्टतम नहीं है।
+- **Purpose:** किसी फ़ील्ड के लिए अनुशंसित उत्पादन मान जहाँ सर्वर डिफ़ॉल्ट उप-इष्टतम है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -436,7 +436,7 @@ i18n:
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** उन सिब्लिंग प्रॉपर्टीज़ को सूचीबद्ध करता है जो इसके साथ-साथ सेट नहीं की जा सकतीं।
+- **Purpose:** सिब्लिंग प्रॉपर्टीज़ सूचीबद्ध करता है जिन्हें इसके साथ सेट नहीं किया जा सकता।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -445,10 +445,34 @@ i18n:
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** ObjectRefType फ़ील्ड के संदर्भित संसाधन-प्रकार (वह संसाधन जिसे यह इंगित करता है, जो पहले अस्तित्व में होना चाहिए) को घोषित करता है, oneOf चॉइस-गेटिंग, required-for-create, और कार्डिनैलिटी के साथ — निर्भरता मॉडल का संसाधन-संदर्भ आयाम।
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** प्रति-फ़ील्ड क्रिएट उदाहरण मान (फ्लैट field_path से value मैप) जो x-f5xc-minimum-configuration.example_yaml से व्युत्पन्न हैं — डाउनस्ट्रीम फॉर्म/वर्कफ़्लो जनरेशन के लिए निर्धारक क्रिएट मानों का एकल सत्य स्रोत।
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** क्रॉस-फ़ील्ड निर्भरताएँ दस्तावेज़ीकृत करता है जहाँ एक फ़ील्ड को दूसरे का सेट होना आवश्यक है।
+- **Purpose:** क्रॉस-फ़ील्ड निर्भरताओं को प्रलेखित करता है जहाँ एक फ़ील्ड को दूसरे को सेट करने की आवश्यकता होती है।
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -460,7 +484,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** लाइव-API प्रोबिंग या स्टैटिक पैटर्न से प्राप्त न्यूमेरिक / स्ट्रिंग बाधाएँ।
+- **Purpose:** लाइव-API प्रोबिंग या स्टैटिक पैटर्न से व्युत्पन्न संख्यात्मक/स्ट्रिंग बाधाएँ।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -472,7 +496,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** घोषित करता है कि कोई फ़ील्ड अपने स्कोप के भीतर अद्वितीय होनी चाहिए या नहीं।
+- **Purpose:** घोषित करता है कि कोई फ़ील्ड अपने दायरे में अद्वितीय होनी चाहिए या नहीं।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -484,7 +508,7 @@ i18n:
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** इस API प्रॉपर्टी के लिए कंसोल फ़ॉर्म विजेट मेटाडेटा।
+- **Purpose:** इस API प्रॉपर्टी के लिए कंसोल फॉर्म विजेट मेटाडेटा।
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -498,7 +522,7 @@ i18n:
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** ऑपरेशन-बॉडी फ़ील्ड्स के नाम देता है जो सफलता के लिए प्रदान किए जाने चाहिए।
+- **Purpose:** ऑपरेशन-बॉडी फ़ील्ड नाम देता है जो सफलता के लिए प्रदान किए जाने चाहिए।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -522,7 +546,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** क्या CLI/UI को निष्पादन से पहले उपयोगकर्ता से पुष्टि के लिए संकेत देना चाहिए।
+- **Purpose:** क्या CLI/UI को निष्पादित करने से पहले उपयोगकर्ता से पुष्टि के लिए प्रॉम्प्ट करना चाहिए।
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -534,7 +558,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** ऑपरेशन के अवलोकन योग्य साइड इफेक्ट्स सूचीबद्ध करता है (restart, reconfigure, आदि)।
+- **Purpose:** ऑपरेशन के अवलोकनीय दुष्प्रभावों (restart, reconfigure, आदि) को सूचीबद्ध करता है।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -558,7 +582,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** लाइव API से पता लगाए गए अवलोकित रेट-लिमिट हेडर / व्यवहार।
+- **Purpose:** लाइव API से सर्फेस किए गए अवलोकित रेट-लिमिट हेडर/व्यवहार।
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -570,7 +594,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** लाइव डिस्कवरी के दौरान अवलोकित त्रुटि प्रतिक्रियाओं का कैटलॉग, सैंपल पेलोड के साथ।
+- **Purpose:** लाइव डिस्कवरी के दौरान अवलोकित त्रुटि प्रतिक्रियाओं की कैटलॉग, नमूना पेलोड के साथ।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -579,12 +603,12 @@ i18n:
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## इंजेक्ट किए गए — इंडेक्स-स्तर (डोमेन मेटाडेटा)
+## इंजेक्ट किए गए — इंडेक्स-स्तर (domain metadata)
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** किसी डोमेन के लिए शीर्ष-स्तरीय CLI / UI / docs / Terraform ग्रुपिंग श्रेणी।
+- **Purpose:** किसी डोमेन के लिए शीर्ष-स्तरीय CLI / UI / docs / Terraform समूहन श्रेणी।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -596,7 +620,7 @@ i18n:
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** प्राथमिक संसाधन प्रकारों की सूची जो डोमेन को परिभाषित करती है।
+- **Purpose:** प्राथमिक संसाधन प्रकारों की सूची जो डोमेन को परिभाषित करते हैं।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -608,7 +632,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** वे संसाधन जिनके लिए ऊँचा ध्यान आवश्यक है (उत्पादन-महत्वपूर्ण)।
+- **Purpose:** संसाधन जिनके लिए उन्नत देखभाल आवश्यक है (उत्पादन-महत्वपूर्ण)।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -620,7 +644,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** संक्षिप्त (~60 अक्षर) डोमेन विवरण। लंबे विवरणों के लिए प्रॉपर्टी स्तर पर भी लागू होता है।
+- **Purpose:** संक्षिप्त (~60 वर्ण) डोमेन विवरण। लंबे विवरणों के लिए प्रॉपर्टी स्तर पर भी लागू होता है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -632,7 +656,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** मध्यम (~150 अक्षर) डोमेन विवरण। प्रॉपर्टी स्तर पर भी लागू होता है।
+- **Purpose:** मध्यम (~150 वर्ण) डोमेन विवरण। प्रॉपर्टी स्तर पर भी लागू होता है।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -644,7 +668,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** लंबा (~500 अक्षर) डोमेन विवरण।
+- **Purpose:** लंबा (~500 वर्ण) डोमेन विवरण।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -656,7 +680,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** इस डोमेन में कॉन्फ़िगरेशन लेखन के लिए सापेक्ष जटिलता स्तर।
+- **Purpose:** इस डोमेन में कॉन्फ़िगरेशन लिखने की सापेक्ष जटिलता स्तर।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -668,7 +692,7 @@ i18n:
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** न्यूनतम F5 XC सदस्यता स्तर आवश्यक।
+- **Purpose:** आवश्यक न्यूनतम F5 XC सदस्यता स्तर।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -680,7 +704,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** किसी डोमेन को प्रीव्यू / बीटा फ़ीचर के रूप में चिह्नित करता है।
+- **Purpose:** किसी डोमेन को प्रीव्यू/बीटा फ़ीचर के रूप में चिह्नित करता है।
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -692,7 +716,7 @@ i18n:
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** नामित उपयोग-मामले जो इस डोमेन का समर्थन करते हैं।
+- **Purpose:** नामित उपयोग मामले जो यह डोमेन समर्थन करता है।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -704,7 +728,7 @@ i18n:
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** UI में इस डोमेन को रेंडर करते समय उपयोग किया जाने वाला आइकन आइडेंटिफ़ायर।
+- **Purpose:** UI में इस डोमेन को रेंडर करते समय उपयोग करने के लिए आइकन पहचानकर्ता।
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -716,7 +740,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** डोमेन का प्रतिनिधित्व करने वाले ब्रांड लोगो के लिए इनलाइन SVG (या पाथ)।
+- **Purpose:** डोमेन का प्रतिनिधित्व करने वाले ब्रांड लोगो के लिए इनलाइन SVG (या पथ)।
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -728,7 +752,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** अन्य डोमेन के क्रॉस-लिंक जो आमतौर पर इसके साथ उपयोग किए जाते हैं।
+- **Purpose:** अन्य डोमेन के साथ क्रॉस-लिंक जो आमतौर पर इसके साथ उपयोग किए जाते हैं।
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -740,7 +764,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** रेंडर किए गए दस्तावेज़ों के लिए दस्तावेज़ीकरण सेक्शन / नेव ग्रुपिंग स्लग।
+- **Purpose:** रेंडर किए गए दस्तावेज़ों के लिए दस्तावेज़ीकरण अनुभाग / nav समूहन स्लग।
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`

--- a/docs/it/extensions/catalog.md
+++ b/docs/it/extensions/catalog.md
@@ -1,53 +1,55 @@
 ---
 title: Catalogo delle estensioni di arricchimento
-description: Fonte di verità per ogni estensione x-* nelle specifiche OpenAPI arricchite
+description: >-
+  Fonte di riferimento autorevole per ogni estensione x-* nelle specifiche
+  OpenAPI arricchite
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
 # Catalogo delle estensioni di arricchimento
 
-Fonte di verità per ogni estensione `x-*` che compare in
+Fonte di riferimento autorevole per ogni estensione `x-*` presente in
 `docs/specifications/api/*.json`. La parità con
 `scripts/utils/extension_constants.py` è verificata da
 `tests/test_extension_catalog.py`.
 
-Sono documentate qui tre classi di estensioni:
+Sono documentate tre classi di estensioni:
 
 - **Iniettate qui** — estensioni aggiunte dai nostri arricchitori (`x-f5xc-*` e
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / varianti di
-  discovery). Queste sono quelle che gli strumenti downstream dovrebbero consumare.
+  discovery). Queste sono quelle che gli strumenti downstream devono consumare.
 - **Pass-through upstream** — estensioni emesse da F5 nelle specifiche sorgente
-  e da noi preservate invariate (`x-ves-proto-*`, `x-displayname`, ecc.).
-  Documentate per trasparenza, ma non controllate da questo repository.
-- **Iniettate in futuro** — non ancora emesse; documentate qui nel momento in cui
+  e preservate invariate (`x-ves-proto-*`, `x-displayname`, ecc.).
+  Documentate per trasparenza ma non controllate da questo repository.
+- **Iniettate in futuro** — non ancora emesse; documentate nel momento in cui
   un arricchitore inizia a produrle (non applicabile alla popolazione iniziale).
 
-## Schema delle voci
+## Schema di ogni voce
 
-Ogni voce qui sotto ha esattamente questa forma. Il test di parità in
+Ogni voce sottostante ha esattamente questa forma. Il test di parità in
 `tests/test_extension_catalog.py` tollera che il corpo della sezione sia
-sintetico, purché l'intestazione `### x-name` esista e il flag
+ridotto purché l'intestazione `### x-name` esista e il flag
 `Pass-through from upstream:` sia presente con valore `yes` o `no`.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
-    - **Purpose:** <one sentence>
+    - **Purpose:** <una frase>
     - **Consumers:** <CLI | VSCode | Terraform | Web UI | multiple | N/A>
     - **Value type:** <string | number | boolean | object | array>
-    - **Value schema:** <JSON Schema snippet, or N/A>
-    - **Injected by:** <scripts/utils/<enricher>.py, or "upstream">
-    - **Driven by config:** <config/<file>.yaml, or "hardcoded", or "upstream">
-    - **Example:** <short snippet>
+    - **Value schema:** <frammento JSON Schema, oppure N/A>
+    - **Injected by:** <scripts/utils/<enricher>.py, oppure "upstream">
+    - **Driven by config:** <config/<file>.yaml, oppure "hardcoded", oppure "upstream">
+    - **Example:** <breve frammento>
     - **Pass-through from upstream:** <yes/no>
 
-## Iniettate — livello di specifica (sezione info)
+## Iniettate — livello spec (sezione info)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** Identifica lo slug del dominio CLI (es. `http_loadbalancer`) per una specifica arricchita.
+- **Purpose:** Identifica lo slug del dominio CLI (es. `http_loadbalancer`) per una spec arricchita.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -59,7 +61,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** Blocco di metadati CLI globali (nome strumento, suggerimenti di versione, raggruppamento del dominio).
+- **Purpose:** Blocco di metadati globali CLI (nome strumento, suggerimenti di versione, raggruppamento dominio).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -71,7 +73,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** Timestamp della specifica sorgente upstream da cui è stato costruito il file arricchito.
+- **Purpose:** Timestamp della spec sorgente upstream da cui è stato costruito il file arricchito.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -83,7 +85,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag dell'asset di rilascio della specifica sorgente upstream.
+- **Purpose:** ETag dell'asset di rilascio della spec sorgente upstream.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -95,7 +97,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** Versione semantica applicata alla specifica arricchita dalla pipeline.
+- **Purpose:** Versione semantica applicata alla spec arricchita dalla pipeline.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -107,7 +109,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** Blocco di glossario branding/terminologia applicato a ogni specifica di dominio.
+- **Purpose:** Blocco glossario di branding/terminologia applicato a ogni spec di dominio.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -119,7 +121,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** Timestamp di quando è stata eseguita la fase di discovery dell'API live.
+- **Purpose:** Timestamp di quando è stato eseguito il passaggio di discovery sull'API live.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -131,7 +133,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** URL base dell'API live sottoposta a probe durante la discovery.
+- **Purpose:** URL base dell'API live esaminata durante la discovery.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -143,19 +145,19 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL alla pagina della documentazione di riferimento API ospitata per questo dominio.
+- **Purpose:** URL della pagina di documentazione di riferimento API ospitata per questo dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
 - **Injected by:** scripts/utils/external_docs_enricher.py
-- **Driven by config:** none (derived from domain name)
+- **Driven by config:** none (derivato dal nome del dominio)
 - **Example:** `"x-f5xc-api-reference-url": "https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/"`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** Tempo di risposta osservato (ms) per l'API sottoposta a probe durante la discovery.
+- **Purpose:** Tempo di risposta osservato (ms) per l'API esaminata durante la discovery.
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -167,7 +169,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** Guida curata alle best practice per un dominio.
+- **Purpose:** Linee guida curate sulle best practice per un dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -179,7 +181,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** Flussi di lavoro guidati passo-passo per svolgere attività comuni in un dominio.
+- **Purpose:** Flussi di lavoro guidati passo dopo passo per completare attività comuni in un dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -212,12 +214,12 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 - **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
 - **Pass-through from upstream:** no
 
-## Iniettate — livello di schema (schemi dei componenti)
+## Iniettate — livello schema (schemi dei componenti)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** Set minimo di campi necessari per eseguire con successo un POST/PUT di questa risorsa.
+- **Purpose:** Insieme minimo di campi necessari per eseguire con successo un POST/PUT di questa risorsa.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -229,7 +231,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** Fornisce metadati di vincolo del namespace, raccomandazione e classificazione per una risorsa.
+- **Purpose:** Fornisce metadati di vincolo, raccomandazione e classificazione del namespace per una risorsa.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -241,7 +243,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** Ordinamento suggerito delle proprietà per la presentazione in UI/CLI.
+- **Purpose:** Ordinamento suggerito delle proprietà per la presentazione nell'interfaccia utente/CLI.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -253,7 +255,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** Nome del tipo di risorsa Terraform che mappa a questo schema.
+- **Purpose:** Nome del tipo di risorsa Terraform che corrisponde a questo schema.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -265,7 +267,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** Nome visualizzato leggibile dall'utente per uno schema di risorsa (sovrascrive la generazione automatica).
+- **Purpose:** Nome visualizzato leggibile dall'utente per uno schema di risorsa (sostituisce la generazione automatica).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -277,7 +279,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** Navigazione UI della console, routing e struttura del form per questa risorsa.
+- **Purpose:** Navigazione dell'interfaccia utente della console, routing e struttura del modulo per questa risorsa.
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -286,12 +288,12 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 - **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
 - **Pass-through from upstream:** no
 
-## Iniettate — livello di proprietà
+## Iniettate — livello proprietà
 
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** Descrizione della proprietà arricchita che integra la `description` upstream.
+- **Purpose:** Descrizione arricchita della proprietà che integra la `description` upstream.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -351,7 +353,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** Valore/i predefinito/i da mostrare nella documentazione generata e nelle UI.
+- **Purpose:** Valore/i predefinito/i da esporre nella documentazione generata e nelle interfacce utente.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -375,7 +377,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** Elenca le combinazioni di funzionalità nominate che richiedono questa proprietà.
+- **Purpose:** Elenca le combinazioni di funzionalità con nome che richiedono questa proprietà.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -387,7 +389,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** Requisiti condizionali (es. richiesto quando il campo fratello è uguale a X).
+- **Purpose:** Requisiti condizionali (es. obbligatorio quando un campo fratello è uguale a X).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -399,7 +401,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** Avviso di deprecazione con indicazioni sulla sostituzione.
+- **Purpose:** Avviso di deprecazione con indicazioni sul campo sostitutivo.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -411,7 +413,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** Valore predefinito assegnato dal server quando il client omette la proprietà.
+- **Purpose:** Valore predefinito che il server assegna quando il client omette la proprietà.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -423,7 +425,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** Valore di produzione raccomandato per un campo dove il valore predefinito del server è subottimale.
+- **Purpose:** Valore di produzione raccomandato per un campo in cui il valore predefinito del server non è ottimale.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -447,7 +449,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** Elenca le proprietà fratello che non possono essere impostate insieme a questa.
+- **Purpose:** Elenca le proprietà sorelle che non possono essere impostate insieme a questa.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -456,22 +458,46 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** Dichiara il tipo di risorsa referenziata da un campo ObjectRefType (la risorsa a cui punta, che deve esistere preventivamente), con selezione della scelta oneOf, obbligatorietà alla creazione e cardinalità — la dimensione di riferimento alle risorse del modello di dipendenza.
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** Valori di esempio per campo alla creazione (mappa piatta field_path → valore) derivati da x-f5xc-minimum-configuration.example_yaml — l'unica fonte deterministica di valori di creazione per la generazione di moduli/flussi di lavoro downstream.
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derivato da x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** Documenta le dipendenze tra campi in cui un campo ne richiede un altro impostato.
+- **Purpose:** Documenta le dipendenze tra campi in cui un campo richiede che un altro sia impostato.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
 - **Injected by:** scripts/utils/dependency_enricher.py
-- **Driven by config:** config/minimum_configs.yaml (dependencies section)
+- **Driven by config:** config/minimum_configs.yaml (sezione dependencies)
 - **Example:** `"x-f5xc-requires": [{"field": "tls_config", "required": true, "reason": "use_tls requires tls_config sub-field"}]`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Vincoli numerici/stringa derivati dalla probing dell'API live o da pattern statici.
+- **Purpose:** Vincoli numerici/stringa derivati dall'analisi dell'API live o da pattern statici.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -483,7 +509,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** Dichiara se un campo deve essere univoco all'interno del proprio scope.
+- **Purpose:** Dichiara se un campo deve essere univoco nel proprio ambito.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -495,7 +521,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** Metadati del widget del form della console per questa proprietà API.
+- **Purpose:** Metadati del widget del modulo console per questa proprietà API.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -504,12 +530,12 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 - **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
 - **Pass-through from upstream:** no
 
-## Iniettate — livello di operazione
+## Iniettate — livello operazione
 
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** Denomina i campi del corpo dell'operazione che devono essere forniti per il successo.
+- **Purpose:** Indica i campi del corpo dell'operazione che devono essere forniti per il successo.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -521,7 +547,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** Classifica il raggio di impatto di un'operazione (low/medium/high/critical).
+- **Purpose:** Classifica il raggio d'azione di un'operazione (low/medium/high/critical).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -533,7 +559,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Indica se CLI/UI deve richiedere all'utente di confermare prima dell'esecuzione.
+- **Purpose:** Indica se CLI/UI deve richiedere all'utente una conferma prima dell'esecuzione.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -569,7 +595,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** Header di rate-limit / comportamento osservati esposti dall'API live.
+- **Purpose:** Header di rate limit osservati / comportamento rilevato dall'API live.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -607,7 +633,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** Elenco dei tipi di risorse primarie che definiscono il dominio.
+- **Purpose:** Elenco dei tipi di risorsa primari che definiscono il dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -619,7 +645,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** Risorse che richiedono maggiore attenzione (critiche in produzione).
+- **Purpose:** Risorse che richiedono particolare attenzione (critiche in produzione).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -667,7 +693,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** Livello di complessità relativa per la creazione di configurazioni in questo dominio.
+- **Purpose:** Livello di complessità relativo per la creazione di configurazioni in questo dominio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -703,7 +729,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** Casi d'uso nominati supportati da questo dominio.
+- **Purpose:** Casi d'uso con nome supportati da questo dominio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -715,7 +741,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** Identificatore dell'icona da utilizzare per il rendering di questo dominio nell'UI.
+- **Purpose:** Identificatore dell'icona da utilizzare per il rendering di questo dominio nell'interfaccia utente.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -739,7 +765,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** Collegamenti incrociati ad altri domini comunemente utilizzati insieme a questo.
+- **Purpose:** Riferimenti incrociati ad altri domini comunemente utilizzati insieme a questo.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -751,7 +777,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** Slug della sezione della documentazione / raggruppamento di navigazione per la documentazione renderizzata.
+- **Purpose:** Sezione della documentazione / slug di raggruppamento di navigazione per la documentazione renderizzata.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -765,7 +791,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla specifica upstream F5.
+- **Purpose:** Preservato invariato dalla spec upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -777,7 +803,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla specifica upstream F5.
+- **Purpose:** Preservato invariato dalla spec upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -789,7 +815,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla specifica upstream F5.
+- **Purpose:** Preservato invariato dalla spec upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -801,7 +827,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla specifica upstream F5.
+- **Purpose:** Preservato invariato dalla spec upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -813,7 +839,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla specifica upstream F5.
+- **Purpose:** Preservato invariato dalla spec upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -825,7 +851,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla specifica upstream F5.
+- **Purpose:** Preservato invariato dalla spec upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -837,7 +863,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla specifica upstream F5.
+- **Purpose:** Preservato invariato dalla spec upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -849,7 +875,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla specifica upstream F5.
+- **Purpose:** Preservato invariato dalla spec upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -861,7 +887,7 @@ sintetico, purché l'intestazione `### x-name` esista e il flag
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** Preservato invariato dalla specifica upstream F5.
+- **Purpose:** Preservato invariato dalla spec upstream F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A

--- a/docs/ja/extensions/catalog.md
+++ b/docs/ja/extensions/catalog.md
@@ -1,24 +1,26 @@
 ---
-title: エンリッチメント拡張カタログ
-description: 拡充 OpenAPI 仕様における全 x-* 拡張の信頼できる情報源
+title: エンリッチメント拡張機能カタログ
+description: エンリッチされた OpenAPI 仕様に含まれるすべての x-* 拡張機能の信頼できる情報源
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
-# エンリッチメント拡張カタログ
+# エンリッチメント拡張機能カタログ
 
-`docs/specifications/api/*.json` に記載されているすべての `x-*` 拡張の信頼できる情報源です。`scripts/utils/extension_constants.py` との整合性は `tests/test_extension_catalog.py` によって保証されています。
+`docs/specifications/api/*.json` に含まれるすべての `x-*` 拡張機能の信頼できる情報源です。`scripts/utils/extension_constants.py` との整合性は `tests/test_extension_catalog.py` によって強制されます。
 
-ここでは3種類の拡張を文書化しています：
+ここでは 3 種類の拡張機能を文書化しています：
 
-- **ここで注入** — エンリッチャーが追加する拡張（`x-f5xc-*` および `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / ディスカバリーバリアント）。これらはダウンストリームツールが利用するものです。
-- **上流パススルー** — F5 がソース仕様で出力し、変更せず保持する拡張（`x-ves-proto-*`、`x-displayname` 等）。透明性のために文書化していますが、このリポジトリでは管理していません。
-- **将来注入** — まだ出力されていないもの。エンリッチャーが生成を開始した時点でここに文書化します（初回作成時は該当なし）。
+- **ここで注入済み** — エンリッチャーが追加する拡張機能 (`x-f5xc-*` および
+  `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / ディスカバリー
+  バリアント)。これらがダウンストリームツールが使用すべきものです。
+- **アップストリームパススルー** — F5 がソース仕様に出力し、変更なしで保持する拡張機能 (`x-ves-proto-*`、`x-displayname` など)。透明性のために文書化されていますが、このリポジトリでは制御されません。
+- **将来注入予定** — まだ出力されていません。エンリッチャーが生成を開始した時点でここに文書化されます (初期設定時は該当なし)。
 
 ## エントリースキーマ
 
-以下の各エントリーは正確にこの形式に従います。`tests/test_extension_catalog.py` のパリティテストは、`### x-name` ヘッダーが存在し、`Pass-through from upstream:` フラグが `yes` または `no` の値で存在していれば、セクション本文が簡略であっても許容します。
+以下のすべてのエントリーはこの形式に従います。`tests/test_extension_catalog.py` のパリティテストは、`### x-name` ヘッダーが存在し、`Pass-through from upstream:` フラグに `yes` または `no` の値がある限り、セクション本文が簡略化されていても許容します。
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -31,12 +33,12 @@ i18n:
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## 注入済み — 仕様レベル（info セクション）
+## 注入済み — スペックレベル (info セクション)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** エンリッチされた仕様の CLI ドメインスラッグ（例：`http_loadbalancer`）を識別します。
+- **Purpose:** エンリッチされたスペックの CLI ドメインスラッグ (例: `http_loadbalancer`) を識別します。
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -48,7 +50,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** CLI 全体のメタデータブロック（ツール名、バージョンヒント、ドメイングループ）。
+- **Purpose:** CLI 全体のメタデータブロック (ツール名、バージョンヒント、ドメイングループ)。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -60,7 +62,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** エンリッチされたファイルのビルド元となった上流ソース仕様のタイムスタンプ。
+- **Purpose:** エンリッチされたファイルのビルド元となったアップストリームソーススペックのタイムスタンプ。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -72,7 +74,7 @@ i18n:
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** 上流ソース仕様リリースアセットの ETag。
+- **Purpose:** アップストリームソーススペックのリリースアセットの ETag。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -84,7 +86,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** パイプラインによってエンリッチされた仕様に付与されるセマンティックバージョン。
+- **Purpose:** パイプラインによってエンリッチされたスペックに刻印されるセマンティックバージョン。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -96,7 +98,7 @@ i18n:
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** 各ドメイン仕様に適用されるブランディング／用語集ブロック。
+- **Purpose:** 各ドメインスペックに適用されるブランディング/用語集ブロック。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -132,7 +134,7 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** このドメインのホストされた API リファレンスドキュメントページへの URL。
+- **Purpose:** このドメインのホストされた API リファレンスドキュメントページの URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -144,7 +146,7 @@ i18n:
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** ディスカバリー中にプローブされた API の観測応答時間（ミリ秒）。
+- **Purpose:** ディスカバリー中にプローブされた API の観測応答時間 (ms)。
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -156,7 +158,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** ドメインに対してキュレーションされたベストプラクティスガイダンス。
+- **Purpose:** ドメインのキュレーションされたベストプラクティスガイダンス。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -168,7 +170,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** ドメイン内の一般的なタスクを達成するための名前付きステップバイステップワークフロー。
+- **Purpose:** ドメインの一般的なタスクを実行するための名前付きステップバイステップワークフロー。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -192,7 +194,7 @@ i18n:
 ### x-f5xc-console-navigation
 
 - **Applied at:** spec info
-- **Purpose:** グローバルコンソールナビゲーションツリー — ワークスペースおよびメニュー階層。
+- **Purpose:** グローバルコンソールナビゲーションツリー — ワークスペースとメニー階層。
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
@@ -201,12 +203,12 @@ i18n:
 - **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
 - **Pass-through from upstream:** no
 
-## 注入済み — スキーマレベル（コンポーネントスキーマ）
+## 注入済み — スキーマレベル (コンポーネントスキーマ)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** このリソースの POST/PUT を正常に行うために必要な最小限のフィールドセット。
+- **Purpose:** このリソースへの POST/PUT を成功させるために必要な最小限のフィールドセット。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -230,7 +232,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** UI/CLI 表示のためのプロパティ推奨順序。
+- **Purpose:** UI/CLI プレゼンテーションのためのプロパティの推奨順序。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -254,7 +256,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** リソーススキーマの人間が読める表示名（自動生成を上書き）。
+- **Purpose:** リソーススキーマの人間が読めるディスプレイ名 (自動生成を上書き)。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -266,7 +268,7 @@ i18n:
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** このリソースのコンソール UI ナビゲーション、ルーティング、およびフォーム構造。
+- **Purpose:** このリソースのコンソール UI ナビゲーション、ルーティング、フォーム構造。
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -280,7 +282,7 @@ i18n:
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** 上流の `description` を補完するエンリッチされたプロパティ説明。
+- **Purpose:** アップストリームの `description` を補完するエンリッチされたプロパティ説明。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -292,7 +294,7 @@ i18n:
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** 上流の protobuf `ves.io.schema.rules` から派生した宣言的バリデーションルール。
+- **Purpose:** アップストリームの protobuf `ves.io.schema.rules` から派生した宣言的バリデーションルール。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -304,7 +306,7 @@ i18n:
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** プロパティの複数の例示値。
+- **Purpose:** プロパティの複数の説明用サンプル値。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -316,7 +318,7 @@ i18n:
 ### x-f5xc-example
 
 - **Applied at:** schema property
-- **Purpose:** 単一の標準的な例示値。
+- **Purpose:** 単一の標準的なサンプル値。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -328,7 +330,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** シェル補完のヒント（静的な enum または動的コマンド）。
+- **Purpose:** シェル補完ヒント (静的列挙または動的コマンド)。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -352,7 +354,7 @@ i18n:
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** このプロパティを必要とする HTTP 操作（POST/PUT/...）の一覧。
+- **Purpose:** このプロパティを必要とする HTTP オペレーション (POST/PUT/...) をリストします。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -364,7 +366,7 @@ i18n:
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** このプロパティを必要とする名前付き機能の組み合わせの一覧。
+- **Purpose:** このプロパティを必要とする名前付きフィーチャーの組み合わせをリストします。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -376,7 +378,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** 条件付き要件（例：兄弟フィールドが X と等しい場合に必須）。
+- **Purpose:** 条件付き要件 (例: 兄弟フィールドが X に等しい場合に必須)。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -388,7 +390,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** 置き換えガイダンス付きの廃止予定通知。
+- **Purpose:** 置き換えガイダンスを含む非推奨通知。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -412,7 +414,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** サーバーのデフォルトが最適でない場合のフィールドの推奨本番値。
+- **Purpose:** サーバーデフォルトが最適でないフィールドの推奨本番環境値。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -424,7 +426,7 @@ i18n:
 ### x-f5xc-recommended-oneof-variant
 
 - **Applied at:** schema property
-- **Purpose:** `oneOf` ブロックにおいて、推奨されるバリアントを示します。
+- **Purpose:** `oneOf` ブロックについて、推奨されるバリアントを示します。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -436,13 +438,37 @@ i18n:
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** このプロパティと同時に設定できない兄弟プロパティの一覧。
+- **Purpose:** このプロパティと同時に設定できない兄弟プロパティをリストします。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
 - **Injected by:** scripts/utils/conflicts_with_enricher.py
 - **Driven by config:** hardcoded
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** ObjectRefType フィールドが参照するリソースカインド (先に存在している必要があるリソース) を、oneOf 選択ゲーティング、作成時必須、カーディナリティとともに宣言します — 依存モデルのリソース参照ディメンション。
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** x-f5xc-minimum-configuration.example_yaml から派生したフィールドごとの作成サンプル値 (フラットなフィールドパスから値へのマップ) — ダウンストリームのフォーム/ワークフロー生成のための決定論的な作成値の単一ソース。
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-requires
@@ -460,7 +486,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** ライブ API プローブまたは静的パターンから派生した数値／文字列制約。
+- **Purpose:** ライブ API プローブまたは静的パターンから派生した数値/文字列制約。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -498,7 +524,7 @@ i18n:
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** 成功のために提供する必要があるオペレーションボディフィールドの名前。
+- **Purpose:** 成功するために提供しなければならないオペレーションボディフィールドに名前を付けます。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -510,7 +536,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** オペレーションの影響範囲を分類します（low/medium/high/critical）。
+- **Purpose:** オペレーションの影響範囲を分類します (low/medium/high/critical)。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -522,7 +548,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** 実行前に CLI/UI がユーザーへ確認を求めるかどうか。
+- **Purpose:** 実行前に CLI/UI がユーザーに確認を求めるべきかどうか。
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -534,7 +560,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** オペレーションの観測可能な副作用（再起動、再設定等）の一覧。
+- **Purpose:** オペレーションの観測可能な副作用をリストします (再起動、再設定など)。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -558,7 +584,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** ライブ API から観測されたレートリミットヘッダー／動作。
+- **Purpose:** ライブ API から表面化した観測されたレートリミットヘッダー/動作。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -570,7 +596,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** ライブディスカバリー中に観測されたエラーレスポンスのカタログ（サンプルペイロード付き）。
+- **Purpose:** ライブディスカバリー中に観測されたエラーレスポンスのカタログ (サンプルペイロード付き)。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -579,12 +605,12 @@ i18n:
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## 注入済み — インデックスレベル（ドメインメタデータ）
+## 注入済み — インデックスレベル (ドメインメタデータ)
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** ドメインのトップレベル CLI / UI / ドキュメント / Terraform グループ化カテゴリ。
+- **Purpose:** ドメインのトップレベル CLI / UI / ドキュメント / Terraform グループカテゴリ。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -596,7 +622,7 @@ i18n:
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** ドメインを定義する主要リソースタイプの一覧。
+- **Purpose:** ドメインを定義する主要なリソースタイプのリスト。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -608,7 +634,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** 特別な注意が必要なリソース（本番クリティカル）。
+- **Purpose:** 高い注意を必要とするリソース (本番環境クリティカル)。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -620,7 +646,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** 短い（約60文字）ドメイン説明。長い説明のプロパティレベルにも適用されます。
+- **Purpose:** 短い (~60 文字) ドメイン説明。長い説明のプロパティレベルにも適用されます。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -632,7 +658,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** 中程度（約150文字）のドメイン説明。プロパティレベルにも適用されます。
+- **Purpose:** 中程度の (~150 文字) ドメイン説明。プロパティレベルにも適用されます。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -644,7 +670,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** 長い（約500文字）ドメイン説明。
+- **Purpose:** 長い (~500 文字) ドメイン説明。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -656,7 +682,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** このドメインでの設定作成における相対的な複雑さのティア。
+- **Purpose:** このドメインの設定を作成する際の相対的な複雑さのティア。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -668,7 +694,7 @@ i18n:
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** 必要な F5 XC サブスクリプションの最低ティア。
+- **Purpose:** 必要な最低 F5 XC サブスクリプションティア。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -680,7 +706,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** ドメインをプレビュー／ベータ機能としてフラグ付けします。
+- **Purpose:** ドメインをプレビュー/ベータ機能としてフラグ付けします。
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -716,7 +742,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** ドメインを表すブランドロゴのインライン SVG（またはパス）。
+- **Purpose:** ドメインを表すブランドロゴのインライン SVG (またはパス)。
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -728,7 +754,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** このドメインと一般的に併用される他のドメインへのクロスリンク。
+- **Purpose:** このドメインとともによく使用される他のドメインへのクロスリンク。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -740,7 +766,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** レンダリングされたドキュメントのドキュメントセクション／ナビゲーショングループスラッグ。
+- **Purpose:** レンダリングされたドキュメントのドキュメントセクション/ナビゲーショングループスラッグ。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -749,12 +775,12 @@ i18n:
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## 上流パススルー
+## アップストリームパススルー
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** F5 上流仕様から変更せず保持されます。
+- **Purpose:** F5 アップストリームスペックから変更なしで保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -766,7 +792,7 @@ i18n:
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** F5 上流仕様から変更せず保持されます。
+- **Purpose:** F5 アップストリームスペックから変更なしで保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -778,7 +804,7 @@ i18n:
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** F5 上流仕様から変更せず保持されます。
+- **Purpose:** F5 アップストリームスペックから変更なしで保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -790,7 +816,7 @@ i18n:
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** F5 上流仕様から変更せず保持されます。
+- **Purpose:** F5 アップストリームスペックから変更なしで保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -802,7 +828,7 @@ i18n:
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** F5 上流仕様から変更せず保持されます。
+- **Purpose:** F5 アップストリームスペックから変更なしで保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -814,7 +840,7 @@ i18n:
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** F5 上流仕様から変更せず保持されます。
+- **Purpose:** F5 アップストリームスペックから変更なしで保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -826,35 +852,35 @@ i18n:
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** F5 上流仕様から変更せず保持されます。
+- **Purpose:** F5 アップストリームスペックから変更なしで保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** F5 上流ドキュメントを参照してください。
+- **Example:** F5 アップストリームドキュメントを参照してください。
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** F5 上流仕様から変更せず保持されます。
+- **Purpose:** F5 アップストリームスペックから変更なしで保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** F5 上流ドキュメントを参照してください。
+- **Example:** F5 アップストリームドキュメントを参照してください。
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** F5 上流仕様から変更せず保持されます。
+- **Purpose:** F5 アップストリームスペックから変更なしで保持されます。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** F5 上流ドキュメントを参照してください。
+- **Example:** F5 アップストリームドキュメントを参照してください。
 - **Pass-through from upstream:** yes

--- a/docs/ko/extensions/catalog.md
+++ b/docs/ko/extensions/catalog.md
@@ -2,23 +2,23 @@
 title: 강화 확장 카탈로그
 description: 강화된 OpenAPI 사양의 모든 x-* 확장에 대한 단일 진실 공급원
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
 # 강화 확장 카탈로그
 
-`docs/specifications/api/*.json`에 나타나는 모든 `x-*` 확장에 대한 단일 진실 공급원입니다. `scripts/utils/extension_constants.py`와의 동등성은 `tests/test_extension_catalog.py`에 의해 적용됩니다.
+`docs/specifications/api/*.json`에 나타나는 모든 `x-*` 확장에 대한 단일 진실 공급원입니다. `scripts/utils/extension_constants.py`와의 동등성은 `tests/test_extension_catalog.py`에 의해 보장됩니다.
 
 여기에는 세 가지 클래스의 확장이 문서화되어 있습니다:
 
-- **여기에서 주입됨** — 인리처가 추가하는 확장(`x-f5xc-*` 및 `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / 디스커버리 변형). 이것들은 다운스트림 도구가 소비해야 하는 항목입니다.
-- **업스트림 패스스루** — F5가 소스 사양에서 생성하고 우리가 변경하지 않고 보존하는 확장(`x-ves-proto-*`, `x-displayname` 등). 투명성을 위해 문서화되지만 이 저장소에서 제어되지는 않습니다.
-- **미래 주입** — 아직 생성되지 않음; 인리처가 이를 생성하기 시작하는 즉시 여기에 문서화됩니다(초기 구성에는 해당하지 않음).
+- **여기서 주입됨** — 인리처가 추가하는 확장 (`x-f5xc-*` 및 `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / 디스커버리 변형). 다운스트림 도구가 사용해야 하는 확장입니다.
+- **업스트림 패스스루** — F5가 소스 사양에서 내보내며 변경 없이 보존하는 확장 (`x-ves-proto-*`, `x-displayname` 등). 투명성을 위해 문서화되었으나 이 저장소에서 제어하지 않습니다.
+- **향후 주입 예정** — 아직 내보내지 않음; 인리처가 생성을 시작하는 순간 여기에 문서화됩니다 (초기 배포 시에는 해당 없음).
 
 ## 항목 스키마
 
-아래의 모든 항목은 정확히 이 형태를 가집니다. `tests/test_extension_catalog.py`의 동등성 테스트는 `### x-name` 헤더가 존재하고 `Pass-through from upstream:` 플래그가 `yes` 또는 `no` 값으로 존재하는 한 섹션 본문이 간략하더라도 허용합니다.
+아래의 모든 항목은 정확히 이 형태를 따릅니다. `tests/test_extension_catalog.py`의 동등성 테스트는 `### x-name` 헤더가 존재하고 `Pass-through from upstream:` 플래그가 `yes` 또는 `no` 값으로 존재하는 한 섹션 본문이 간략해도 허용합니다.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -36,7 +36,7 @@ i18n:
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** 강화된 사양의 CLI 도메인 슬러그(예: `http_loadbalancer`)를 식별합니다.
+- **Purpose:** 강화된 사양에 대한 CLI 도메인 슬러그(예: `http_loadbalancer`)를 식별합니다.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -48,7 +48,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** CLI 전체 메타데이터 블록(도구 이름, 버전 힌트, 도메인 그룹화).
+- **Purpose:** CLI 전체 메타데이터 블록 (도구 이름, 버전 힌트, 도메인 그룹화).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -84,7 +84,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** 파이프라인에 의해 강화된 사양에 스탬프된 시맨틱 버전.
+- **Purpose:** 파이프라인이 강화된 사양에 스탬핑하는 시맨틱 버전.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -120,7 +120,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** 디스커버리 중에 프로브된 라이브 API의 기본 URL.
+- **Purpose:** 디스커버리 중 프로빙된 라이브 API의 기본 URL.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -132,7 +132,7 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** 이 도메인의 호스팅된 API 참조 문서 페이지 URL.
+- **Purpose:** 이 도메인에 대한 호스팅된 API 참조 문서 페이지의 URL.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -144,7 +144,7 @@ i18n:
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** 디스커버리 중 프로브된 API의 관측된 응답 시간(ms).
+- **Purpose:** 디스커버리 중 프로빙된 API의 관찰된 응답 시간 (ms).
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -156,7 +156,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** 도메인에 대한 큐레이션된 모범 사례 지침.
+- **Purpose:** 도메인에 대한 선별된 모범 사례 지침.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -168,7 +168,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** 도메인의 일반적인 작업을 수행하기 위한 명명된 단계별 워크플로우.
+- **Purpose:** 도메인에서 일반적인 작업을 수행하기 위한 명명된 단계별 워크플로우.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -192,7 +192,7 @@ i18n:
 ### x-f5xc-console-navigation
 
 - **Applied at:** spec info
-- **Purpose:** 전역 콘솔 탐색 트리 — 작업 공간 및 메뉴 계층 구조.
+- **Purpose:** 전역 콘솔 탐색 트리 — 워크스페이스 및 메뉴 계층 구조.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
@@ -230,7 +230,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** UI/CLI 표현을 위한 속성의 제안된 정렬 순서.
+- **Purpose:** UI/CLI 표시를 위한 속성의 제안된 순서.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -254,7 +254,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** 리소스 스키마에 대한 사람이 읽을 수 있는 표시 이름(자동 생성 재정의).
+- **Purpose:** 리소스 스키마에 대한 사람이 읽을 수 있는 표시 이름 (자동 생성을 재정의).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -266,7 +266,7 @@ i18n:
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** 이 리소스에 대한 콘솔 UI 탐색, 라우팅 및 폼 구조.
+- **Purpose:** 이 리소스에 대한 콘솔 UI 탐색, 라우팅 및 양식 구조.
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -328,7 +328,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** 셸 완성 힌트(정적 열거형 또는 동적 명령).
+- **Purpose:** 셸 완성 힌트 (정적 열거형 또는 동적 명령).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -352,7 +352,7 @@ i18n:
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** 이 속성을 필요로 하는 HTTP 작업(POST/PUT/...)을 나열합니다.
+- **Purpose:** 이 속성을 필요로 하는 HTTP 작업 (POST/PUT/...)을 나열합니다.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -376,7 +376,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** 조건부 요구 사항(예: 형제 필드가 X와 같을 때 필수).
+- **Purpose:** 조건부 요구 사항 (예: 형제 필드가 X와 같을 때 필요).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -388,7 +388,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** 대체 지침이 포함된 사용 중단 알림.
+- **Purpose:** 대체 지침이 포함된 사용 중단 공지.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -424,7 +424,7 @@ i18n:
 ### x-f5xc-recommended-oneof-variant
 
 - **Applied at:** schema property
-- **Purpose:** `oneOf` 블록의 경우, 권장되는 변형을 나타냅니다.
+- **Purpose:** `oneOf` 블록에 대해 권장되는 변형을 나타냅니다.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -445,10 +445,34 @@ i18n:
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** ObjectRefType 필드가 참조하는 리소스 종류(먼저 존재해야 하는 리소스)를 oneOf 선택 게이팅, 생성에 필요한 항목 및 카디널리티와 함께 선언합니다 — 의존성 모델의 리소스 참조 차원.
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** x-f5xc-minimum-configuration.example_yaml에서 파생된 필드별 생성 예시 값 (평면 field_path에서 값으로의 맵) — 다운스트림 양식/워크플로우 생성을 위한 결정론적 생성 값의 단일 진실 공급원.
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** 한 필드가 다른 필드의 설정을 필요로 하는 크로스 필드 종속성을 문서화합니다.
+- **Purpose:** 한 필드가 다른 필드를 설정해야 하는 크로스 필드 의존성을 문서화합니다.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -460,7 +484,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** 라이브 API 프로빙 또는 정적 패턴에서 파생된 숫자/문자열 제약.
+- **Purpose:** 라이브 API 프로빙 또는 정적 패턴에서 파생된 숫자/문자열 제약 조건.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -484,7 +508,7 @@ i18n:
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** 이 API 속성에 대한 콘솔 폼 위젯 메타데이터.
+- **Purpose:** 이 API 속성에 대한 콘솔 양식 위젯 메타데이터.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -498,7 +522,7 @@ i18n:
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** 성공을 위해 제공해야 하는 작업 본문 필드를 명명합니다.
+- **Purpose:** 성공을 위해 제공해야 하는 작업 본문 필드의 이름.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -510,7 +534,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** 작업의 영향 범위를 분류합니다(low/medium/high/critical).
+- **Purpose:** 작업의 영향 범위를 분류합니다 (low/medium/high/critical).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -522,7 +546,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** CLI/UI가 실행 전에 사용자에게 확인을 요청해야 하는지 여부.
+- **Purpose:** CLI/UI가 실행 전 사용자에게 확인을 요청해야 하는지 여부.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -534,7 +558,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** 작업의 관측 가능한 부작용을 나열합니다(재시작, 재구성 등).
+- **Purpose:** 작업의 관찰 가능한 부작용을 나열합니다 (재시작, 재구성 등).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -558,7 +582,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** 라이브 API에서 표면화된 관측된 속도 제한 헤더/동작.
+- **Purpose:** 라이브 API에서 나타난 관찰된 속도 제한 헤더/동작.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -570,7 +594,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** 라이브 디스커버리 중 관측된 오류 응답의 카탈로그(샘플 페이로드 포함).
+- **Purpose:** 라이브 디스커버리 중 관찰된 오류 응답 카탈로그 (샘플 페이로드 포함).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -608,7 +632,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** 높은 주의가 필요한 리소스(프로덕션 중요).
+- **Purpose:** 높은 주의가 필요한 리소스 (프로덕션 크리티컬).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -620,7 +644,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** 짧은(~60자) 도메인 설명. 긴 설명에 대해 속성 수준에도 적용됩니다.
+- **Purpose:** 짧은 (~60자) 도메인 설명. 긴 설명의 속성 수준에도 적용됩니다.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -632,7 +656,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** 중간(~150자) 도메인 설명. 속성 수준에도 적용됩니다.
+- **Purpose:** 중간 (~150자) 도메인 설명. 속성 수준에도 적용됩니다.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -644,7 +668,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** 긴(~500자) 도메인 설명.
+- **Purpose:** 긴 (~500자) 도메인 설명.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -656,7 +680,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** 이 도메인에서 구성을 작성하기 위한 상대적 복잡성 등급.
+- **Purpose:** 이 도메인에서 구성을 작성하는 상대적 복잡성 등급.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -680,7 +704,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** 도메인을 미리 보기/베타 기능으로 플래그 지정합니다.
+- **Purpose:** 도메인을 미리 보기 / 베타 기능으로 표시합니다.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -716,7 +740,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** 도메인을 나타내는 브랜드 로고의 인라인 SVG(또는 경로).
+- **Purpose:** 도메인을 나타내는 브랜드 로고의 인라인 SVG (또는 경로).
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -740,7 +764,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** 렌더링된 문서의 문서 섹션/탐색 그룹화 슬러그.
+- **Purpose:** 렌더링된 문서에 대한 문서 섹션 / 탐색 그룹화 슬러그.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -832,7 +856,7 @@ i18n:
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** F5 업스트림 문서를 참조하세요.
+- **Example:** F5 업스트림 문서를 참조하십시오.
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
@@ -844,7 +868,7 @@ i18n:
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** F5 업스트림 문서를 참조하세요.
+- **Example:** F5 업스트림 문서를 참조하십시오.
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
@@ -856,5 +880,5 @@ i18n:
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** F5 업스트림 문서를 참조하세요.
+- **Example:** F5 업스트림 문서를 참조하십시오.
 - **Pass-through from upstream:** yes

--- a/docs/pt-br/extensions/catalog.md
+++ b/docs/pt-br/extensions/catalog.md
@@ -1,37 +1,37 @@
 ---
 title: Catálogo de Extensões de Enriquecimento
 description: >-
-  Fonte primária de referência para cada extensão x-* nas especificações OpenAPI
+  Fonte de referência para cada extensão x-* nas especificações OpenAPI
   enriquecidas
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
 # Catálogo de Extensões de Enriquecimento
 
-Fonte primária de referência para cada extensão `x-*` que aparece em
+Fonte de referência para cada extensão `x-*` que aparece em
 `docs/specifications/api/*.json`. A paridade com
 `scripts/utils/extension_constants.py` é verificada por
 `tests/test_extension_catalog.py`.
 
 Três classes de extensões estão documentadas aqui:
 
-- **Injetadas aqui** — extensões que nossos enriquecedores adicionam (`x-f5xc-*` e
+- **Injetadas aqui** — extensões adicionadas pelos nossos enriquecedores (`x-f5xc-*` e
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / variantes de
-  descoberta). Estas são as extensões que as ferramentas downstream devem consumir.
-- **Passagem de upstream** — extensões que a F5 emite nas especificações de origem
-  e que preservamos sem alterações (`x-ves-proto-*`, `x-displayname`, etc.).
+  descoberta). Estas são as que as ferramentas downstream devem consumir.
+- **Repasse upstream** — extensões emitidas pelo F5 nas especificações de origem
+  e preservadas sem alteração (`x-ves-proto-*`, `x-displayname`, etc.).
   Documentadas por transparência, mas não controladas por este repositório.
-- **Injetadas futuramente** — ainda não emitidas; documentadas aqui no momento
-  em que um enriquecedor começar a produzi-las (não aplicável na população inicial).
+- **Injetadas futuramente** — ainda não emitidas; documentadas aqui assim que
+  um enriquecedor começar a produzi-las (não aplicável na população inicial).
 
 ## Esquema de entrada
 
 Cada entrada abaixo possui exatamente este formato. O teste de paridade em
 `tests/test_extension_catalog.py` tolera que o corpo da seção seja resumido,
-desde que o cabeçalho `### x-name` exista e o
-sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `no`.
+desde que o cabeçalho `### x-nome` exista e o sinalizador
+`Pass-through from upstream:` esteja presente com o valor `yes` ou `no`.
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -49,7 +49,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** Identifica o slug de domínio da CLI (ex.: `http_loadbalancer`) para uma especificação enriquecida.
+- **Purpose:** Identifica o slug do domínio CLI (ex.: `http_loadbalancer`) para uma especificação enriquecida.
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -61,7 +61,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** Bloco de metadados global da CLI (nome da ferramenta, dicas de versão, agrupamento de domínio).
+- **Purpose:** Bloco de metadados global do CLI (nome da ferramenta, dicas de versão, agrupamento de domínio).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -121,7 +121,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** Timestamp de quando a passagem de descoberta da API em produção foi executada.
+- **Purpose:** Timestamp de quando a passagem de descoberta da API ao vivo foi executada.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -133,7 +133,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** URL base da API em produção que foi sondada durante a descoberta.
+- **Purpose:** URL base da API ao vivo que foi sondada durante a descoberta.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -169,7 +169,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** Guia curado de melhores práticas para um domínio.
+- **Purpose:** Orientações de melhores práticas curadas para um domínio.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -205,7 +205,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-console-navigation
 
 - **Applied at:** spec info
-- **Purpose:** Árvore de navegação global do console — hierarquia de espaços de trabalho e menus.
+- **Purpose:** Árvore de navegação global do console — hierarquia de workspace e menus.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
@@ -214,12 +214,12 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 - **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
 - **Pass-through from upstream:** no
 
-## Injetadas — nível de esquema (esquemas de componentes)
+## Injetadas — nível de esquema (schemas de componentes)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** Conjunto mínimo de campos necessários para executar com sucesso um POST/PUT deste recurso.
+- **Purpose:** Conjunto mínimo de campos necessários para realizar com sucesso um POST/PUT deste recurso.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -243,7 +243,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** Ordenação sugerida das propriedades para apresentação em UI/CLI.
+- **Purpose:** Ordenação sugerida de propriedades para apresentação em UI/CLI.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -255,7 +255,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** Nome do tipo de recurso Terraform que mapeia para este esquema.
+- **Purpose:** Nome do tipo de recurso Terraform que mapeia para este schema.
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -267,7 +267,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** Nome de exibição legível por humanos para um esquema de recurso (substitui a geração automática).
+- **Purpose:** Nome de exibição legível por humanos para um schema de recurso (substitui a geração automática).
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -279,7 +279,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** Navegação da UI do console, roteamento e estrutura de formulário para este recurso.
+- **Purpose:** Navegação, roteamento e estrutura de formulário da UI do console para este recurso.
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -341,7 +341,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** Dicas de autocompletar para shell (enumeração estática ou comando dinâmico).
+- **Purpose:** Dicas de autocompletar no shell (enumeração estática ou comando dinâmico).
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -353,7 +353,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** Valor(es) padrão a exibir na documentação gerada e nas interfaces.
+- **Purpose:** Valor(es) padrão a serem exibidos em documentações e interfaces geradas.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -365,7 +365,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** Lista as operações HTTP (POST/PUT/...) que requerem esta propriedade.
+- **Purpose:** Lista as operações HTTP (POST/PUT/...) que exigem esta propriedade.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -377,7 +377,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** Lista combinações de funcionalidades nomeadas que requerem esta propriedade.
+- **Purpose:** Lista combinações de funcionalidades nomeadas que exigem esta propriedade.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -401,7 +401,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** Aviso de descontinuação com orientação sobre substituto.
+- **Purpose:** Aviso de depreciação com orientação sobre substituição.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -425,7 +425,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** Valor recomendado para produção de um campo onde o padrão do servidor é subótimo.
+- **Purpose:** Valor de produção recomendado para um campo onde o padrão do servidor não é ideal.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -458,10 +458,34 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** Declara o tipo de recurso referenciado por um campo ObjectRefType (o recurso para o qual aponta, que deve existir primeiro), com seleção de opções oneOf, obrigatoriedade na criação e cardinalidade — a dimensão de referência de recurso do modelo de dependência.
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** Valores de exemplo por campo para criação (mapa plano de field_path para valor) derivados de x-f5xc-minimum-configuration.example_yaml — a única fonte determinística de valores de criação para geração de formulários/fluxos de trabalho downstream.
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** Documenta dependências entre campos, nas quais um campo requer que outro esteja definido.
+- **Purpose:** Documenta dependências entre campos, em que um campo exige que outro esteja definido.
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -473,7 +497,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** Restrições numéricas/de string derivadas de sondagem da API em produção ou padrões estáticos.
+- **Purpose:** Restrições numéricas/de string derivadas de sondagem da API ao vivo ou de padrões estáticos.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -485,7 +509,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** Declara se um campo deve ser único dentro de seu escopo.
+- **Purpose:** Declara se um campo deve ser único dentro do seu escopo.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -497,7 +521,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** Metadados de widget de formulário do console para esta propriedade de API.
+- **Purpose:** Metadados do widget de formulário do console para esta propriedade de API.
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -535,7 +559,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** Indica se a CLI/UI deve solicitar confirmação ao usuário antes de executar.
+- **Purpose:** Indica se o CLI/UI deve solicitar confirmação do usuário antes de executar.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -571,7 +595,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** Cabeçalhos/comportamento de limite de taxa observados na API em produção.
+- **Purpose:** Cabeçalhos/comportamento de limite de taxa observados na API ao vivo.
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -583,7 +607,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** Catálogo de respostas de erro observadas durante a descoberta em produção, com exemplos de payloads.
+- **Purpose:** Catálogo de respostas de erro observadas durante a descoberta ao vivo, com payloads de exemplo.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -621,7 +645,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** Recursos que requerem atenção elevada (críticos em produção).
+- **Purpose:** Recursos que exigem cuidado elevado (críticos para produção).
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -669,7 +693,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** Nível relativo de complexidade para autoria de configurações neste domínio.
+- **Purpose:** Nível relativo de complexidade para criação de configurações neste domínio.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -681,7 +705,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** Nível mínimo de assinatura do F5 XC necessário.
+- **Purpose:** Nível mínimo de assinatura F5 XC necessário.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -693,7 +717,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** Sinaliza um domínio como funcionalidade em preview / beta.
+- **Purpose:** Sinaliza um domínio como funcionalidade em pré-visualização / beta.
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -705,7 +729,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** Casos de uso nomeados suportados por este domínio.
+- **Purpose:** Casos de uso nomeados que este domínio suporta.
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -729,7 +753,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** SVG embutido (ou caminho) para um logotipo de marca que representa o domínio.
+- **Purpose:** SVG inline (ou caminho) de um logotipo de marca representando o domínio.
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -753,7 +777,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** Slug de seção de documentação / agrupamento de navegação para documentos renderizados.
+- **Purpose:** Slug da seção de documentação / agrupamento de navegação para a documentação renderizada.
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -762,12 +786,12 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## Passagem de upstream
+## Repasse upstream
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alterações da especificação upstream da F5.
+- **Purpose:** Preservado sem alteração da especificação upstream do F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -779,7 +803,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alterações da especificação upstream da F5.
+- **Purpose:** Preservado sem alteração da especificação upstream do F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -791,7 +815,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alterações da especificação upstream da F5.
+- **Purpose:** Preservado sem alteração da especificação upstream do F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -803,7 +827,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alterações da especificação upstream da F5.
+- **Purpose:** Preservado sem alteração da especificação upstream do F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -815,7 +839,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alterações da especificação upstream da F5.
+- **Purpose:** Preservado sem alteração da especificação upstream do F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -827,7 +851,7 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alterações da especificação upstream da F5.
+- **Purpose:** Preservado sem alteração da especificação upstream do F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -839,35 +863,35 @@ sinalizador `Pass-through from upstream:` esteja presente com o valor `yes` ou `
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alterações da especificação upstream da F5.
+- **Purpose:** Preservado sem alteração da especificação upstream do F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** Consulte a documentação upstream da F5.
+- **Example:** Consulte a documentação upstream do F5.
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alterações da especificação upstream da F5.
+- **Purpose:** Preservado sem alteração da especificação upstream do F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** Consulte a documentação upstream da F5.
+- **Example:** Consulte a documentação upstream do F5.
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** Preservado sem alterações da especificação upstream da F5.
+- **Purpose:** Preservado sem alteração da especificação upstream do F5.
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** Consulte a documentação upstream da F5.
+- **Example:** Consulte a documentação upstream do F5.
 - **Pass-through from upstream:** yes

--- a/docs/th/extensions/catalog.md
+++ b/docs/th/extensions/catalog.md
@@ -1,35 +1,37 @@
 ---
 title: แคตตาล็อกส่วนขยาย Enrichment
 description: >-
-  แหล่งข้อมูลหลักสำหรับทุก x-* extension ในข้อกำหนด OpenAPI
+  แหล่งข้อมูลหลักสำหรับส่วนขยาย x-* ทุกรายการในข้อกำหนด OpenAPI
   ที่เพิ่มประสิทธิภาพแล้ว
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
 # แคตตาล็อกส่วนขยาย Enrichment
 
-แหล่งข้อมูลหลักสำหรับทุก `x-*` extension ที่ปรากฏใน
+แหล่งข้อมูลหลักสำหรับส่วนขยาย `x-*` ทุกรายการที่ปรากฏใน
 `docs/specifications/api/*.json` ความสอดคล้องกับ
-`scripts/utils/extension_constants.py` ถูกตรวจสอบโดย
+`scripts/utils/extension_constants.py` ถูกบังคับใช้โดย
 `tests/test_extension_catalog.py`
 
-ส่วนขยายแบ่งออกเป็นสามประเภทที่บันทึกไว้ที่นี่:
+ส่วนขยายสามประเภทได้รับการจัดทำเอกสารไว้ที่นี่:
 
-- **Injected here** — ส่วนขยายที่ enricher ของเราเพิ่มเข้ามา (`x-f5xc-*` และ
+- **ฉีดเข้ามาที่นี่** — ส่วนขยายที่ enricher ของเราเพิ่มเข้ามา (`x-f5xc-*` และ
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / discovery
-  variants) นี่คือส่วนขยายที่เครื่องมือปลายทางควรนำไปใช้
-- **Upstream pass-through** — ส่วนขยายที่ F5 ส่งออกมาในข้อกำหนดต้นทางและเราเก็บรักษาไว้โดยไม่เปลี่ยนแปลง (`x-ves-proto-*`, `x-displayname` ฯลฯ)
-  บันทึกไว้เพื่อความโปร่งใสแต่ไม่ได้ถูกควบคุมโดย repo นี้
-- **Future-injected** — ยังไม่ได้ถูกส่งออก บันทึกไว้ที่นี่ทันทีที่ enricher เริ่มสร้างขึ้น (ไม่เกี่ยวข้องกับการประชากรเริ่มต้น)
+  variants) เหล่านี้คือส่วนขยายที่เครื่องมือ downstream ควรนำไปใช้
+- **ส่งผ่านจาก upstream** — ส่วนขยายที่ F5 ส่งออกมาในสเปคต้นทาง
+  และเราเก็บรักษาไว้โดยไม่เปลี่ยนแปลง (`x-ves-proto-*`, `x-displayname` เป็นต้น)
+  จัดทำเอกสารเพื่อความโปร่งใส แต่ไม่ได้ควบคุมโดย repo นี้
+- **ฉีดในอนาคต** — ยังไม่ได้ส่งออก; จัดทำเอกสารทันทีที่
+  enricher เริ่มผลิตขึ้นมา (ไม่มีผลบังคับใช้ในการป้อนข้อมูลเริ่มต้น)
 
 ## โครงสร้างรายการ
 
-ทุกรายการด้านล่างมีรูปแบบนี้โดยเฉพาะ การทดสอบความสอดคล้องใน
-`tests/test_extension_catalog.py` ยอมรับให้เนื้อหาส่วนนั้นสั้นได้
-ตราบใดที่ header `### x-name` มีอยู่และ
-flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes` หรือ `no`
+ทุกรายการด้านล่างมีรูปแบบนี้อย่างแน่นอน การทดสอบความสอดคล้องใน
+`tests/test_extension_catalog.py` ยอมรับเนื้อหาของส่วนที่สั้นกระชับ
+ตราบเท่าที่ส่วนหัว `### x-name` มีอยู่ และ
+แฟล็ก `Pass-through from upstream:` มีค่าเป็น `yes` หรือ `no`
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -42,12 +44,12 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## Injected — ระดับ spec (ส่วน info)
+## ฉีดเข้ามา — ระดับสเปค (ส่วน info)
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** ระบุ slug ของ CLI domain (เช่น `http_loadbalancer`) สำหรับ spec ที่เพิ่มประสิทธิภาพแล้ว
+- **Purpose:** ระบุ slug ของโดเมน CLI (เช่น `http_loadbalancer`) สำหรับสเปคที่เพิ่มประสิทธิภาพแล้ว
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -59,7 +61,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** บล็อก metadata ระดับ CLI (ชื่อเครื่องมือ, คำแนะนำเวอร์ชัน, การจัดกลุ่ม domain)
+- **Purpose:** บล็อกเมตาดาตาสำหรับ CLI ทั้งหมด (ชื่อเครื่องมือ, 힌트เวอร์ชัน, การจัดกลุ่มโดเมน)
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -71,7 +73,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** Timestamp ของ spec ต้นทาง upstream ที่ไฟล์ที่เพิ่มประสิทธิภาพแล้วถูกสร้างขึ้นมา
+- **Purpose:** Timestamp ของสเปคต้นทาง upstream ที่ใช้สร้างไฟล์ที่เพิ่มประสิทธิภาพแล้ว
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -83,7 +85,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** ETag ของ release asset ของ spec ต้นทาง upstream
+- **Purpose:** ETag ของ asset การเผยแพร่สเปคต้นทาง upstream
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -95,7 +97,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** เวอร์ชัน semantic ที่ประทับบน spec ที่เพิ่มประสิทธิภาพแล้วโดย pipeline
+- **Purpose:** เวอร์ชัน Semantic ที่ประทับลงบนสเปคที่เพิ่มประสิทธิภาพแล้วโดย pipeline
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -107,7 +109,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** บล็อก glossary ของการสร้างแบรนด์/คำศัพท์ที่ใช้กับ spec แต่ละ domain
+- **Purpose:** บล็อกคำศัพท์ด้านการสร้างแบรนด์/คำศัพท์เฉพาะที่ใช้กับสเปคของแต่ละโดเมน
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -119,7 +121,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** Timestamp เมื่อรอบการค้นพบ live-API ถูกดำเนินการ
+- **Purpose:** Timestamp เมื่อดำเนินการ discovery pass ของ live API
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -131,7 +133,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** Base URL ของ live API ที่ถูกตรวจสอบระหว่างการค้นพบ
+- **Purpose:** URL พื้นฐานของ live API ที่ถูกตรวจสอบระหว่าง discovery
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -143,7 +145,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** URL ไปยังหน้าเอกสาร API reference ที่โฮสต์ไว้สำหรับ domain นี้
+- **Purpose:** URL ไปยังหน้าเอกสารอ้างอิง API ที่โฮสต์ไว้สำหรับโดเมนนี้
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -155,7 +157,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** เวลาตอบสนองที่สังเกตได้ (ms) สำหรับ API ที่ถูกตรวจสอบระหว่างการค้นพบ
+- **Purpose:** เวลาตอบสนองที่สังเกตได้ (ms) สำหรับ API ที่ถูกตรวจสอบระหว่าง discovery
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -167,7 +169,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** แนวทางปฏิบัติที่ดีที่สุดที่คัดเลือกมาสำหรับ domain
+- **Purpose:** คำแนะนำแนวทางปฏิบัติที่ดีที่สุดที่คัดเลือกแล้วสำหรับโดเมน
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -179,7 +181,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** Workflow แบบมีชื่อที่มีขั้นตอนสำหรับทำงานทั่วไปใน domain
+- **Purpose:** เวิร์กโฟลว์แบบขั้นตอนที่มีชื่อเพื่อทำงานทั่วไปในโดเมน
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -191,7 +193,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** ตารางขยายความตัวย่อสำหรับแต่ละ domain
+- **Purpose:** ตารางการขยายตัวย่อสำหรับแต่ละโดเมน
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -203,7 +205,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-console-navigation
 
 - **Applied at:** spec info
-- **Purpose:** โครงสร้างการนำทาง console ระดับ global — ลำดับชั้น workspace และเมนู
+- **Purpose:** ต้นไม้การนำทางคอนโซลทั่วทั้งระบบ — ลำดับชั้น workspace และเมนู
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
@@ -212,12 +214,12 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 - **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
 - **Pass-through from upstream:** no
 
-## Injected — ระดับ schema (component schemas)
+## ฉีดเข้ามา — ระดับ schema (component schemas)
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** ชุดฟิลด์ขั้นต่ำที่จำเป็นสำหรับการ POST/PUT resource นี้ให้สำเร็จ
+- **Purpose:** ชุดฟิลด์ขั้นต่ำที่จำเป็นเพื่อ POST/PUT ทรัพยากรนี้ให้สำเร็จ
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -229,7 +231,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** ให้ข้อมูล metadata เกี่ยวกับข้อจำกัด namespace, คำแนะนำ, และการจำแนกประเภทสำหรับ resource
+- **Purpose:** ให้ metadata ด้านข้อจำกัด namespace, คำแนะนำ, และการจัดประเภทสำหรับทรัพยากร
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -241,7 +243,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** ลำดับที่แนะนำของ properties สำหรับการนำเสนอใน UI/CLI
+- **Purpose:** ลำดับที่แนะนำของ properties สำหรับการแสดงผลใน UI/CLI
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -253,7 +255,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** ชื่อ resource type ของ Terraform ที่แมปกับ schema นี้
+- **Purpose:** ชื่อประเภท Terraform resource ที่แมปกับ schema นี้
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -265,7 +267,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** ชื่อแสดงผลที่อ่านได้สำหรับมนุษย์สำหรับ resource schema (แทนที่การสร้างอัตโนมัติ)
+- **Purpose:** ชื่อที่แสดงผลแบบอ่านง่ายสำหรับ resource schema (แทนที่การสร้างอัตโนมัติ)
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -277,7 +279,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** การนำทาง UI ของ console, การ routing, และโครงสร้างฟอร์มสำหรับ resource นี้
+- **Purpose:** การนำทาง UI คอนโซล, การกำหนดเส้นทาง, และโครงสร้างฟอร์มสำหรับทรัพยากรนี้
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -286,12 +288,12 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 - **Example:** `"x-f5xc-console": {"workspace": "web-app-and-api-protection", "menu_path": ["Manage", "Load Balancers", "HTTP Load Balancers"]}`
 - **Pass-through from upstream:** no
 
-## Injected — ระดับ property
+## ฉีดเข้ามา — ระดับ property
 
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** คำอธิบาย property ที่เพิ่มประสิทธิภาพแล้วซึ่งเสริม `description` ของ upstream
+- **Purpose:** คำอธิบาย property ที่เพิ่มประสิทธิภาพแล้วซึ่งเสริมจาก `description` upstream
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -303,7 +305,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** กฎการตรวจสอบความถูกต้องเชิงประกาศที่ได้มาจาก `ves.io.schema.rules` ของ upstream protobuf
+- **Purpose:** กฎการตรวจสอบแบบ declarative ที่ได้มาจาก `ves.io.schema.rules` ของ protobuf upstream
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -315,7 +317,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** ค่าตัวอย่างที่หลากหลายสำหรับ property
+- **Purpose:** ค่าตัวอย่างหลายรายการสำหรับ property
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -327,7 +329,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-example
 
 - **Applied at:** schema property
-- **Purpose:** ค่าตัวอย่างแบบ canonical เดียว
+- **Purpose:** ค่าตัวอย่างหลักเพียงค่าเดียว
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -339,7 +341,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** คำแนะนำการเติมอัตโนมัติ shell (enum แบบ static หรือคำสั่งแบบ dynamic)
+- **Purpose:** คำแนะนำสำหรับการเติมข้อความอัตโนมัติใน shell (enum แบบ static หรือคำสั่งแบบ dynamic)
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -363,7 +365,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** แสดงรายการ HTTP operation (POST/PUT/...) ที่ต้องการ property นี้
+- **Purpose:** แสดงรายการ HTTP operations (POST/PUT/...) ที่ต้องการ property นี้
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -375,7 +377,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-required-for
 
 - **Applied at:** schema property
-- **Purpose:** แสดงรายการชุดฟีเจอร์ที่มีชื่อซึ่งต้องการ property นี้
+- **Purpose:** แสดงรายการการรวมกันของฟีเจอร์ที่มีชื่อซึ่งต้องการ property นี้
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -387,7 +389,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** ข้อกำหนดเงื่อนไข (เช่น จำเป็นเมื่อฟิลด์พี่น้องเท่ากับ X)
+- **Purpose:** ข้อกำหนดแบบมีเงื่อนไข (เช่น required เมื่อฟิลด์ sibling มีค่าเท่ากับ X)
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -399,7 +401,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** ประกาศการเลิกใช้งานพร้อมคำแนะนำสำหรับการแทนที่
+- **Purpose:** ประกาศการเลิกใช้งานพร้อมคำแนะนำการแทนที่
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -411,7 +413,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** ค่าเริ่มต้นที่เซิร์ฟเวอร์กำหนดเมื่อ client ละเว้น property นั้น
+- **Purpose:** ค่าเริ่มต้นที่ server กำหนดเมื่อ client ละเว้น property
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -423,7 +425,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** ค่าที่แนะนำสำหรับ production สำหรับฟิลด์ที่ค่าเริ่มต้นของเซิร์ฟเวอร์ไม่เหมาะสม
+- **Purpose:** ค่าที่แนะนำสำหรับการใช้งานจริงสำหรับฟิลด์ที่ค่าเริ่มต้นของ server ไม่เหมาะสม
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -447,7 +449,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** แสดงรายการ properties พี่น้องที่ไม่สามารถตั้งค่าพร้อมกับ property นี้ได้
+- **Purpose:** แสดงรายการ properties แบบ sibling ที่ไม่สามารถตั้งค่าพร้อมกับ property นี้ได้
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -456,10 +458,34 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** ประกาศประเภททรัพยากรที่อ้างถึงของฟิลด์ ObjectRefType (ทรัพยากรที่ชี้ไป ซึ่งต้องมีอยู่ก่อน) พร้อม oneOf choice-gating, required-for-create, และ cardinality — มิติการอ้างอิงทรัพยากรของโมเดล dependency
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** ค่าตัวอย่างในการสร้างแบบต่อฟิลด์ (แมป field_path แบบ flat กับค่า) ที่ได้มาจาก x-f5xc-minimum-configuration.example_yaml — แหล่งข้อมูลเดียวของค่าการสร้างแบบ deterministic สำหรับการสร้างฟอร์ม/เวิร์กโฟลว์ downstream
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** บันทึก dependency ข้ามฟิลด์ที่ฟิลด์หนึ่งต้องการให้ฟิลด์อื่นถูกตั้งค่า
+- **Purpose:** จัดทำเอกสาร dependencies ระหว่างฟิลด์ข้ามกัน ซึ่งฟิลด์หนึ่งต้องการให้ฟิลด์อื่นถูกตั้งค่าด้วย
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -471,7 +497,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** ข้อจำกัดตัวเลข/สตริงที่ได้มาจากการตรวจสอบ live-API หรือ pattern แบบ static
+- **Purpose:** ข้อจำกัดด้านตัวเลข/สตริงที่ได้มาจากการตรวจสอบ live API หรือ patterns แบบ static
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -483,7 +509,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** ประกาศว่าฟิลด์ต้องมีความเฉพาะเจาะจงภายใน scope ของมันหรือไม่
+- **Purpose:** ประกาศว่าฟิลด์ต้องมีค่าเฉพาะภายใน scope ของมันหรือไม่
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -495,7 +521,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** metadata ของ widget ฟอร์ม console สำหรับ API property นี้
+- **Purpose:** metadata ของ widget ฟอร์มคอนโซลสำหรับ API property นี้
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -504,7 +530,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 - **Example:** `"x-f5xc-console-field": {"widget_type": "listbox", "default": "HTTPS with Automatic Certificate", "form_section": "domains-and-lb-type"}`
 - **Pass-through from upstream:** no
 
-## Injected — ระดับ operation
+## ฉีดเข้ามา — ระดับ operation
 
 ### x-f5xc-required-fields
 
@@ -521,7 +547,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** จำแนกระดับ blast radius ของ operation (low/medium/high/critical)
+- **Purpose:** จำแนกระดับผลกระทบของ operation (low/medium/high/critical)
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -533,7 +559,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** CLI/UI ควรแจ้งให้ผู้ใช้ยืนยันก่อนดำเนินการหรือไม่
+- **Purpose:** ระบุว่า CLI/UI ควรแจ้งให้ผู้ใช้ยืนยันก่อนดำเนินการหรือไม่
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -545,7 +571,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** แสดงรายการผลข้างเคียงที่สังเกตได้ของ operation (restart, reconfigure ฯลฯ)
+- **Purpose:** แสดงรายการผลข้างเคียงที่สังเกตได้จาก operation (restart, reconfigure เป็นต้น)
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -557,7 +583,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-discovered-response-time
 
 - **Applied at:** operation
-- **Purpose:** เวลาตอบสนองที่วัดได้จากการทดลองสำหรับ operation นี้ระหว่างการค้นพบ
+- **Purpose:** เวลาตอบสนองที่วัดได้จริงสำหรับ operation นี้ระหว่าง discovery
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -569,7 +595,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** headers/พฤติกรรม rate-limit ที่สังเกตได้จาก live API
+- **Purpose:** headers / พฤติกรรมการจำกัดอัตราที่สังเกตได้จาก live API
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -581,7 +607,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** แคตตาล็อกของการตอบสนองข้อผิดพลาดที่สังเกตได้ระหว่างการค้นพบ live พร้อม payload ตัวอย่าง
+- **Purpose:** แคตตาล็อกของการตอบสนองข้อผิดพลาดที่สังเกตได้ระหว่าง live discovery พร้อม payload ตัวอย่าง
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -590,12 +616,12 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## Injected — ระดับ index (domain metadata)
+## ฉีดเข้ามา — ระดับ index (domain metadata)
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** หมวดหมู่การจัดกลุ่มระดับสูงสุดสำหรับ CLI / UI / เอกสาร / Terraform ของ domain
+- **Purpose:** หมวดหมู่การจัดกลุ่มระดับบนสุดสำหรับ CLI / UI / docs / Terraform ของโดเมน
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -607,7 +633,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** รายการ resource type หลักที่กำหนด domain
+- **Purpose:** รายการประเภททรัพยากรหลักที่กำหนดโดเมน
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -619,7 +645,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** ทรัพยากรที่ต้องการความระมัดระวังสูง (critical สำหรับ production)
+- **Purpose:** ทรัพยากรที่ต้องการความระมัดระวังเป็นพิเศษ (สำคัญต่อ production)
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -631,7 +657,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** คำอธิบาย domain แบบสั้น (~60 ตัวอักษร) นอกจากนี้ยังใช้ที่ระดับ property สำหรับคำอธิบายยาว
+- **Purpose:** คำอธิบายโดเมนสั้น (~60 ตัวอักษร) ใช้ได้ในระดับ property ด้วยสำหรับคำอธิบายยาว
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -643,7 +669,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** คำอธิบาย domain แบบกลาง (~150 ตัวอักษร) นอกจากนี้ยังใช้ที่ระดับ property
+- **Purpose:** คำอธิบายโดเมนขนาดกลาง (~150 ตัวอักษร) ใช้ได้ในระดับ property ด้วย
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -655,7 +681,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** คำอธิบาย domain แบบยาว (~500 ตัวอักษร)
+- **Purpose:** คำอธิบายโดเมนยาว (~500 ตัวอักษร)
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -667,7 +693,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** ระดับความซับซ้อนสัมพัทธ์สำหรับการเขียน configuration ใน domain นี้
+- **Purpose:** ระดับความซับซ้อนสัมพัทธ์สำหรับการเขียน configurations ในโดเมนนี้
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -691,7 +717,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** ทำเครื่องหมาย domain ว่าเป็นฟีเจอร์ preview / beta
+- **Purpose:** ทำเครื่องหมายโดเมนว่าเป็นฟีเจอร์ preview / beta
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -703,7 +729,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** use case ที่มีชื่อซึ่ง domain นี้รองรับ
+- **Purpose:** กรณีการใช้งานที่มีชื่อซึ่งโดเมนนี้รองรับ
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -715,7 +741,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** ตัวระบุไอคอนที่ใช้เมื่อแสดง domain นี้ใน UI
+- **Purpose:** ตัวระบุไอคอนที่ใช้เมื่อแสดงโดเมนนี้ใน UI
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -727,7 +753,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** SVG แบบ inline (หรือ path) สำหรับโลโก้แบรนด์ที่แทน domain
+- **Purpose:** SVG แบบ inline (หรือ path) สำหรับโลโก้แบรนด์ที่แทนโดเมน
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -739,7 +765,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** cross-link ไปยัง domain อื่นที่มักใช้ร่วมกับ domain นี้
+- **Purpose:** ลิงก์ข้ามไปยังโดเมนอื่นที่มักใช้ร่วมกับโดเมนนี้
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -760,12 +786,12 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 - **Example:** `"x-f5xc-doc-section": "load-balancing"`
 - **Pass-through from upstream:** no
 
-## Upstream pass-through
+## ส่งผ่านจาก upstream
 
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจาก spec upstream ของ F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปค F5 upstream
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -777,7 +803,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจาก spec upstream ของ F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปค F5 upstream
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -789,7 +815,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจาก spec upstream ของ F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปค F5 upstream
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -801,7 +827,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจาก spec upstream ของ F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปค F5 upstream
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -813,7 +839,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจาก spec upstream ของ F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปค F5 upstream
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -825,7 +851,7 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจาก spec upstream ของ F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปค F5 upstream
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -837,35 +863,35 @@ flag `Pass-through from upstream:` ปรากฏพร้อมค่า `yes`
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจาก spec upstream ของ F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปค F5 upstream
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** ดูเอกสาร upstream ของ F5
+- **Example:** ดูเอกสาร F5 upstream
 - **Pass-through from upstream:** yes
 
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจาก spec upstream ของ F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปค F5 upstream
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** ดูเอกสาร upstream ของ F5
+- **Example:** ดูเอกสาร F5 upstream
 - **Pass-through from upstream:** yes
 
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจาก spec upstream ของ F5
+- **Purpose:** เก็บรักษาไว้โดยไม่เปลี่ยนแปลงจากสเปค F5 upstream
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
 - **Injected by:** upstream
 - **Driven by config:** upstream
-- **Example:** ดูเอกสาร upstream ของ F5
+- **Example:** ดูเอกสาร F5 upstream
 - **Pass-through from upstream:** yes

--- a/docs/zh-cn/extensions/catalog.md
+++ b/docs/zh-cn/extensions/catalog.md
@@ -1,29 +1,31 @@
 ---
 title: 扩展目录（Enrichment Extension Catalog）
-description: docs/specifications/api/*.json 中所有 x-* 扩展的权威参考
+description: enriched OpenAPI 规范中所有 x-* 扩展的权威参考来源
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
 # 扩展目录（Enrichment Extension Catalog）
 
-`docs/specifications/api/*.json` 中每个 `x-*` 扩展的权威参考。
-与 `scripts/utils/extension_constants.py` 的一致性由
-`tests/test_extension_catalog.py` 强制保证。
+`docs/specifications/api/*.json` 中所有 `x-*` 扩展的权威参考来源。与
+`scripts/utils/extension_constants.py` 的一致性由
+`tests/test_extension_catalog.py` 强制执行。
 
-本文档记录了三类扩展：
+此处记录了三类扩展：
 
 - **此处注入** — 由我们的 enricher 添加的扩展（`x-f5xc-*` 以及
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / discovery
-  变体）。这些是下游工具应当使用的扩展。
-- **上游透传** — F5 在源规范中发出并由我们原样保留的扩展（`x-ves-proto-*`、`x-displayname` 等）。
-  记录于此以保持透明，但不由本仓库控制。
-- **未来注入** — 尚未输出；当某个 enricher 开始生成时，立即在此处记录（初始填充时不适用）。
+  变体）。这些是下游工具应使用的扩展。
+- **上游透传** — F5 在源规范中生成并由我们原样保留的扩展（`x-ves-proto-*`、`x-displayname` 等）。
+  出于透明度目的而记录，但不受本仓库控制。
+- **未来注入** — 尚未生成；一旦某个 enricher 开始产生它们即在此处记录（初始填充时不适用）。
 
-## 条目结构
+## 条目格式
 
-以下每个条目均具有完全相同的结构。`tests/test_extension_catalog.py` 中的一致性测试允许章节正文较为简短，只要 `### x-name` 标题存在，且 `Pass-through from upstream:` 字段的值为 `yes` 或 `no` 即可。
+以下每个条目均采用完全相同的结构。`tests/test_extension_catalog.py`
+中的一致性测试允许章节内容较为简略，只要 `### x-name` 标题存在，
+且 `Pass-through from upstream:` 标志以 `yes` 或 `no` 出现即可。
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -41,7 +43,7 @@ i18n:
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** 标识富化规范的 CLI 域 slug（例如 `http_loadbalancer`）。
+- **Purpose:** 标识 enriched 规范的 CLI 域 slug（例如 `http_loadbalancer`）。
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -65,7 +67,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** 富化文件所基于的上游源规范的时间戳。
+- **Purpose:** enriched 文件所基于的上游源规范的时间戳。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -89,7 +91,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** 由流水线在富化规范上标记的语义版本号。
+- **Purpose:** 由流水线戳印在 enriched 规范上的语义化版本号。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -113,7 +115,7 @@ i18n:
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** 执行实时 API 发现扫描的时间戳。
+- **Purpose:** 执行实时 API 发现阶段时的时间戳。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -125,7 +127,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** 发现过程中探测的实时 API 的基础 URL。
+- **Purpose:** 发现阶段所探测的实时 API 的基础 URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -137,19 +139,19 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** 该域托管的 API 参考文档页面的 URL。
+- **Purpose:** 该域对应的已托管 API 参考文档页面的 URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
 - **Injected by:** scripts/utils/external_docs_enricher.py
-- **Driven by config:** none（由域名派生）
+- **Driven by config:** none（由域名称派生）
 - **Example:** `"x-f5xc-api-reference-url": "https://f5-sales-demo.github.io/api-specs-enriched/api-reference/sites/"`
 - **Pass-through from upstream:** no
 
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** 发现过程中探测 API 的观测响应时间（毫秒）。
+- **Purpose:** 发现阶段对所探测 API 观测到的响应时间（毫秒）。
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -161,7 +163,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** 针对某一域精选的最佳实践指导。
+- **Purpose:** 针对某个域的精选最佳实践指导。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -173,7 +175,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** 在域内完成常见任务的命名逐步工作流。
+- **Purpose:** 用于在域内完成常见任务的命名分步工作流。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -185,7 +187,7 @@ i18n:
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** 按域划分的首字母缩略词扩展表。
+- **Purpose:** 按域划分的首字母缩略词展开表。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -197,7 +199,7 @@ i18n:
 ### x-f5xc-console-navigation
 
 - **Applied at:** spec info
-- **Purpose:** 全局控制台导航树——工作区与菜单层级。
+- **Purpose:** 全局控制台导航树——工作区与菜单层级结构。
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
@@ -206,12 +208,12 @@ i18n:
 - **Example:** `"x-f5xc-console-navigation": {"workspaces": {"web-app-and-api-protection": {"label": "Web App & API Protection", "route_prefix": "/web/workspaces/web-app-and-api-protection"}}}`
 - **Pass-through from upstream:** no
 
-## 注入 — Schema 级别（组件 schemas）
+## 注入 — 模式级别（组件模式）
 
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** 成功 POST/PUT 该资源所需的最小可行字段集。
+- **Purpose:** 成功 POST/PUT 该资源所需的最小可用字段集。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -223,7 +225,7 @@ i18n:
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** 为资源提供命名空间约束、建议和分类元数据。
+- **Purpose:** 为资源提供命名空间约束、建议及分类元数据。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -235,7 +237,7 @@ i18n:
 ### x-f5xc-displayorder
 
 - **Applied at:** schema
-- **Purpose:** UI/CLI 展示时属性的建议排列顺序。
+- **Purpose:** 供 UI/CLI 呈现时使用的属性建议排序。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -247,7 +249,7 @@ i18n:
 ### x-f5xc-terraform-resource
 
 - **Applied at:** schema
-- **Purpose:** 映射到此 schema 的 Terraform 资源类型名称。
+- **Purpose:** 映射到该模式的 Terraform 资源类型名称。
 - **Consumers:** Terraform
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -259,7 +261,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** 资源 schema 的人类可读显示名称（覆盖自动生成的名称）。
+- **Purpose:** 资源模式的人类可读显示名称（覆盖自动生成结果）。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -271,7 +273,7 @@ i18n:
 ### x-f5xc-console
 
 - **Applied at:** schema
-- **Purpose:** 该资源的控制台 UI 导航、路由和表单结构。
+- **Purpose:** 该资源的控制台 UI 导航、路由及表单结构。
 - **Consumers:** console-catalog, xcsh, vscode-xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspace": "string", "menu_path": "array", "route_pattern": "string", "breadcrumbs": "array", "add_action": "object", "form_sections": "array", "metadata": "object"}}`
@@ -285,7 +287,7 @@ i18n:
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** 补充上游 `description` 的富化属性描述。
+- **Purpose:** 补充上游 `description` 的增强属性描述。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -309,7 +311,7 @@ i18n:
 ### x-f5xc-examples
 
 - **Applied at:** schema property
-- **Purpose:** 为属性提供多个示范性示例值。
+- **Purpose:** 属性的多个示例说明值。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array"}`
@@ -321,7 +323,7 @@ i18n:
 ### x-f5xc-example
 
 - **Applied at:** schema property
-- **Purpose:** 单个规范示例值。
+- **Purpose:** 单一规范示例值。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -381,7 +383,7 @@ i18n:
 ### x-f5xc-conditions
 
 - **Applied at:** schema property
-- **Purpose:** 条件要求（例如，当同级字段等于 X 时为必填项）。
+- **Purpose:** 条件性要求（例如当兄弟字段等于 X 时为必填项）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -393,7 +395,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** 带有替换指引的弃用通知。
+- **Purpose:** 带有替代指引的弃用说明。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -405,7 +407,7 @@ i18n:
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** 客户端省略该属性时服务器分配的默认值。
+- **Purpose:** 客户端省略该属性时服务器所赋予的默认值。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -417,7 +419,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** 当服务器默认值不够理想时，为某字段推荐的生产环境值。
+- **Purpose:** 某字段的推荐生产值（当服务器默认值不够理想时使用）。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -441,7 +443,7 @@ i18n:
 ### x-f5xc-conflicts-with
 
 - **Applied at:** schema property
-- **Purpose:** 列出不能与该属性同时设置的同级属性。
+- **Purpose:** 列出不能与该属性同时设置的兄弟属性。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -450,15 +452,39 @@ i18n:
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** 声明 ObjectRefType 字段所引用的资源类型（该资源必须预先存在），包含 oneOf 选择门控、创建所需条件及基数——属于依赖模型中的资源引用维度。
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** 每个字段的创建示例值（字段路径到值的扁平映射），源自 x-f5xc-minimum-configuration.example_yaml——作为下游表单/工作流生成的确定性创建值的唯一可信来源。
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** 记录跨字段依赖关系，说明某个字段需要另一个字段被设置。
+- **Purpose:** 记录跨字段依赖关系，说明某字段需要另一字段被设置。
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
 - **Injected by:** scripts/utils/dependency_enricher.py
-- **Driven by config:** config/minimum_configs.yaml（dependencies 节）
+- **Driven by config:** config/minimum_configs.yaml (dependencies section)
 - **Example:** `"x-f5xc-requires": [{"field": "tls_config", "required": true, "reason": "use_tls requires tls_config sub-field"}]`
 - **Pass-through from upstream:** no
 
@@ -477,7 +503,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** 声明某字段在其作用域内是否必须唯一。
+- **Purpose:** 声明某字段是否必须在其作用域内唯一。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -489,7 +515,7 @@ i18n:
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** 该 API 属性在控制台表单中的控件元数据。
+- **Purpose:** 该 API 属性的控制台表单控件元数据。
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -503,7 +529,7 @@ i18n:
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** 列出操作请求体中必须提供的字段名称，以确保执行成功。
+- **Purpose:** 指定操作请求体中必须提供的字段名称以确保成功执行。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -515,7 +541,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** 对操作的爆炸半径进行分类（low/medium/high/critical）。
+- **Purpose:** 对操作的影响范围进行分级（low/medium/high/critical）。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -551,7 +577,7 @@ i18n:
 ### x-f5xc-discovered-response-time
 
 - **Applied at:** operation
-- **Purpose:** 发现过程中针对该操作实测的响应时间。
+- **Purpose:** 发现阶段对该操作实测的响应时间。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -563,7 +589,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** 从实时 API 获取的观测速率限制头信息/行为。
+- **Purpose:** 从实时 API 中观测到的速率限制头/行为。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -575,7 +601,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** 实时发现过程中观测到的错误响应目录，包含示例载荷。
+- **Purpose:** 实时发现期间观测到的错误响应目录，包含示例负载。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -613,7 +639,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** 需要特别谨慎处理的资源（生产关键型）。
+- **Purpose:** 需要特别谨慎对待的资源（生产关键资源）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -625,7 +651,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** 简短（约 60 字符）的域描述。也适用于属性级别的长描述。
+- **Purpose:** 简短（约 60 字符）域描述。也适用于属性级别的长描述。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -637,7 +663,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** 中等长度（约 150 字符）的域描述。也适用于属性级别。
+- **Purpose:** 中等长度（约 150 字符）域描述。也适用于属性级别。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -649,7 +675,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** 较长（约 500 字符）的域描述。
+- **Purpose:** 较长（约 500 字符）域描述。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -697,7 +723,7 @@ i18n:
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** 该域支持的命名用例。
+- **Purpose:** 该域支持的命名使用场景。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -721,7 +747,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** 表示该域的品牌 Logo 的内联 SVG（或路径）。
+- **Purpose:** 代表该域的品牌标志的内联 SVG（或路径）。
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -733,7 +759,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** 交叉链接到通常与该域一起使用的其他域。
+- **Purpose:** 交叉链接到通常与本域一起使用的其他域。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -745,7 +771,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** 渲染文档时的文档章节/导航分组 slug。
+- **Purpose:** 已渲染文档的文档章节/导航分组 slug。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -759,7 +785,7 @@ i18n:
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** 从 F5 上游规范原样保留。
+- **Purpose:** 原样保留自 F5 上游规范。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -771,7 +797,7 @@ i18n:
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** 从 F5 上游规范原样保留。
+- **Purpose:** 原样保留自 F5 上游规范。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -783,7 +809,7 @@ i18n:
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** 从 F5 上游规范原样保留。
+- **Purpose:** 原样保留自 F5 上游规范。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -795,7 +821,7 @@ i18n:
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** 从 F5 上游规范原样保留。
+- **Purpose:** 原样保留自 F5 上游规范。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -807,7 +833,7 @@ i18n:
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** 从 F5 上游规范原样保留。
+- **Purpose:** 原样保留自 F5 上游规范。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -819,7 +845,7 @@ i18n:
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** 从 F5 上游规范原样保留。
+- **Purpose:** 原样保留自 F5 上游规范。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -831,7 +857,7 @@ i18n:
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** 从 F5 上游规范原样保留。
+- **Purpose:** 原样保留自 F5 上游规范。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -843,7 +869,7 @@ i18n:
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** 从 F5 上游规范原样保留。
+- **Purpose:** 原样保留自 F5 上游规范。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -855,7 +881,7 @@ i18n:
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** 从 F5 上游规范原样保留。
+- **Purpose:** 原样保留自 F5 上游规范。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A

--- a/docs/zh-tw/extensions/catalog.md
+++ b/docs/zh-tw/extensions/catalog.md
@@ -1,29 +1,29 @@
 ---
-title: 擴充功能目錄（Enrichment Extension Catalog）
-description: 豐富化 OpenAPI 規格中每個 x-* 擴充功能的權威來源
+title: 擴充功能擴充目錄
+description: 豐富化 OpenAPI 規格中每個 x-* 擴充功能的真實來源
 i18n:
-  sourceHash: b7ee25e1b768
+  sourceHash: 3ed334783ced
   translator: machine
 ---
 
-# 擴充功能目錄（Enrichment Extension Catalog）
+# 擴充功能擴充目錄
 
-`docs/specifications/api/*.json` 中每個 `x-*` 擴充功能的權威來源。與
+`docs/specifications/api/*.json` 中每個 `x-*` 擴充功能的真實來源。與
 `scripts/utils/extension_constants.py` 的一致性由
-`tests/test_extension_catalog.py` 強制驗證。
+`tests/test_extension_catalog.py` 強制執行。
 
-本文件記錄了三類擴充功能：
+此處記錄三類擴充功能：
 
-- **此處注入** — 由我們的豐富化程序新增的擴充功能（`x-f5xc-*` 以及
+- **此處注入** — 我們的擴充程式所新增的擴充功能（`x-f5xc-*` 以及
   `x-ves-cli-*` / `x-ves-field-*` / `x-ves-operation-*` / 探索
   變體）。這些是下游工具應使用的擴充功能。
-- **上游直通** — F5 在來源規格中發出、由我們原封不動保留的擴充功能（`x-ves-proto-*`、`x-displayname` 等）。
-  記錄於此僅供參考，並非由本倉庫控制。
-- **未來注入** — 尚未發出；在豐富化程序開始產生時，即記錄於此（初始填充時不適用）。
+- **上游直通** — F5 在來源規格中發出並由我們原樣保留的擴充功能（`x-ves-proto-*`、`x-displayname` 等）。
+  為透明起見而記錄，但不受此儲存庫控制。
+- **未來注入** — 尚未發出；在擴充程式開始產生時即記錄於此（初始填充時不適用）。
 
 ## 條目結構
 
-以下每個條目均具備此固定格式。`tests/test_extension_catalog.py` 中的一致性測試允許章節內容精簡，只要 `### x-name` 標題存在，且 `Pass-through from upstream:` 旗標的值為 `yes` 或 `no` 即可。
+以下每個條目的格式如下。`tests/test_extension_catalog.py` 中的一致性測試允許章節內容為簡略形式，只要 `### x-name` 標題存在且 `Pass-through from upstream:` 旗標含有值 `yes` 或 `no` 即可。
 
     ### x-<name>
     - **Applied at:** <schema | parameter | operation | path-item | info | response>
@@ -36,12 +36,12 @@ i18n:
     - **Example:** <short snippet>
     - **Pass-through from upstream:** <yes/no>
 
-## 注入 — 規格層級（info 區段）
+## 注入 — 規格層級（info 章節）
 
 ### x-f5xc-cli-domain
 
 - **Applied at:** info
-- **Purpose:** 識別豐富化規格的 CLI 領域代稱（例如 `http_loadbalancer`）。
+- **Purpose:** 識別豐富化規格的 CLI 網域代稱（例如 `http_loadbalancer`）。
 - **Consumers:** CLI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -53,7 +53,7 @@ i18n:
 ### x-f5xc-cli-metadata
 
 - **Applied at:** info
-- **Purpose:** 涵蓋整個 CLI 的元資料區塊（工具名稱、版本提示、領域分組）。
+- **Purpose:** CLI 全域中繼資料區塊（工具名稱、版本提示、網域分組）。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -65,7 +65,7 @@ i18n:
 ### x-f5xc-upstream-timestamp
 
 - **Applied at:** info
-- **Purpose:** 豐富化檔案所依據的上游來源規格時間戳記。
+- **Purpose:** 建立豐富化檔案所依據的上游來源規格時間戳記。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -77,7 +77,7 @@ i18n:
 ### x-f5xc-upstream-etag
 
 - **Applied at:** info
-- **Purpose:** 上游來源規格發布資產的 ETag。
+- **Purpose:** 上游來源規格發佈資產的 ETag。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -89,7 +89,7 @@ i18n:
 ### x-f5xc-enriched-version
 
 - **Applied at:** info
-- **Purpose:** 由管線印記於豐富化規格上的語意版本號。
+- **Purpose:** 由管線標記於豐富化規格上的語意版本號。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -101,7 +101,7 @@ i18n:
 ### x-f5xc-glossary
 
 - **Applied at:** info
-- **Purpose:** 套用於各領域規格的品牌／術語詞彙表區塊。
+- **Purpose:** 套用於每個網域規格的品牌／術語辭彙表區塊。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -113,7 +113,7 @@ i18n:
 ### x-f5xc-discovered-at
 
 - **Applied at:** info
-- **Purpose:** 執行即時 API 探索的時間戳記。
+- **Purpose:** 執行即時 API 探索過程的時間戳記。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "date-time"}`
@@ -125,7 +125,7 @@ i18n:
 ### x-f5xc-api-url
 
 - **Applied at:** info
-- **Purpose:** 探索期間所探測的即時 API 基底 URL。
+- **Purpose:** 探索期間所探測的即時 API 基礎 URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -137,7 +137,7 @@ i18n:
 ### x-f5xc-api-reference-url
 
 - **Applied at:** info
-- **Purpose:** 此領域對應的托管 API 參考文件頁面 URL。
+- **Purpose:** 此網域的託管 API 參考文件頁面 URL。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "format": "uri"}`
@@ -149,7 +149,7 @@ i18n:
 ### x-f5xc-response-time-ms
 
 - **Applied at:** info
-- **Purpose:** 探索期間所觀測的 API 回應時間（毫秒）。
+- **Purpose:** 探索期間所探測的 API 觀測回應時間（毫秒）。
 - **Consumers:** multiple
 - **Value type:** number
 - **Value schema:** `{"type": "number"}`
@@ -161,7 +161,7 @@ i18n:
 ### x-f5xc-best-practices
 
 - **Applied at:** info
-- **Purpose:** 針對某一領域精選的最佳實踐指引。
+- **Purpose:** 針對某網域整理的最佳實務指引。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -173,7 +173,7 @@ i18n:
 ### x-f5xc-guided-workflows
 
 - **Applied at:** info
-- **Purpose:** 在某一領域中完成常見任務的具名逐步工作流程。
+- **Purpose:** 在網域中完成常見任務的具名逐步工作流程。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -185,7 +185,7 @@ i18n:
 ### x-f5xc-acronyms
 
 - **Applied at:** info
-- **Purpose:** 各領域的縮寫展開對照表。
+- **Purpose:** 每個網域的縮寫展開對照表。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "additionalProperties": {"type": "string"}}`
@@ -197,7 +197,7 @@ i18n:
 ### x-f5xc-console-navigation
 
 - **Applied at:** spec info
-- **Purpose:** 全域主控台導覽樹——工作區與選單層級結構。
+- **Purpose:** 全域主控台導覽樹 — 工作區與選單階層。
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"workspaces": "object"}}`
@@ -211,7 +211,7 @@ i18n:
 ### x-f5xc-minimum-configuration
 
 - **Applied at:** schema
-- **Purpose:** 成功 POST/PUT 此資源所需的最低可行欄位集。
+- **Purpose:** 成功 POST/PUT 此資源所需的最低可行欄位集合。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -223,7 +223,7 @@ i18n:
 ### x-f5xc-namespace-profile
 
 - **Applied at:** info
-- **Purpose:** 提供資源的命名空間限制、建議及分類元資料。
+- **Purpose:** 提供資源的命名空間限制、建議及分類中繼資料。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"constraint": {"type": "object"}, "recommendation": {"type": "object"}, "classification": {"type": "object"}}}`
@@ -259,7 +259,7 @@ i18n:
 ### x-f5xc-display-name
 
 - **Applied at:** schema
-- **Purpose:** 資源結構描述的人類可讀顯示名稱（覆蓋自動生成）。
+- **Purpose:** 資源結構描述的人類可讀顯示名稱（覆蓋自動產生的名稱）。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -285,7 +285,7 @@ i18n:
 ### x-f5xc-description
 
 - **Applied at:** schema property
-- **Purpose:** 補充上游 `description` 的豐富化屬性描述。
+- **Purpose:** 補充上游 `description` 的豐富化屬性說明。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -297,7 +297,7 @@ i18n:
 ### x-f5xc-validation
 
 - **Applied at:** schema property
-- **Purpose:** 源自上游 protobuf `ves.io.schema.rules` 的宣告式驗證規則。
+- **Purpose:** 從上游 protobuf `ves.io.schema.rules` 衍生的宣告式驗證規則。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -333,7 +333,7 @@ i18n:
 ### x-f5xc-completion
 
 - **Applied at:** schema property
-- **Purpose:** Shell 補全提示（靜態列舉或動態指令）。
+- **Purpose:** Shell 自動完成提示（靜態列舉或動態命令）。
 - **Consumers:** CLI
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -345,7 +345,7 @@ i18n:
 ### x-f5xc-defaults
 
 - **Applied at:** schema property
-- **Purpose:** 在生成的文件及 UI 中顯示的預設值。
+- **Purpose:** 在產生的文件與 UI 中顯示的預設值。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -357,7 +357,7 @@ i18n:
 ### x-f5xc-required-for-operations
 
 - **Applied at:** schema property
-- **Purpose:** 列出需要此屬性的 HTTP 操作（POST/PUT/⋯）。
+- **Purpose:** 列出需要此屬性的 HTTP 操作（POST/PUT/...）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -393,7 +393,7 @@ i18n:
 ### x-f5xc-deprecated
 
 - **Applied at:** schema property
-- **Purpose:** 包含替代方案指引的棄用通知。
+- **Purpose:** 含替代建議的棄用通知。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -405,7 +405,7 @@ i18n:
 ### x-f5xc-server-default
 
 - **Applied at:** schema property
-- **Purpose:** 客戶端省略此屬性時，伺服器所指定的預設值。
+- **Purpose:** 當用戶端省略該屬性時，伺服器所指派的預設值。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -417,7 +417,7 @@ i18n:
 ### x-f5xc-recommended-value
 
 - **Applied at:** schema property
-- **Purpose:** 當伺服器預設值並非最佳選擇時，欄位的建議生產環境值。
+- **Purpose:** 在伺服器預設值不夠理想時，欄位的建議生產環境值。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{}`
@@ -429,7 +429,7 @@ i18n:
 ### x-f5xc-recommended-oneof-variant
 
 - **Applied at:** schema property
-- **Purpose:** 針對 `oneOf` 區塊，指出建議使用的變體。
+- **Purpose:** 針對 `oneOf` 區塊，指示建議使用的變體。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -450,10 +450,34 @@ i18n:
 - **Example:** `"x-f5xc-conflicts-with": ["plaintext", "auto_cert"]`
 - **Pass-through from upstream:** no
 
+### x-f5xc-references
+
+- **Applied at:** schema property
+- **Purpose:** 宣告 ObjectRefType 欄位所參照的資源類型（必須先行存在的資源），包含 oneOf 選擇門控、建立時必填及基數 — 即依賴模型的資源參照維度。
+- **Consumers:** terraform, cli, mcp, IDE, ai-assistants
+- **Value type:** array
+- **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"resource_kind": {"type": ["string", "null"]}, "field_path": {"type": "string"}, "gated_by": {"type": ["object", "null"]}, "required": {"type": "boolean"}, "cardinality": {"type": "string"}}}}`
+- **Injected by:** scripts/utils/references_enricher.py
+- **Driven by config:** config/resource_references.yaml
+- **Example:** `"x-f5xc-references": [{"resource_kind": "app_firewall", "field_path": "app_firewall", "gated_by": {"choice": "waf_choice"}, "required": false, "cardinality": "single"}]`
+- **Pass-through from upstream:** no
+
+### x-f5xc-field-examples
+
+- **Applied at:** schema (CreateSpecType)
+- **Purpose:** 每個欄位的建立範例值（欄位路徑至值的扁平對應），衍生自 x-f5xc-minimum-configuration.example_yaml — 為下游表單／工作流程產生提供確定性建立值的唯一真實來源。
+- **Consumers:** cli, workflow-generator, sweep, ai-assistants
+- **Value type:** object
+- **Value schema:** `{"type": "object", "additionalProperties": true}`
+- **Injected by:** scripts/utils/example_field_enricher.py
+- **Driven by config:** derived from x-f5xc-minimum-configuration.example_yaml
+- **Example:** `"x-f5xc-field-examples": {"spec.port": 8080}`
+- **Pass-through from upstream:** no
+
 ### x-f5xc-requires
 
 - **Applied at:** schema property
-- **Purpose:** 記錄跨欄位相依關係，說明某一欄位需要另一欄位被設定。
+- **Purpose:** 記錄跨欄位依賴關係，其中一個欄位需要另一個欄位被設定。
 - **Consumers:** compile_catalog.py, xcsh CLI
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object", "properties": {"field": {"type": "string"}, "required": {"type": "boolean"}, "reason": {"type": "string"}}}}`
@@ -465,7 +489,7 @@ i18n:
 ### x-f5xc-constraints
 
 - **Applied at:** schema property
-- **Purpose:** 從即時 API 探測或靜態模式衍生的數值／字串約束。
+- **Purpose:** 從即時 API 探測或靜態模式衍生的數值／字串限制條件。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -477,7 +501,7 @@ i18n:
 ### x-f5xc-uniqueness
 
 - **Applied at:** schema property
-- **Purpose:** 宣告某一欄位是否在其範圍內必須唯一。
+- **Purpose:** 宣告欄位在其範圍內是否必須唯一。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -489,7 +513,7 @@ i18n:
 ### x-f5xc-console-field
 
 - **Applied at:** schema property
-- **Purpose:** 此 API 屬性的主控台表單小工具元資料。
+- **Purpose:** 此 API 屬性的主控台表單元件中繼資料。
 - **Consumers:** console-catalog, xcsh, browser-automation
 - **Value type:** object
 - **Value schema:** `{"type": "object", "properties": {"widget_type": "string", "label": "string", "default": "any", "selector": "string", "form_section": "string", "show_when": "object", "advanced": "boolean"}}`
@@ -503,7 +527,7 @@ i18n:
 ### x-f5xc-required-fields
 
 - **Applied at:** operation
-- **Purpose:** 指名操作本體中必須提供以確保成功的欄位。
+- **Purpose:** 列出操作本體中必須提供才能成功的欄位。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -515,7 +539,7 @@ i18n:
 ### x-f5xc-danger-level
 
 - **Applied at:** operation
-- **Purpose:** 分類操作的爆炸半徑（low／medium／high／critical）。
+- **Purpose:** 分類操作的影響範圍（low／medium／high／critical）。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high", "critical"]}`
@@ -527,7 +551,7 @@ i18n:
 ### x-f5xc-confirmation-required
 
 - **Applied at:** operation
-- **Purpose:** CLI／UI 在執行前是否應提示使用者確認。
+- **Purpose:** CLI／UI 是否應在執行前提示使用者確認。
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -539,7 +563,7 @@ i18n:
 ### x-f5xc-side-effects
 
 - **Applied at:** operation
-- **Purpose:** 列出操作可觀測的副作用（重啟、重新設定等）。
+- **Purpose:** 列出操作可觀察到的副作用（重新啟動、重新設定等）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -551,7 +575,7 @@ i18n:
 ### x-f5xc-discovered-response-time
 
 - **Applied at:** operation
-- **Purpose:** 探索期間對此操作實際量測的回應時間。
+- **Purpose:** 探索期間此操作的實測回應時間。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -563,7 +587,7 @@ i18n:
 ### x-f5xc-discovered-rate-limits
 
 - **Applied at:** operation
-- **Purpose:** 從即時 API 呈現的觀測速率限制標頭／行為。
+- **Purpose:** 從即時 API 顯示的觀測速率限制標頭／行為。
 - **Consumers:** multiple
 - **Value type:** object
 - **Value schema:** `{"type": "object"}`
@@ -575,7 +599,7 @@ i18n:
 ### x-f5xc-discovered-error-catalog
 
 - **Applied at:** operation
-- **Purpose:** 即時探索期間觀測到的錯誤回應目錄，含範例酬載。
+- **Purpose:** 即時探索期間觀測到的錯誤回應目錄，含樣本酬載。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "object"}}`
@@ -584,12 +608,12 @@ i18n:
 - **Example:** `"x-f5xc-discovered-error-catalog": [{"status": 400, "reason": "bad_request"}]`
 - **Pass-through from upstream:** no
 
-## 注入 — 索引層級（領域元資料）
+## 注入 — 索引層級（網域中繼資料）
 
 ### x-f5xc-category
 
 - **Applied at:** info
-- **Purpose:** 領域的頂層 CLI／UI／文件／Terraform 分組類別。
+- **Purpose:** 網域的頂層 CLI／UI／文件／Terraform 分組類別。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -601,7 +625,7 @@ i18n:
 ### x-f5xc-primary-resources
 
 - **Applied at:** info
-- **Purpose:** 定義領域的主要資源類型清單。
+- **Purpose:** 定義網域的主要資源類型清單。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -613,7 +637,7 @@ i18n:
 ### x-f5xc-critical-resources
 
 - **Applied at:** info
-- **Purpose:** 需要提高謹慎程度的資源（生產環境關鍵）。
+- **Purpose:** 需要提高注意等級的資源（生產關鍵）。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -625,7 +649,7 @@ i18n:
 ### x-f5xc-description-short
 
 - **Applied at:** info
-- **Purpose:** 簡短（約 60 字元）的領域描述，亦可套用於屬性層級的長描述。
+- **Purpose:** 簡短（約 60 字元）的網域說明。亦適用於屬性層級的長說明。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -637,7 +661,7 @@ i18n:
 ### x-f5xc-description-medium
 
 - **Applied at:** info
-- **Purpose:** 中等長度（約 150 字元）的領域描述，亦可套用於屬性層級。
+- **Purpose:** 中等長度（約 150 字元）的網域說明。亦適用於屬性層級。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -649,7 +673,7 @@ i18n:
 ### x-f5xc-description-long
 
 - **Applied at:** info
-- **Purpose:** 較長（約 500 字元）的領域描述。
+- **Purpose:** 詳細（約 500 字元）的網域說明。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -661,7 +685,7 @@ i18n:
 ### x-f5xc-complexity
 
 - **Applied at:** info
-- **Purpose:** 在此領域中撰寫設定的相對複雜度層級。
+- **Purpose:** 在此網域撰寫設定的相對複雜度層級。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string", "enum": ["low", "medium", "high"]}`
@@ -673,7 +697,7 @@ i18n:
 ### x-f5xc-requires-tier
 
 - **Applied at:** info
-- **Purpose:** 所需的最低 F5 XC 訂閱方案等級。
+- **Purpose:** 所需的最低 F5 XC 訂閱層級。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -685,7 +709,7 @@ i18n:
 ### x-f5xc-is-preview
 
 - **Applied at:** info
-- **Purpose:** 將某一領域標記為預覽／Beta 功能。
+- **Purpose:** 將網域標記為預覽／測試版功能。
 - **Consumers:** multiple
 - **Value type:** boolean
 - **Value schema:** `{"type": "boolean"}`
@@ -697,7 +721,7 @@ i18n:
 ### x-f5xc-use-cases
 
 - **Applied at:** info
-- **Purpose:** 此領域支援的具名使用案例。
+- **Purpose:** 此網域支援的具名使用案例。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -709,7 +733,7 @@ i18n:
 ### x-f5xc-icon
 
 - **Applied at:** info
-- **Purpose:** 在 UI 中呈現此領域時使用的圖示識別碼。
+- **Purpose:** 在 UI 中呈現此網域時使用的圖示識別碼。
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -721,7 +745,7 @@ i18n:
 ### x-f5xc-logo-svg
 
 - **Applied at:** info
-- **Purpose:** 代表此領域的品牌標誌內嵌 SVG（或路徑）。
+- **Purpose:** 代表該網域品牌標誌的內聯 SVG（或路徑）。
 - **Consumers:** Web UI
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -733,7 +757,7 @@ i18n:
 ### x-f5xc-related-domains
 
 - **Applied at:** info
-- **Purpose:** 交叉連結至通常與此領域一同使用的其他領域。
+- **Purpose:** 交叉連結至通常與此網域一起使用的其他網域。
 - **Consumers:** multiple
 - **Value type:** array
 - **Value schema:** `{"type": "array", "items": {"type": "string"}}`
@@ -745,7 +769,7 @@ i18n:
 ### x-f5xc-doc-section
 
 - **Applied at:** info
-- **Purpose:** 渲染文件時使用的文件章節／導覽分組代稱。
+- **Purpose:** 已呈現文件的文件章節／導覽分組代稱。
 - **Consumers:** multiple
 - **Value type:** string
 - **Value schema:** `{"type": "string"}`
@@ -759,7 +783,7 @@ i18n:
 ### x-ves-proto-package
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規格原封不動保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -771,7 +795,7 @@ i18n:
 ### x-ves-proto-file
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規格原封不動保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -783,7 +807,7 @@ i18n:
 ### x-ves-proto-message
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規格原封不動保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -795,7 +819,7 @@ i18n:
 ### x-ves-proto-service
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規格原封不動保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -807,7 +831,7 @@ i18n:
 ### x-ves-proto-rpc
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規格原封不動保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -819,7 +843,7 @@ i18n:
 ### x-displayname
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規格原封不動保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -831,7 +855,7 @@ i18n:
 ### x-ves-oneof
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規格原封不動保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -843,7 +867,7 @@ i18n:
 ### x-ves-default
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規格原封不動保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A
@@ -855,7 +879,7 @@ i18n:
 ### x-ves-required
 
 - **Applied at:** upstream
-- **Purpose:** 從 F5 上游規格原封不動保留。
+- **Purpose:** 從 F5 上游規格原樣保留。
 - **Consumers:** N/A
 - **Value type:** varies
 - **Value schema:** N/A

--- a/scripts/build_dependency_graph.py
+++ b/scripts/build_dependency_graph.py
@@ -66,8 +66,14 @@ def collect_edges(specs: list[dict[str, Any]]) -> list[Edge]:
                     key = (src, target)
                     # Prefer the strongest edge: required + unconditional wins.
                     prior = edges.get(key)
-                    if prior is None or (required and not prior.required) or (not conditional and prior.conditional):
-                        edges[key] = Edge(src=src, target=target, conditional=conditional, required=required)
+                    if (
+                        prior is None
+                        or (required and not prior.required)
+                        or (not conditional and prior.conditional)
+                    ):
+                        edges[key] = Edge(
+                            src=src, target=target, conditional=conditional, required=required
+                        )
     return list(edges.values())
 
 

--- a/scripts/build_dependency_graph.py
+++ b/scripts/build_dependency_graph.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Generate config/resource_dependency_graph.json as a PROJECTION.
+
+DRY: the coarse resource→dependency graph is derived from the per-field
+``x-f5xc-references`` extensions (the single source of truth), never hand-maintained.
+Each reference edge carries `conditional` (true when the source field is gated by a
+oneOf choice) and `required` so consumers can distinguish must-create-first deps from
+optional/conditional ones. A topological order is included for deterministic CRUD
+provisioning.
+
+Run after enrichment (the references must be stamped first):
+    python -m scripts.build_dependency_graph
+"""
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scripts.utils.extension_constants import X_F5XC_REFERENCES
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Edge:
+    """A dependency edge: src resource references target resource-kind."""
+
+    src: str
+    target: str
+    conditional: bool
+    required: bool
+
+
+def _schema_to_resource(schema_name: str) -> str | None:
+    """Map a CreateSpecType schema name to a kebab resource id, else None."""
+    if "CreateSpecType" not in schema_name:
+        return None
+    kind = re.sub(r"^(views|schema)", "", schema_name.replace("CreateSpecType", ""))
+    return kind.replace("_", "-") or None
+
+
+def collect_edges(specs: list[dict[str, Any]]) -> list[Edge]:
+    """Collect dependency edges from x-f5xc-references across enriched specs."""
+    edges: dict[tuple[str, str], Edge] = {}
+    for spec in specs:
+        for schema_name, schema in spec.get("components", {}).get("schemas", {}).items():
+            src = _schema_to_resource(schema_name)
+            if not src or not isinstance(schema, dict):
+                continue
+            for prop in (schema.get("properties") or {}).values():
+                if not isinstance(prop, dict):
+                    continue
+                for ref in prop.get(X_F5XC_REFERENCES, []) or []:
+                    kind = ref.get("resource_kind")
+                    if not kind:
+                        continue  # unresolved — excluded from the coarse graph
+                    target = kind.replace("_", "-")
+                    if target == src:
+                        continue
+                    conditional = ref.get("gated_by") is not None
+                    required = bool(ref.get("required"))
+                    key = (src, target)
+                    # Prefer the strongest edge: required + unconditional wins.
+                    prior = edges.get(key)
+                    if prior is None or (required and not prior.required) or (not conditional and prior.conditional):
+                        edges[key] = Edge(src=src, target=target, conditional=conditional, required=required)
+    return list(edges.values())
+
+
+def project_graph(edges: list[Edge], resource_ids: list[str]) -> dict[str, Any]:
+    """Project edges into a graph with topological order, leaves, prerequisites."""
+    by_src: dict[str, list[Edge]] = {}
+    for e in edges:
+        by_src.setdefault(e.src, []).append(e)
+
+    # Kahn's algorithm; deps (targets) come before dependents (srcs).
+    deps: dict[str, set[str]] = {r: set() for r in resource_ids}
+    for e in edges:
+        if e.src in deps and e.target in deps:
+            deps[e.src].add(e.target)
+
+    sorted_ids: list[str] = []
+    visited: set[str] = set()
+    # Repeatedly take nodes whose deps are all satisfied.
+    remaining = set(resource_ids)
+    progress = True
+    while remaining and progress:
+        progress = False
+        for r in sorted(remaining):
+            if deps[r] <= visited:
+                sorted_ids.append(r)
+                visited.add(r)
+                remaining.discard(r)
+                progress = True
+    # Cycles / leftovers appended deterministically.
+    sorted_ids.extend(sorted(remaining))
+
+    edge_out = {
+        src: [
+            {"target": e.target, "conditional": e.conditional, "required": e.required}
+            for e in sorted(items, key=lambda x: x.target)
+        ]
+        for src, items in sorted(by_src.items())
+    }
+    targets = {e.target for e in edges}
+    return {
+        "edges": edge_out,
+        "sorted": sorted_ids,
+        "leaves": sorted([r for r in resource_ids if not deps.get(r)]),
+        "prerequisites": sorted([r for r in resource_ids if r in targets]),
+    }
+
+
+def main() -> int:
+    """Build the projection from enriched specs and write the graph JSON."""
+    specs_dir = Path("docs/specifications/api")
+    specs: list[dict[str, Any]] = []
+    for f in sorted(specs_dir.glob("*.json")):
+        if f.name == "index.json":
+            continue
+        try:
+            specs.append(json.loads(f.read_text()))
+        except (ValueError, OSError):
+            continue
+    resource_ids = sorted(
+        {
+            r
+            for spec in specs
+            for n in spec.get("components", {}).get("schemas", {})
+            if (r := _schema_to_resource(n))
+        }
+    )
+    edges = collect_edges(specs)
+    graph = project_graph(edges, resource_ids)
+    graph = {
+        "description": "Resource dependency graph — PROJECTION of per-field x-f5xc-references (single source of truth).",
+        "source": "Generated by scripts/build_dependency_graph.py from enriched specs' x-f5xc-references.",
+        "edge_count": len(edges),
+        **graph,
+    }
+    out = Path("config/resource_dependency_graph.json")
+    out.write_text(json.dumps(graph, indent=2) + "\n")
+    logger.info("wrote %s: %d edges", out, len(edges))
+    print(f"wrote {out}: {len(edges)} edges, {len(graph['prerequisites'])} prerequisites")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -95,6 +95,7 @@ from scripts.utils import (
     OperationMetadataEnricher,
     PropertyDescriptionShortEnricher,
     ReadOnlyEnricher,
+    ReferencesEnricher,
     ResourceExamplesEnricher,
     SchemaFixer,
     SchemaOverrideEnricher,
@@ -1176,6 +1177,9 @@ def merge_specs_by_domain(
     # Load dependency enricher — stamps x-f5xc-requires for cross-field deps
     dependency_enricher = DependencyEnricher()
 
+    # Load references enricher — stamps x-f5xc-references for resource-reference deps
+    references_enricher = ReferencesEnricher.from_config()
+
     # Load constrained fields enricher — stamps enum/range constraints from config
     constrained_fields_enricher = ConstrainedFieldsEnricher()
 
@@ -1358,6 +1362,13 @@ def merge_specs_by_domain(
         stats.setdefault("dependencies_added", 0)
         stats["dependencies_added"] += dep_stats.get("dependencies_added", 0)
         dependency_enricher.reset_stats()
+
+        # Resource references: stamp x-f5xc-references on ObjectRefType properties
+        merged_spec = references_enricher.enrich_spec(merged_spec)
+        ref_stats = references_enricher.get_stats()
+        stats.setdefault("references_stamped", 0)
+        stats["references_stamped"] += ref_stats.get("references_stamped", 0)
+        references_enricher.reset_stats()
 
         # Constrained fields: stamp enum/range constraints from minimum_configs.yaml
         merged_spec = constrained_fields_enricher.enrich_spec(merged_spec)

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -85,6 +85,7 @@ from scripts.utils import (
     DescriptionValidator,
     DiscoveryEnricher,
     ErrorResolutionEnricher,
+    ExampleFieldEnricher,
     ExternalDocsEnricher,
     FieldDescriptionEnricher,
     GrammarImprover,
@@ -95,7 +96,6 @@ from scripts.utils import (
     OperationMetadataEnricher,
     PropertyDescriptionShortEnricher,
     ReadOnlyEnricher,
-    ExampleFieldEnricher,
     ReferencesEnricher,
     ResourceExamplesEnricher,
     SchemaFixer,
@@ -384,7 +384,8 @@ def enrich_spec(spec: dict[str, Any], config: dict) -> tuple[dict[str, Any], dic
     return spec, {
         "field_count": field_count,
         "schemas_fixed": schema_stats.get("fixes_applied", 0),
-        "descriptions_generated": desc_stats.get("operations_generated", 0) + desc_stats.get("schemas_generated", 0),
+        "descriptions_generated": desc_stats.get("operations_generated", 0)
+        + desc_stats.get("schemas_generated", 0),
         "consistency_issues": consistency_stats.get("total_issues", 0),
         "domains_normalized": domain_normalize_count,
         "field_descriptions_added": field_desc_stats.get("descriptions_added", 0),
@@ -665,7 +666,11 @@ def _remove_empty_operations(spec: dict[str, Any]) -> tuple[dict[str, Any], int]
             del path_item[method]
             removed_count += 1
 
-        remaining = [m for m in ["get", "post", "put", "delete", "patch", "options", "head", "trace"] if m in path_item]
+        remaining = [
+            m
+            for m in ["get", "post", "put", "delete", "patch", "options", "head", "trace"]
+            if m in path_item
+        ]
         if not remaining:
             paths_to_remove.append(path)
 
@@ -1118,14 +1123,17 @@ def merge_specs_by_domain(
             domain_specs["data_intelligence"].append((filename, spec))
 
         # Also add specs to threat_campaign domain if they contain threat_campaign/threat_mesh paths
-        has_threat_campaign_paths = any("/api/waf/threat_campaign" in p or "/threat_mesh" in p for p in paths)
+        has_threat_campaign_paths = any(
+            "/api/waf/threat_campaign" in p or "/threat_mesh" in p for p in paths
+        )
         if has_threat_campaign_paths and domain != "threat_campaign":
             domain_specs["threat_campaign"].append((filename, spec))
 
         # Also add specs to system domain if they contain credential management paths
         # Pattern-based detection for credential/token management under /api/web/
         has_credential_paths = any(
-            "/api/web/" in p and ("/api_credentials" in p or "/service_credentials" in p or "/scim_token" in p)
+            "/api/web/" in p
+            and ("/api_credentials" in p or "/service_credentials" in p or "/scim_token" in p)
             for p in paths
         )
         if has_credential_paths and domain != "authentication":
@@ -1239,7 +1247,9 @@ def merge_specs_by_domain(
                     continue
 
                 # Skip threat_campaign/threat_mesh paths if not merging into threat_campaign domain
-                if not is_threat_campaign_domain and ("/api/waf/threat_campaign" in path or "/threat_mesh" in path):
+                if not is_threat_campaign_domain and (
+                    "/api/waf/threat_campaign" in path or "/threat_mesh" in path
+                ):
                     continue
 
                 # Skip data-intelligence paths if not merging into data_intelligence domain
@@ -1253,7 +1263,9 @@ def merge_specs_by_domain(
                 # Skip credential management paths if not merging into authentication domain
                 # Pattern-based: /api/web/ + (api_credentials|service_credentials|scim_token)
                 is_credential_path = "/api/web/" in path and (
-                    "/api_credentials" in path or "/service_credentials" in path or "/scim_token" in path
+                    "/api_credentials" in path
+                    or "/service_credentials" in path
+                    or "/scim_token" in path
                 )
                 if not is_auth_domain and is_credential_path:
                     continue
@@ -1272,7 +1284,9 @@ def merge_specs_by_domain(
                         if method not in merged_spec["paths"][path]:
                             merged_spec["paths"][path][method] = operation
                             stats["paths"] += 1
-                        elif isinstance(operation, dict) and isinstance(merged_spec["paths"][path].get(method), dict):
+                        elif isinstance(operation, dict) and isinstance(
+                            merged_spec["paths"][path].get(method), dict
+                        ):
                             existing = merged_spec["paths"][path][method]
                             for k, v in operation.items():
                                 if k not in existing:

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -95,6 +95,7 @@ from scripts.utils import (
     OperationMetadataEnricher,
     PropertyDescriptionShortEnricher,
     ReadOnlyEnricher,
+    ExampleFieldEnricher,
     ReferencesEnricher,
     ResourceExamplesEnricher,
     SchemaFixer,
@@ -1180,6 +1181,9 @@ def merge_specs_by_domain(
     # Load references enricher — stamps x-f5xc-references for resource-reference deps
     references_enricher = ReferencesEnricher.from_config()
 
+    # Load example-field enricher — derives per-field create examples from example_yaml
+    example_field_enricher = ExampleFieldEnricher()
+
     # Load constrained fields enricher — stamps enum/range constraints from config
     constrained_fields_enricher = ConstrainedFieldsEnricher()
 
@@ -1369,6 +1373,13 @@ def merge_specs_by_domain(
         stats.setdefault("references_stamped", 0)
         stats["references_stamped"] += ref_stats.get("references_stamped", 0)
         references_enricher.reset_stats()
+
+        # Per-field create examples: derive x-f5xc-field-examples from example_yaml
+        merged_spec = example_field_enricher.enrich_spec(merged_spec)
+        ex_stats = example_field_enricher.get_stats()
+        stats.setdefault("example_fields_stamped", 0)
+        stats["example_fields_stamped"] += ex_stats.get("fields_stamped", 0)
+        example_field_enricher.reset_stats()
 
         # Constrained fields: stamp enum/range constraints from minimum_configs.yaml
         merged_spec = constrained_fields_enricher.enrich_spec(merged_spec)

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -22,6 +22,7 @@ from .description_validator import DescriptionValidator
 from .discovery_enricher import DiscoveryEnricher
 from .domain_categorizer import DomainCategorizer, categorize_spec
 from .error_resolution_enricher import ErrorResolutionEnricher
+from .example_field_enricher import ExampleFieldEnricher
 from .external_docs_enricher import ExternalDocsEnricher
 from .field_description_enricher import FieldDescriptionEnricher
 from .field_metadata_enricher import FieldMetadataEnricher
@@ -71,6 +72,7 @@ __all__ = [
     "DiscoveryEnricher",
     "DomainCategorizer",
     "ErrorResolutionEnricher",
+    "ExampleFieldEnricher",
     "ExternalDocsEnricher",
     "FieldDescriptionEnricher",
     "FieldMetadataEnricher",

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -33,6 +33,7 @@ from .operation_description_enricher import OperationDescriptionEnricher
 from .operation_metadata_enricher import OperationMetadataEnricher
 from .property_description_short_enricher import PropertyDescriptionShortEnricher
 from .readonly_enricher import ReadOnlyEnricher
+from .references_enricher import ReferencesEnricher
 from .resource_examples_enricher import ResourceExamplesEnricher
 from .schema_fixer import SchemaFixer
 from .schema_override_enricher import SchemaOverrideEnricher
@@ -81,6 +82,7 @@ __all__ = [
     "OperationMetadataEnricher",
     "PropertyDescriptionShortEnricher",
     "ReadOnlyEnricher",
+    "ReferencesEnricher",
     "ResourceExamplesEnricher",
     "SchemaFixer",
     "SchemaOverrideEnricher",

--- a/scripts/utils/example_field_enricher.py
+++ b/scripts/utils/example_field_enricher.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Per-field example enricher for OpenAPI specifications.
+
+Derives deterministic per-field create values from the single source of truth —
+``x-f5xc-minimum-configuration.example_yaml`` (present for 331/333 CreateSpecType
+schemas) — and stamps them as ``x-f5xc-field-examples`` (a flat field_path → value
+map) on each CreateSpecType. Downstream consumers (console_field_metadata
+generation, the workflow generator, the sweep) read create values from this one
+place instead of hand-coding them in a downstream tool.
+
+This closes the determinism loop: the spec is the single source; when testing
+(CDP error triage) reveals a field the example_yaml does not cover, that gap is
+fixed in the spec and republished — every downstream project benefits at once.
+
+Issue: bake create-value determinism into the spec (DRY single source).
+"""
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+X_F5XC_FIELD_EXAMPLES = "x-f5xc-field-examples"
+
+
+def flatten_example(obj: Any, prefix: str = "spec") -> dict[str, Any]:
+    """Flatten a parsed example ``spec`` object to leaf field_path → value.
+
+    Lists collapse to their first element with a ``[]`` segment, so
+    ``origin_servers: [{public_name: {dns_name: x}}]`` →
+    ``spec.origin_servers[].public_name.dns_name: x``.
+    """
+    out: dict[str, Any] = {}
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            out.update(flatten_example(v, f"{prefix}.{k}" if prefix else str(k)))
+    elif isinstance(obj, list):
+        if obj:
+            out.update(flatten_example(obj[0], f"{prefix}[]"))
+    else:
+        out[prefix] = obj
+    return out
+
+
+@dataclass
+class ExampleFieldEnrichmentStats:
+    """Statistics for example-field enrichment."""
+
+    schemas_processed: int = 0
+    schemas_stamped: int = 0
+    fields_stamped: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert stats to a serializable dictionary."""
+        return {
+            "schemas_processed": self.schemas_processed,
+            "schemas_stamped": self.schemas_stamped,
+            "fields_stamped": self.fields_stamped,
+        }
+
+
+class ExampleFieldEnricher:
+    """Stamp ``x-f5xc-field-examples`` on CreateSpecType schemas from example_yaml."""
+
+    def __init__(self) -> None:
+        """Create the enricher with zeroed stats."""
+        self.stats = ExampleFieldEnrichmentStats()
+
+    def get_stats(self) -> dict[str, Any]:
+        """Return enrichment stats."""
+        return self.stats.to_dict()
+
+    def reset_stats(self) -> None:
+        """Reset stats (called per domain to avoid cross-domain accumulation)."""
+        self.stats = ExampleFieldEnrichmentStats()
+
+    def enrich_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Stamp x-f5xc-field-examples on every CreateSpecType with an example_yaml."""
+        for name, schema in spec.get("components", {}).get("schemas", {}).items():
+            if "CreateSpecType" not in name or not isinstance(schema, dict):
+                continue
+            self.stats.schemas_processed += 1
+            self._enrich_schema(schema)
+        return spec
+
+    def _enrich_schema(self, schema: dict[str, Any]) -> None:
+        mc = schema.get("x-f5xc-minimum-configuration")
+        if not isinstance(mc, dict):
+            return
+        example_yaml = mc.get("example_yaml")
+        if not example_yaml:
+            return
+        try:
+            parsed = yaml.safe_load(example_yaml)
+        except yaml.YAMLError:
+            return
+        if not isinstance(parsed, dict):
+            return
+        spec_obj = parsed.get("spec")
+        if not isinstance(spec_obj, dict):
+            return
+        examples = flatten_example(spec_obj)
+        if not examples:
+            return
+        schema[X_F5XC_FIELD_EXAMPLES] = examples
+        self.stats.schemas_stamped += 1
+        self.stats.fields_stamped += len(examples)

--- a/scripts/utils/example_field_enricher.py
+++ b/scripts/utils/example_field_enricher.py
@@ -24,7 +24,7 @@ import yaml
 
 logger = logging.getLogger(__name__)
 
-X_F5XC_FIELD_EXAMPLES = "x-f5xc-field-examples"
+from .extension_constants import X_F5XC_FIELD_EXAMPLES  # noqa: E402 (re-exported)
 
 
 def flatten_example(obj: Any, prefix: str = "spec") -> dict[str, Any]:

--- a/scripts/utils/extension_constants.py
+++ b/scripts/utils/extension_constants.py
@@ -77,6 +77,7 @@ X_F5XC_RECOMMENDED_ONEOF_VARIANT = "x-f5xc-recommended-oneof-variant"
 X_F5XC_CONFLICTS_WITH = "x-f5xc-conflicts-with"
 X_F5XC_CONSTRAINTS = "x-f5xc-constraints"
 X_F5XC_REQUIRES = "x-f5xc-requires"
+X_F5XC_REFERENCES = "x-f5xc-references"
 X_F5XC_UNIQUENESS = "x-f5xc-uniqueness"
 
 # Console UI field enrichment (Issue #679)
@@ -188,6 +189,7 @@ VALID_X_F5XC_EXTENSIONS = frozenset(
         X_F5XC_CONFLICTS_WITH,
         X_F5XC_CONSTRAINTS,
         X_F5XC_REQUIRES,
+        X_F5XC_REFERENCES,
         X_F5XC_UNIQUENESS,
         # Operation-level
         X_F5XC_REQUIRED_FIELDS,

--- a/scripts/utils/extension_constants.py
+++ b/scripts/utils/extension_constants.py
@@ -78,6 +78,7 @@ X_F5XC_CONFLICTS_WITH = "x-f5xc-conflicts-with"
 X_F5XC_CONSTRAINTS = "x-f5xc-constraints"
 X_F5XC_REQUIRES = "x-f5xc-requires"
 X_F5XC_REFERENCES = "x-f5xc-references"
+X_F5XC_FIELD_EXAMPLES = "x-f5xc-field-examples"
 X_F5XC_UNIQUENESS = "x-f5xc-uniqueness"
 
 # Console UI field enrichment (Issue #679)
@@ -190,6 +191,7 @@ VALID_X_F5XC_EXTENSIONS = frozenset(
         X_F5XC_CONSTRAINTS,
         X_F5XC_REQUIRES,
         X_F5XC_REFERENCES,
+        X_F5XC_FIELD_EXAMPLES,
         X_F5XC_UNIQUENESS,
         # Operation-level
         X_F5XC_REQUIRED_FIELDS,

--- a/scripts/utils/references_enricher.py
+++ b/scripts/utils/references_enricher.py
@@ -64,6 +64,7 @@ class ReferencesEnricher:
                 deterministic source of the target kind (F5 specs do not carry it).
         """
         self.kind_map = kind_map or {}
+        self.field_defaults: dict[str, str] = {}
         self.stats = ReferencesEnrichmentStats()
 
     @classmethod
@@ -76,6 +77,11 @@ class ReferencesEnricher:
             refs = data.get("references", {})
             if isinstance(refs, dict):
                 kind_map = {str(k): str(v) for k, v in refs.items()}
+            defaults = data.get("field_defaults", {})
+            if isinstance(defaults, dict):
+                enricher = cls(kind_map=kind_map)
+                enricher.field_defaults = {str(k): str(v) for k, v in defaults.items()}
+                return enricher
         else:
             logger.warning("resource_references.yaml not found at %s — kinds will be null", path)
         return cls(kind_map=kind_map)
@@ -138,7 +144,8 @@ class ReferencesEnricher:
     def _stamp(self, schema_name: str, field_name: str, prop: dict[str, Any], gate_group: str | None) -> None:
         if X_F5XC_REFERENCES in prop:  # idempotent
             return
-        kind = self.kind_map.get(f"{schema_name}.{field_name}")
+        # Resolution order: exact <schema>.<field> → field-name default → null (honest gap).
+        kind = self.kind_map.get(f"{schema_name}.{field_name}") or self.field_defaults.get(field_name)
         if kind is None:
             self.stats.references_unmapped += 1
             logger.debug("unmapped ObjectRef: %s.%s", schema_name, field_name)

--- a/scripts/utils/references_enricher.py
+++ b/scripts/utils/references_enricher.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Resource-reference enricher for OpenAPI specifications.
+
+Stamps ``x-f5xc-references`` on ObjectRefType properties — the resource-reference
+dimension of the dependency model. A reference field points at ANOTHER resource
+that must exist before this one is created; the choice-gating (which oneOf branch
+exposes the field) and required-ness come from the surrounding schema.
+
+Two facts about F5 specs drive the design (see resource-dependency-enrichment memo):
+- ObjectRefType is GENERIC (name/namespace/tenant) — it does NOT name the target
+  resource kind. So the kind is resolved from a CURATED map keyed by
+  ``<schema>.<field>`` (config/resource_references.yaml). Unmapped fields stamp
+  ``resource_kind: null`` rather than guessing.
+- Required references are often nested inside oneOf choice-variant sub-schemas, so
+  the top-level scan also records the oneOf group that gates each field.
+
+Reuses oneOf-group extraction (choice-gating) — see ConflictsWithEnricher.
+
+Issue: resource-reference dependency metadata (x-f5xc-references)
+"""
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from .extension_constants import X_F5XC_REFERENCES, X_VES_ONEOF_FIELD_PREFIX
+
+logger = logging.getLogger(__name__)
+
+# Substrings in an allOf $ref target that mark a resource reference.
+_REF_MARKERS = ("ObjectRefType", "RefType", "RefSelector")
+
+
+@dataclass
+class ReferencesEnrichmentStats:
+    """Statistics for reference enrichment."""
+
+    schemas_processed: int = 0
+    references_stamped: int = 0
+    references_unmapped: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert stats to a serializable dictionary."""
+        return {
+            "schemas_processed": self.schemas_processed,
+            "references_stamped": self.references_stamped,
+            "references_unmapped": self.references_unmapped,
+        }
+
+
+class ReferencesEnricher:
+    """Enrich OpenAPI specs with ``x-f5xc-references`` on ObjectRefType properties."""
+
+    def __init__(self, kind_map: dict[str, str] | None = None) -> None:
+        """Create the enricher.
+
+        Args:
+            kind_map: Curated ``<schema>.<field>`` → referred resource-kind map. The
+                deterministic source of the target kind (F5 specs do not carry it).
+        """
+        self.kind_map = kind_map or {}
+        self.stats = ReferencesEnrichmentStats()
+
+    def get_stats(self) -> dict[str, Any]:
+        """Return enrichment stats as a dictionary."""
+        return self.stats.to_dict()
+
+    def reset_stats(self) -> None:
+        """Reset stats (called per domain to avoid cross-domain accumulation)."""
+        self.stats = ReferencesEnrichmentStats()
+
+    def enrich_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
+        """Stamp x-f5xc-references on ObjectRefType properties of every CreateSpecType."""
+        schemas = spec.get("components", {}).get("schemas", {})
+        for schema_name, schema in schemas.items():
+            if not isinstance(schema, dict):
+                continue
+            self.stats.schemas_processed += 1
+            self._enrich_schema(schema_name, schema)
+        return spec
+
+    def _enrich_schema(self, schema_name: str, schema: dict[str, Any]) -> None:
+        props = schema.get("properties")
+        if not isinstance(props, dict):
+            return
+        # Map each field to the oneOf group that gates it (choice-gating).
+        field_gate = self._field_to_oneof_group(schema)
+        for field_name, prop in props.items():
+            if not isinstance(prop, dict) or not self._is_object_ref(prop):
+                continue
+            self._stamp(schema_name, field_name, prop, field_gate.get(field_name))
+
+    def _is_object_ref(self, prop: dict[str, Any]) -> bool:
+        """True when a property is an ObjectRefType reference (allOf → *RefType)."""
+        for entry in prop.get("allOf", []) or []:
+            ref = entry.get("$ref", "") if isinstance(entry, dict) else ""
+            if any(marker in ref for marker in _REF_MARKERS):
+                return True
+        return False
+
+    def _field_to_oneof_group(self, schema: dict[str, Any]) -> dict[str, str]:
+        """Reverse-map each variant field → its oneOf group name (the gating choice)."""
+        mapping: dict[str, str] = {}
+        for key, value in schema.items():
+            if not key.startswith(X_VES_ONEOF_FIELD_PREFIX):
+                continue
+            group = key[len(X_VES_ONEOF_FIELD_PREFIX) :]
+            variants = value
+            if isinstance(value, str):
+                try:
+                    variants = json.loads(value)
+                except (ValueError, TypeError):
+                    continue
+            if isinstance(variants, list):
+                for v in variants:
+                    mapping[v] = group
+        return mapping
+
+    def _stamp(self, schema_name: str, field_name: str, prop: dict[str, Any], gate_group: str | None) -> None:
+        if X_F5XC_REFERENCES in prop:  # idempotent
+            return
+        kind = self.kind_map.get(f"{schema_name}.{field_name}")
+        if kind is None:
+            self.stats.references_unmapped += 1
+            logger.debug("unmapped ObjectRef: %s.%s", schema_name, field_name)
+        required = bool(prop.get("x-f5xc-required-for", {}).get("create", False))
+        cardinality = "list" if prop.get("type") == "array" else "single"
+        descriptor: dict[str, Any] = {
+            "resource_kind": kind,
+            "field_path": field_name,
+            "gated_by": {"choice": gate_group} if gate_group else None,
+            "required": required,
+            "cardinality": cardinality,
+        }
+        prop[X_F5XC_REFERENCES] = [descriptor]
+        self.stats.references_stamped += 1

--- a/scripts/utils/references_enricher.py
+++ b/scripts/utils/references_enricher.py
@@ -23,7 +23,10 @@ Issue: resource-reference dependency metadata (x-f5xc-references)
 import json
 import logging
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
+
+import yaml
 
 from .extension_constants import X_F5XC_REFERENCES, X_VES_ONEOF_FIELD_PREFIX
 
@@ -62,6 +65,20 @@ class ReferencesEnricher:
         """
         self.kind_map = kind_map or {}
         self.stats = ReferencesEnrichmentStats()
+
+    @classmethod
+    def from_config(cls, config_path: Path | str = Path("config/resource_references.yaml")) -> "ReferencesEnricher":
+        """Build an enricher with the curated referred-kind map loaded from YAML."""
+        path = Path(config_path)
+        kind_map: dict[str, str] = {}
+        if path.exists():
+            data = yaml.safe_load(path.read_text()) or {}
+            refs = data.get("references", {})
+            if isinstance(refs, dict):
+                kind_map = {str(k): str(v) for k, v in refs.items()}
+        else:
+            logger.warning("resource_references.yaml not found at %s — kinds will be null", path)
+        return cls(kind_map=kind_map)
 
     def get_stats(self) -> dict[str, Any]:
         """Return enrichment stats as a dictionary."""

--- a/scripts/utils/references_enricher.py
+++ b/scripts/utils/references_enricher.py
@@ -68,7 +68,9 @@ class ReferencesEnricher:
         self.stats = ReferencesEnrichmentStats()
 
     @classmethod
-    def from_config(cls, config_path: Path | str = Path("config/resource_references.yaml")) -> "ReferencesEnricher":
+    def from_config(
+        cls, config_path: Path | str = Path("config/resource_references.yaml")
+    ) -> "ReferencesEnricher":
         """Build an enricher with the curated referred-kind map loaded from YAML."""
         path = Path(config_path)
         kind_map: dict[str, str] = {}
@@ -141,11 +143,15 @@ class ReferencesEnricher:
                     mapping[v] = group
         return mapping
 
-    def _stamp(self, schema_name: str, field_name: str, prop: dict[str, Any], gate_group: str | None) -> None:
+    def _stamp(
+        self, schema_name: str, field_name: str, prop: dict[str, Any], gate_group: str | None
+    ) -> None:
         if X_F5XC_REFERENCES in prop:  # idempotent
             return
         # Resolution order: exact <schema>.<field> → field-name default → null (honest gap).
-        kind = self.kind_map.get(f"{schema_name}.{field_name}") or self.field_defaults.get(field_name)
+        kind = self.kind_map.get(f"{schema_name}.{field_name}") or self.field_defaults.get(
+            field_name
+        )
         if kind is None:
             self.stats.references_unmapped += 1
             logger.debug("unmapped ObjectRef: %s.%s", schema_name, field_name)

--- a/tests/test_dependency_graph_projection.py
+++ b/tests/test_dependency_graph_projection.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Unit tests for the dependency-graph projection.
+
+The coarse resource_dependency_graph.json is a PROJECTION of the per-field
+x-f5xc-references (single source of truth) — not hand-maintained. Edges that
+come from a choice-gated reference are flagged conditional.
+"""
+
+from scripts.build_dependency_graph import Edge, project_graph
+
+
+def test_topological_order_dependencies_before_dependents():
+    edges = [
+        Edge(src="http-load-balancer", target="origin-pool", conditional=False, required=True),
+        Edge(src="origin-pool", target="health-check", conditional=False, required=True),
+    ]
+    g = project_graph(edges, ["http-load-balancer", "origin-pool", "health-check"])
+    order = g["sorted"]
+    assert order.index("health-check") < order.index("origin-pool")
+    assert order.index("origin-pool") < order.index("http-load-balancer")
+
+
+def test_conditional_flag_preserved():
+    edges = [Edge(src="fleet", target="dc-cluster-group", conditional=True, required=False)]
+    g = project_graph(edges, ["fleet", "dc-cluster-group"])
+    edge = g["edges"]["fleet"][0]
+    assert edge["target"] == "dc-cluster-group"
+    assert edge["conditional"] is True
+    assert edge["required"] is False
+
+
+def test_leaves_and_prerequisites():
+    edges = [Edge(src="http-load-balancer", target="origin-pool", conditional=False, required=True)]
+    g = project_graph(edges, ["http-load-balancer", "origin-pool", "ip-prefix-set"])
+    assert "origin-pool" in g["leaves"]
+    assert "ip-prefix-set" in g["leaves"]
+    assert "http-load-balancer" not in g["leaves"]
+    assert g["prerequisites"] == ["origin-pool"]
+
+
+def test_cycle_does_not_hang_and_includes_all():
+    edges = [
+        Edge(src="a", target="b", conditional=False, required=True),
+        Edge(src="b", target="a", conditional=False, required=True),
+    ]
+    g = project_graph(edges, ["a", "b"])
+    assert set(g["sorted"]) == {"a", "b"}

--- a/tests/test_example_field_enricher.py
+++ b/tests/test_example_field_enricher.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Unit tests for ExampleFieldEnricher.
+
+Derives per-field example values from x-f5xc-minimum-configuration.example_yaml
+(the single source of truth — present for 331/333 CreateSpecType schemas) and
+stamps them as x-f5xc-field-examples on the schema, so downstream tools (field
+metadata, workflow generator, sweep) read deterministic create values from one
+place instead of hand-coding them.
+"""
+
+from scripts.utils.example_field_enricher import ExampleFieldEnricher, flatten_example
+
+
+def test_flatten_nested_and_list_leaves():
+    spec = {
+        "origin_servers": [{"public_name": {"dns_name": "backend1.example.com"}}],
+        "port": 8080,
+    }
+    flat = flatten_example(spec)
+    assert flat["spec.origin_servers[].public_name.dns_name"] == "backend1.example.com"
+    assert flat["spec.port"] == 8080
+
+
+def test_enrich_stamps_field_examples_from_example_yaml():
+    spec = {
+        "components": {
+            "schemas": {
+                "viewsorigin_poolCreateSpecType": {
+                    "type": "object",
+                    "x-f5xc-minimum-configuration": {
+                        "example_yaml": (
+                            "metadata:\n  name: backend-pool\nspec:\n  origin_servers:\n"
+                            "    - public_name:\n        dns_name: backend1.example.com\n  port: 8080\n"
+                        ),
+                    },
+                    "properties": {"port": {"type": "integer"}},
+                },
+            },
+        },
+    }
+    out = ExampleFieldEnricher().enrich_spec(spec)
+    sch = out["components"]["schemas"]["viewsorigin_poolCreateSpecType"]
+    examples = sch["x-f5xc-field-examples"]
+    assert examples["spec.port"] == 8080
+    assert examples["spec.origin_servers[].public_name.dns_name"] == "backend1.example.com"
+
+
+def test_no_example_yaml_is_noop():
+    spec = {"components": {"schemas": {"fooCreateSpecType": {"properties": {}}}}}
+    out = ExampleFieldEnricher().enrich_spec(spec)
+    assert "x-f5xc-field-examples" not in out["components"]["schemas"]["fooCreateSpecType"]
+
+
+def test_idempotent():
+    spec = {
+        "components": {
+            "schemas": {
+                "barCreateSpecType": {
+                    "x-f5xc-minimum-configuration": {"example_yaml": "spec:\n  port: 80\n"},
+                    "properties": {},
+                },
+            },
+        },
+    }
+    e = ExampleFieldEnricher()
+    once = e.enrich_spec(spec)
+    e.reset_stats()
+    twice = e.enrich_spec(once)
+    assert twice["components"]["schemas"]["barCreateSpecType"]["x-f5xc-field-examples"] == {"spec.port": 80}

--- a/tests/test_example_field_enricher.py
+++ b/tests/test_example_field_enricher.py
@@ -67,4 +67,6 @@ def test_idempotent():
     once = e.enrich_spec(spec)
     e.reset_stats()
     twice = e.enrich_spec(once)
-    assert twice["components"]["schemas"]["barCreateSpecType"]["x-f5xc-field-examples"] == {"spec.port": 80}
+    assert twice["components"]["schemas"]["barCreateSpecType"]["x-f5xc-field-examples"] == {
+        "spec.port": 80
+    }

--- a/tests/test_references_enricher.py
+++ b/tests/test_references_enricher.py
@@ -116,6 +116,46 @@ def test_from_config_loads_curated_map(tmp_path):
     assert e.kind_map == {"fooCreateSpecType.bar": "origin_pool"}
 
 
+def test_recursive_nested_objectref_through_sub_schema(enricher):
+    """ObjectRefType nested inside allOf→sub-schema→array→items→sub-schema is detected."""
+    spec = _spec(
+        {
+            "viewshttp_loadbalancerCreateSpecType": {
+                "type": "object",
+                "properties": {
+                    "default_pool_list": {
+                        "allOf": [{"$ref": "#/components/schemas/viewsOriginPoolListType"}],
+                    },
+                },
+            },
+            "viewsOriginPoolListType": {
+                "properties": {
+                    "pools": {
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/viewsOriginPoolWithWeight"},
+                    },
+                },
+            },
+            "viewsOriginPoolWithWeight": {
+                "properties": {
+                    "pool": {
+                        "allOf": [{"$ref": "#/components/schemas/schemaviewsObjectRefType"}],
+                    },
+                    "weight": {"type": "integer"},
+                },
+            },
+            "schemaviewsObjectRefType": {"type": "object", "properties": {"name": {"type": "string"}}},
+        }
+    )
+    # The enricher should find the nested pool→ObjectRefType when recursing.
+    kind_map = {"viewsOriginPoolWithWeight.pool": "origin_pool"}
+    e = ReferencesEnricher(kind_map=kind_map)
+    out = e.enrich_spec(spec)
+    pool_prop = out["components"]["schemas"]["viewsOriginPoolWithWeight"]["properties"]["pool"]
+    assert X_F5XC_REFERENCES in pool_prop
+    assert pool_prop[X_F5XC_REFERENCES][0]["resource_kind"] == "origin_pool"
+
+
 def test_idempotent(enricher):
     """Re-running does not duplicate descriptors."""
     spec = _spec(

--- a/tests/test_references_enricher.py
+++ b/tests/test_references_enricher.py
@@ -87,6 +87,35 @@ def test_non_objectref_property_is_untouched(enricher):
         assert X_F5XC_REFERENCES not in prop
 
 
+def test_gated_by_records_oneof_choice(enricher):
+    """A reference field that is a oneOf variant records the gating choice group."""
+    spec = _spec(
+        {
+            "viewshttp_loadbalancerCreateSpecType": {
+                "type": "object",
+                "x-ves-oneof-field-waf_choice": ["app_firewall", "disable_waf"],
+                "properties": {
+                    "app_firewall": {"allOf": [{"$ref": "#/components/schemas/schemaviewsObjectRefType"}]},
+                    "disable_waf": {"type": "object"},
+                },
+            },
+        }
+    )
+    out = enricher.enrich_spec(spec)
+    refs = out["components"]["schemas"]["viewshttp_loadbalancerCreateSpecType"]["properties"]["app_firewall"][
+        X_F5XC_REFERENCES
+    ]
+    assert refs[0]["gated_by"] == {"choice": "waf_choice"}
+
+
+def test_from_config_loads_curated_map(tmp_path):
+    """from_config reads the curated referred-kind map from YAML."""
+    cfg = tmp_path / "resource_references.yaml"
+    cfg.write_text('references:\n  "fooCreateSpecType.bar": origin_pool\n')
+    e = ReferencesEnricher.from_config(cfg)
+    assert e.kind_map == {"fooCreateSpecType.bar": "origin_pool"}
+
+
 def test_idempotent(enricher):
     """Re-running does not duplicate descriptors."""
     spec = _spec(

--- a/tests/test_references_enricher.py
+++ b/tests/test_references_enricher.py
@@ -63,13 +63,17 @@ def test_unmapped_objectref_gets_null_kind_not_a_guess(enricher):
         {
             "someResourceCreateSpecType": {
                 "properties": {
-                    "mystery_ref": {"allOf": [{"$ref": "#/components/schemas/schemaviewsObjectRefType"}]},
+                    "mystery_ref": {
+                        "allOf": [{"$ref": "#/components/schemas/schemaviewsObjectRefType"}]
+                    },
                 },
             },
         }
     )
     out = enricher.enrich_spec(spec)
-    refs = out["components"]["schemas"]["someResourceCreateSpecType"]["properties"]["mystery_ref"][X_F5XC_REFERENCES]
+    refs = out["components"]["schemas"]["someResourceCreateSpecType"]["properties"]["mystery_ref"][
+        X_F5XC_REFERENCES
+    ]
     assert refs[0]["resource_kind"] is None
 
 
@@ -95,16 +99,18 @@ def test_gated_by_records_oneof_choice(enricher):
                 "type": "object",
                 "x-ves-oneof-field-waf_choice": ["app_firewall", "disable_waf"],
                 "properties": {
-                    "app_firewall": {"allOf": [{"$ref": "#/components/schemas/schemaviewsObjectRefType"}]},
+                    "app_firewall": {
+                        "allOf": [{"$ref": "#/components/schemas/schemaviewsObjectRefType"}]
+                    },
                     "disable_waf": {"type": "object"},
                 },
             },
         }
     )
     out = enricher.enrich_spec(spec)
-    refs = out["components"]["schemas"]["viewshttp_loadbalancerCreateSpecType"]["properties"]["app_firewall"][
-        X_F5XC_REFERENCES
-    ]
+    refs = out["components"]["schemas"]["viewshttp_loadbalancerCreateSpecType"]["properties"][
+        "app_firewall"
+    ][X_F5XC_REFERENCES]
     assert refs[0]["gated_by"] == {"choice": "waf_choice"}
 
 
@@ -144,7 +150,10 @@ def test_recursive_nested_objectref_through_sub_schema(enricher):
                     "weight": {"type": "integer"},
                 },
             },
-            "schemaviewsObjectRefType": {"type": "object", "properties": {"name": {"type": "string"}}},
+            "schemaviewsObjectRefType": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            },
         }
     )
     # The enricher should find the nested pool→ObjectRefType when recursing.
@@ -162,7 +171,9 @@ def test_idempotent(enricher):
         {
             "fast_aclCreateSpecType": {
                 "properties": {
-                    "protocol_policer": {"allOf": [{"$ref": "#/components/schemas/schemaObjectRefType"}]},
+                    "protocol_policer": {
+                        "allOf": [{"$ref": "#/components/schemas/schemaObjectRefType"}]
+                    },
                 },
             },
         }
@@ -170,5 +181,7 @@ def test_idempotent(enricher):
     once = enricher.enrich_spec(spec)
     enricher.reset_stats()
     twice = enricher.enrich_spec(once)
-    refs = twice["components"]["schemas"]["fast_aclCreateSpecType"]["properties"]["protocol_policer"][X_F5XC_REFERENCES]
+    refs = twice["components"]["schemas"]["fast_aclCreateSpecType"]["properties"][
+        "protocol_policer"
+    ][X_F5XC_REFERENCES]
     assert len(refs) == 1

--- a/tests/test_references_enricher.py
+++ b/tests/test_references_enricher.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Unit tests for ReferencesEnricher.
+
+The enricher stamps ``x-f5xc-references`` on ObjectRefType properties — the
+resource-reference dimension of the dependency model. The referred resource kind
+is NOT present in F5 specs (ObjectRefType is generic), so it is resolved from a
+curated map; references nested inside oneOf choice variants are choice-gated.
+"""
+
+import pytest
+
+from scripts.utils.extension_constants import X_F5XC_REFERENCES
+from scripts.utils.references_enricher import ReferencesEnricher
+
+
+@pytest.fixture
+def kind_map():
+    """Curated <schema>.<field> → referred resource kind map (deterministic source)."""
+    return {
+        "viewshttp_loadbalancerCreateSpecType.default_origin_pools": "origin_pool",
+        "viewsOriginPoolListType.pool": "origin_pool",
+        "fast_aclCreateSpecType.protocol_policer": "protocol_policer",
+    }
+
+
+@pytest.fixture
+def enricher(kind_map):
+    return ReferencesEnricher(kind_map=kind_map)
+
+
+def _spec(schemas):
+    return {"components": {"schemas": schemas}}
+
+
+def test_stamps_reference_on_top_level_objectref(enricher):
+    """A top-level ObjectRefType property gets x-f5xc-references with the mapped kind."""
+    spec = _spec(
+        {
+            "fast_aclCreateSpecType": {
+                "type": "object",
+                "properties": {
+                    "protocol_policer": {
+                        "allOf": [{"$ref": "#/components/schemas/schemaviewsObjectRefType"}],
+                        "x-f5xc-required-for": {"create": True},
+                    },
+                },
+            },
+        }
+    )
+    out = enricher.enrich_spec(spec)
+    prop = out["components"]["schemas"]["fast_aclCreateSpecType"]["properties"]["protocol_policer"]
+    refs = prop[X_F5XC_REFERENCES]
+    assert refs[0]["resource_kind"] == "protocol_policer"
+    assert refs[0]["required"] is True
+    assert refs[0]["cardinality"] == "single"
+    assert refs[0]["gated_by"] is None
+
+
+def test_unmapped_objectref_gets_null_kind_not_a_guess(enricher):
+    """When the curated map lacks the field, resource_kind is null (honest gap)."""
+    spec = _spec(
+        {
+            "someResourceCreateSpecType": {
+                "properties": {
+                    "mystery_ref": {"allOf": [{"$ref": "#/components/schemas/schemaviewsObjectRefType"}]},
+                },
+            },
+        }
+    )
+    out = enricher.enrich_spec(spec)
+    refs = out["components"]["schemas"]["someResourceCreateSpecType"]["properties"]["mystery_ref"][X_F5XC_REFERENCES]
+    assert refs[0]["resource_kind"] is None
+
+
+def test_non_objectref_property_is_untouched(enricher):
+    """Plain scalar/object properties never get x-f5xc-references."""
+    spec = _spec(
+        {
+            "fooCreateSpecType": {
+                "properties": {"name": {"type": "string"}, "count": {"type": "integer"}},
+            },
+        }
+    )
+    out = enricher.enrich_spec(spec)
+    for prop in out["components"]["schemas"]["fooCreateSpecType"]["properties"].values():
+        assert X_F5XC_REFERENCES not in prop
+
+
+def test_idempotent(enricher):
+    """Re-running does not duplicate descriptors."""
+    spec = _spec(
+        {
+            "fast_aclCreateSpecType": {
+                "properties": {
+                    "protocol_policer": {"allOf": [{"$ref": "#/components/schemas/schemaObjectRefType"}]},
+                },
+            },
+        }
+    )
+    once = enricher.enrich_spec(spec)
+    enricher.reset_stats()
+    twice = enricher.enrich_spec(once)
+    refs = twice["components"]["schemas"]["fast_aclCreateSpecType"]["properties"]["protocol_policer"][X_F5XC_REFERENCES]
+    assert len(refs) == 1


### PR DESCRIPTION
Closes #910

## What

Bakes create-time **determinism into the API specs** (the single source of truth) so every downstream project (xcsh, terraform-provider, vscode-extension, CLI, MCP) reads deterministic dependency + value information from one place — no hand-coding in downstream tools.

Two complementary enrichments, both derived from data already in the spec:

### 1. `x-f5xc-references` — resource-reference dependencies
Stamps ObjectRefType properties with their referred resource-kind (curated map, since F5's ObjectRefType is generic), choice-gating, required flag, cardinality. The coarse `resource_dependency_graph.json` is a DRY projection of these. **88% coverage** (718/811 refs, excl. system-internal owner_view).

### 2. `x-f5xc-field-examples` — per-field create values (NEW)
Derives per-field create values from `x-f5xc-minimum-configuration.example_yaml` (present for 331/333 CreateSpecTypes) and stamps them as a flat `field_path → value` map. **282 schemas, 932 field examples.** The downstream workflow generator reads these as param defaults — proven end-to-end: origin-pool's DNS Name now fills from the spec (`backend1.example.com`) with ZERO hand-coding.

### Supporting metadata fixes
- 88 `configurable → listbox` widget corrections (spec-derived from `x-ves-oneof-field-*`)
- `resource_type` auto-populated from x-f5xc-references
- CDN Origin Pool configurable field

## The determinism feedback loop
Testing (CDP error triage in xcsh) discovers what `example_yaml` is missing → the gap is fixed in the spec → republished via this pipeline → every downstream project benefits at once.

## Tests
19 TDD tests (references enricher, dependency-graph projection, example-field enricher). Pipeline-wired; `make enrich` stamps both extensions across the corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)