### PR TITLE
feat(guided-workflows): add create-and-use-API-token roadmap (authentication domain)

### DIFF
--- a/config/guided_workflows.yaml
+++ b/config/guided_workflows.yaml
@@ -401,3 +401,40 @@ workflows:
             - "Site shows online status"
             - "Tunnel connectivity established"
             - "Services deployed successfully"
+
+  authentication:
+    - id: create_and_use_api_token
+      name: Create and Use an API Token
+      description: Create an API token in the console via guided browser automation, then call the F5 XC API with it
+      complexity: low
+      estimated_steps: 3
+      prerequisites:
+        - "Logged in to the F5 XC console"
+        - "User role: admin (access to Personal Management > Credentials)"
+      steps:
+        - order: 1
+          action: create_api_token
+          name: Create API Token
+          description: In Administration > Personal Management > Credentials, click Add Credentials, set Credential Type to API Token, enter a Credential Name and Expiry Date, then Generate
+          resource: api_credential
+          required_fields:
+            - credential_name
+            - credential_type
+            - expiry_date
+          tips:
+            - "Set Credential Type to API Token. The default is API Certificate, which produces a P12 file, not a bearer token."
+            - "The token string is shown only once on the reveal panel. Capture it immediately, before dismissing the panel."
+        - order: 2
+          action: capture_token
+          name: Capture the Generated Token
+          description: Read the one-time token value from the reveal panel
+          depends_on: [1]
+          verification:
+            - "Token value captured before the reveal panel is dismissed"
+        - order: 3
+          action: call_api_with_token
+          name: Call the F5 XC API with the Token
+          description: Use the captured token in an XC-API call with header Authorization APIToken to confirm it works, for example list namespaces
+          depends_on: [2]
+          verification:
+            - "XC-API GET /api/web/namespaces returns HTTP 200 with the tenant namespaces"

--- a/tests/test_guided_workflow_enricher.py
+++ b/tests/test_guided_workflow_enricher.py
@@ -305,8 +305,6 @@ class TestAuthenticationApiTokenWorkflow:
         self, enricher, spec_with_authentication_domain
     ):
         """The workflow is emitted under x-f5xc-guided-workflows for the domain."""
-        enriched = enricher.enrich_spec(
-            spec_with_authentication_domain, domain="authentication"
-        )
+        enriched = enricher.enrich_spec(spec_with_authentication_domain, domain="authentication")
         workflows = enriched["info"]["x-f5xc-guided-workflows"]
         assert any(w["id"] == self.WORKFLOW_ID for w in workflows)

--- a/tests/test_guided_workflow_enricher.py
+++ b/tests/test_guided_workflow_enricher.py
@@ -245,3 +245,68 @@ class TestWorkflowToDict:
             step = steps[0]
             assert "order" in step
             assert "action" in step
+
+
+@pytest.fixture
+def spec_with_authentication_domain():
+    """Create a spec classified under the authentication CLI domain."""
+    return {
+        "info": {
+            "title": "F5 XC Authentication API",
+            "description": "Authentication and API credential management",
+            "x-f5xc-cli-domain": "authentication",
+        },
+        "paths": {},
+    }
+
+
+class TestAuthenticationApiTokenWorkflow:
+    """The authentication domain must ship a create-and-use-API-token roadmap.
+
+    This encodes the deterministic roadmap the model follows: create an API
+    token via guided browser automation in the console, capture the one-time
+    revealed token, then call the F5 XC API with it via the XC-API tool.
+    """
+
+    WORKFLOW_ID = "create_and_use_api_token"
+
+    def test_authentication_is_a_configured_domain(self, enricher):
+        """authentication must be present as a guided-workflow domain."""
+        assert "authentication" in enricher.get_configured_domains()
+
+    def test_workflow_present_with_three_ordered_steps(self, enricher):
+        """The workflow exists and has the three expected ordered steps."""
+        workflow = enricher.get_workflow("authentication", self.WORKFLOW_ID)
+        assert workflow is not None, f"missing workflow {self.WORKFLOW_ID}"
+
+        actions = [step.action for step in workflow.steps]
+        assert actions == [
+            "create_api_token",
+            "capture_token",
+            "call_api_with_token",
+        ]
+        orders = [step.order for step in workflow.steps]
+        assert orders == sorted(orders), "steps must be ordered"
+
+    def test_step_dependencies_and_create_step_shape(self, enricher):
+        """Later steps depend on earlier ones; the create step targets api_credential."""
+        workflow = enricher.get_workflow("authentication", self.WORKFLOW_ID)
+        assert workflow is not None
+        by_action = {step.action: step for step in workflow.steps}
+
+        create = by_action["create_api_token"]
+        assert create.resource == "api_credential"
+        assert "credential_type" in create.required_fields
+
+        assert by_action["capture_token"].depends_on == [1]
+        assert by_action["call_api_with_token"].depends_on == [2]
+
+    def test_workflow_injected_into_authentication_spec(
+        self, enricher, spec_with_authentication_domain
+    ):
+        """The workflow is emitted under x-f5xc-guided-workflows for the domain."""
+        enriched = enricher.enrich_spec(
+            spec_with_authentication_domain, domain="authentication"
+        )
+        workflows = enriched["info"]["x-f5xc-guided-workflows"]
+        assert any(w["id"] == self.WORKFLOW_ID for w in workflows)


### PR DESCRIPTION
## What & why

Adds a guided workflow for the most fundamental first task a new user hits — getting API
access — which `config/guided_workflows.yaml` did not previously cover. The new
`authentication → create_and_use_api_token` roadmap directs the model to create an F5 XC
**API token** via guided browser automation and then use that token in a direct XC-API
call.

Placed under the `authentication` CLI-domain because `scripts/utils/domain_metadata.py`
maps `api_credential` to that domain; the enricher attaches the workflow to any spec whose
`x-f5xc-cli-domain` is `authentication` (verified against the built `authentication.json`).

## Changes
- `config/guided_workflows.yaml` — new `authentication` domain, workflow
  `create_and_use_api_token` (steps: `create_api_token` → `capture_token` →
  `call_api_with_token`). Directs Credential Type = **API Token** (not the default API
  Certificate) and the one-time token reveal, then a verifying XC-API `GET /api/web/namespaces`.
- `tests/test_guided_workflow_enricher.py` — TDD tests for presence, step order,
  dependencies, `api_credential` target, and injection under `x-f5xc-guided-workflows`.

## Verification
- `.venv/bin/python -m pytest tests/test_guided_workflow_enricher.py` → **25 passed**
  (21 existing + 4 new).
- Ran the real enricher against the built `authentication.json`: `create_and_use_api_token`
  injected with steps in order.
- `yamllint -c .yamllint.yaml config/guided_workflows.yaml` clean (pre-existing
  document-start warning only).

## Out of scope (follow-up)
The downstream `xcsh` console browser catalog currently drives only the API *Certificate*
form; an API-Token variant of the `api_credential` browser workflow is needed to make step 1
fully deterministic end-to-end. Noted in the issue.

Closes #928

🤖 Generated with [Claude Code](https://claude.com/claude-code)
