### PR TITLE
feat: add enable_request_logging guided workflow

### DIFF
--- a/config/guided_workflows.yaml
+++ b/config/guided_workflows.yaml
@@ -146,6 +146,53 @@ workflows:
             - "HTTPS response codes"
             - "WAF policy application"
 
+    - id: enable_request_logging
+      name: Enable Request Logging (All Requests)
+      description: >-
+        Stream logs for every request a load balancer serves — not just WAF
+        security-event/violation logs. WAF violations show up under Security
+        Events; capturing legitimate (allowed) requests requires a Global Log
+        Receiver configured with the Request Logs log type.
+      complexity: medium
+      estimated_steps: 3
+      prerequisites:
+        - "An existing HTTP load balancer serving traffic"
+        - "A reachable log collector (HTTP endpoint, Syslog, Kafka, AWS S3, GCP, Datadog, Splunk, …)"
+      steps:
+        - order: 1
+          action: create_global_log_receiver
+          name: Create a Global Log Receiver for request logs
+          description: >-
+            Create a global_log_receiver whose log type is Request Logs so every
+            request (allowed and blocked) is exported, then point it at your collector.
+          resource: global_log_receiver
+          required_fields:
+            - name
+            - request_logs
+          tips:
+            - "Select the 'Request Logs' log type (spec.request_logs) — this captures legitimate/allowed requests, unlike Security Events which only capture WAF violations."
+            - "Scope by namespace, or use the shared/system namespace for tenant-wide collection."
+            - "Pick exactly one receiver sink: http_receiver, syslog, kafka_receiver, aws_cloud_watch, s3_receiver, gcp_bucket, datadog, or splunk."
+        - order: 2
+          action: confirm_loadbalancer_scope
+          name: Confirm the load balancers in scope
+          description: >-
+            Request logs stream for the load balancers in the receiver's namespace
+            scope; confirm the target http_loadbalancer is included.
+          resource: http_loadbalancer
+          depends_on: [1]
+          tips:
+            - "Enhanced request analytics and extra log fields can be tuned on the load balancer but are not required to receive request logs."
+        - order: 3
+          action: verify_request_logs
+          name: Verify legitimate requests are logged
+          description: Send allowed traffic and confirm request-log entries arrive at the collector.
+          depends_on: [1]
+          verification:
+            - "Non-violation (2xx/3xx) requests appear at the collector, not only blocked ones"
+            - "Use the Test action on the Global Log Receiver to validate delivery"
+            - "The Requests dashboard in the console shows the traffic"
+
   waf:
     - id: enable_waf_protection
       name: Enable WAF Protection


### PR DESCRIPTION
Closes #923.

## What

Adds an `enable_request_logging` guided workflow to `config/guided_workflows.yaml` (domain `virtual`).

Customers see WAF **security events / violations** and ask how to log **legitimate/all requests**. This workflow ties that intent to the real mechanism — a **Global Log Receiver** with the **Request Logs** log type (`spec.request_logs`) — and contrasts it with Security Events (WAF violations only).

Steps:
1. Create a `global_log_receiver` with the Request Logs log type, pointed at a collector (HTTP/Syslog/Kafka/S3/…).
2. Confirm the target `http_loadbalancer` is in the receiver's namespace scope.
3. Verify legitimate (non-violation) requests reach the collector.

## Testing

- `tests/test_guided_workflow_enricher.py` — 21 passed.
- YAML validated; workflow parses with 3 well-formed steps.
- Enrichment pipeline (`scripts.pipeline`) run locally: the workflow flows into `x-f5xc-guided-workflows`. Generated docs are regenerated by the release pipeline, not committed here.

## Downstream

xcsh consumes this via the `enriched-specs-updated` repository_dispatch, which regenerates its embedded index and opens a sync PR automatically — no manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)