### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ oauth-success.html
 # Lock file preferences (Bun-based repos)
 package-lock.json
 yarn.lock
+bun.lock
 
 # Monorepo build
 .turbo/
@@ -138,6 +139,9 @@ worktrees/
 .wt/
 .codex/
 playground/
+
+# Locally cloned dev repos (checked out alongside the parent, not tracked by it)
+starlight-mega-menu/
 
 # Documentation build artifacts
 docs/_data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,6 +134,11 @@ repos:
         entry: codespell
         language: system
         types: [text]
+        # codespell's own `skip` list only applies during its directory
+        # traversal; when pre-commit passes explicit file paths it is bypassed.
+        # Filter translation dirs here so their foreign-language words
+        # (e.g. German "Referenz") never reach codespell. See issue #579.
+        exclude: ^docs/(ar|de|es|fr|hi|it|ja|ko|pt-br|th|zh-cn|zh-tw)/
 
   # ===========================================================================
   # EditorConfig conformance — config: .editorconfig-checker.json


### PR DESCRIPTION
Closes #917

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .gitignore
- .pre-commit-config.yaml