### PR TITLE
fix(namespace-profile): strip 'schema' prefix when mapping schema to resource

### DIFF
--- a/scripts/utils/namespace_profile_enricher.py
+++ b/scripts/utils/namespace_profile_enricher.py
@@ -213,8 +213,10 @@ class NamespaceProfileEnricher:
                 name = name[: -len(suffix)]
                 break
 
-        # Strip common prefixes
-        for prefix in ("views",):
+        # Strip common prefixes. Some spec schema keys are 'schema'-prefixed
+        # (e.g. schemadns_load_balancerCreateSpecType); without stripping it the
+        # name would never match its resource and would inherit the domain default.
+        for prefix in ("views", "schema"):
             name = name.removeprefix(prefix)
 
         s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)

--- a/tests/test_namespace_profile_enricher.py
+++ b/tests/test_namespace_profile_enricher.py
@@ -210,6 +210,21 @@ class TestResourceTypeExtraction:
         profile = enricher.get_profile_for_resource("views_aws_vpc_site")
         assert profile["constraint"]["allowed"] == ["system"]
 
+    def test_schema_prefix_stripped(self, enricher: NamespaceProfileEnricher) -> None:
+        # Some spec schema keys are 'schema'-prefixed (e.g.
+        # schemadns_load_balancerCreateSpecType). They must map back to their
+        # resource, not fall through to the domain default.
+        assert (
+            enricher._schema_name_to_resource_type("schemadns_load_balancerCreateSpecType")
+            == "dns_load_balancer"
+        )
+        assert (
+            enricher._match_schema_to_resource(
+                "schemadns_load_balancerCreateSpecType", enricher.config.get("resources", {})
+            )
+            == "dns_load_balancer"
+        )
+
 
 # -- Spec Enrichment Tests --
 
@@ -239,6 +254,28 @@ class TestSpecEnrichment:
         result = enricher.enrich_spec(shared_spec)
         profile = result["info"]["x-f5xc-namespace-profile"]
         assert profile["constraint"]["allowed"] == ["shared"]
+
+    def test_schema_prefixed_createspec_gets_resource_profile(
+        self, enricher: NamespaceProfileEnricher
+    ) -> None:
+        # A 'schema'-prefixed CreateSpecType must receive its resource's profile
+        # (system for dns_load_balancer), not the domain default — even when the
+        # domain-level detection falls back to the default.
+        spec: dict[str, Any] = {
+            "info": {"title": "DNS API"},
+            "paths": {},
+            "components": {
+                "schemas": {
+                    "schemadns_load_balancerCreateSpecType": {"type": "object"},
+                    "schemadns_load_balancerGetSpecType": {"type": "object"},
+                }
+            },
+        }
+        result = enricher.enrich_spec(spec)
+        schemas = result["components"]["schemas"]
+        for name in ("schemadns_load_balancerCreateSpecType", "schemadns_load_balancerGetSpecType"):
+            profile = schemas[name]["x-f5xc-namespace-profile"]
+            assert profile["constraint"]["allowed"] == ["system"], name
 
     def test_idempotent(self, enricher: NamespaceProfileEnricher, sample_spec: dict) -> None:
         result1 = enricher.enrich_spec(sample_spec)


### PR DESCRIPTION
## Problem

`_schema_name_to_resource_type` strips the `views` prefix but not `schema`, so `schema`-prefixed spec schema keys (e.g. `schemadns_load_balancerCreateSpecType`) never match their resource in `_match_schema_to_resource` and inherit the **domain-default** namespace profile instead of the resource's.

Result: `dns_load_balancer`'s `Create`/`GetSpecType` carried `constraint.allowed = [custom, default, shared]` instead of `[system]` (unlike its siblings `dns_zone`/`dns_lb_pool`/`dns_lb_health_check`), so `terraform-provider-xcsh` emitted its `namespace` as `Required` rather than defaulting to `system`.

## Fix

Add `schema` to the stripped prefixes in `_schema_name_to_resource_type`.

## Tests (TDD)

- Unit: `_schema_name_to_resource_type` / `_match_schema_to_resource` map `schemadns_load_balancerCreateSpecType` → `dns_load_balancer`.
- Integration: `enrich_spec` gives a `schema`-prefixed Create/GetSpecType the resource's **system** profile.
- Verified both tests fail without the fix; **full suite green (2187 passed, 3 skipped, 1 xfailed)**; ruff clean.

Once released, `terraform-provider-xcsh` picks up the corrected profile automatically (its generator is already spec-driven) and `dns_load_balancer` will default `namespace` to `system` like the other DNS resources — no provider change needed.

Closes #931