### PR TITLE
feat(namespace-profile): gate constraint.enforced on verification status

### DIFF
--- a/config/extension_registry.yaml
+++ b/config/extension_registry.yaml
@@ -157,10 +157,16 @@ schema_level:
     type: object
     purpose: Rich namespace constraint, recommendation, and classification profile
     consumers: [cli, mcp, ide, terraform]
+    notes: >-
+      constraint.enforced is verification-gated: it is true ONLY when the resource's
+      namespace constraint is verified (a live CRUD probe or a strong spec signal;
+      _verification.status == 'verified'). Assumed/restricted/unverified classifications
+      emit enforced=false so consumers (e.g. the Terraform provider) treat them as
+      advisory and do not over-restrict a namespace on an unverified guess.
     example:
       constraint:
         allowed: ["custom", "default", "shared"]
-        enforced: true
+        enforced: false
       recommendation:
         primary: "custom"
         alternatives: []

--- a/scripts/utils/namespace_profile_enricher.py
+++ b/scripts/utils/namespace_profile_enricher.py
@@ -94,6 +94,16 @@ class NamespaceProfileEnricher:
                 self.stats.default_fallback_resources.append(resource_type)
 
         profile = _deep_merge(default, override)
+
+        # Gate enforcement on verification. `constraint.enforced` means "downstream
+        # tooling should enforce this restriction" — we only assert that for
+        # constraints whose _verification.status is 'verified' (live CRUD probe or a
+        # strong spec signal). Assumed/restricted/unverified classifications are
+        # advisory (enforced=False) so consumers (e.g. the Terraform provider) don't
+        # over-restrict a namespace on a guess.
+        status = (override.get("_verification") or {}).get("status")
+        profile.setdefault("constraint", {})["enforced"] = status == "verified"
+
         profile.pop("_verification", None)
         return profile
 

--- a/tests/test_namespace_profile_enricher.py
+++ b/tests/test_namespace_profile_enricher.py
@@ -137,7 +137,9 @@ class TestDeepMerge:
     def test_partial_override_merges_with_default(self, enricher: NamespaceProfileEnricher) -> None:
         profile = enricher.get_profile_for_resource("http_loadbalancer")
         assert profile["constraint"]["allowed"] == ["custom", "default", "shared"]
-        assert profile["constraint"]["enforced"] is True
+        # enforced now reflects verification status, not a hardcoded default:
+        # http_loadbalancer is not 'verified', so the constraint is advisory.
+        assert profile["constraint"]["enforced"] is False
         assert profile["classification"]["category"] == "networking"
         assert profile["recommendation"]["primary"] == "custom"
 
@@ -181,6 +183,36 @@ class TestProfileValidation:
 
 
 # -- Resource Type Extraction Tests --
+
+
+class TestVerificationGate:
+    """constraint.enforced must reflect verification: only 'verified' resources are
+    enforced; assumed/restricted/unverified/default-fallback are advisory."""
+
+    def test_verified_resource_is_enforced(self, enricher: NamespaceProfileEnricher) -> None:
+        # dns_load_balancer is _verification.status == 'verified' (live CRUD probe).
+        profile = enricher.get_profile_for_resource("dns_load_balancer")
+        assert profile["constraint"]["allowed"] == ["system"]
+        assert profile["constraint"]["enforced"] is True
+
+    def test_unverified_single_allowed_is_advisory(
+        self, enricher: NamespaceProfileEnricher
+    ) -> None:
+        # A single-allowed resource that is not 'verified' must be advisory, so the
+        # provider keeps namespace Required rather than over-restricting.
+        res = enricher.config["resources"]
+        target = next(
+            r
+            for r, p in res.items()
+            if len((p.get("constraint") or {}).get("allowed", [])) == 1
+            and (p.get("_verification") or {}).get("status") != "verified"
+        )
+        profile = enricher.get_profile_for_resource(target)
+        assert profile["constraint"]["enforced"] is False, target
+
+    def test_default_fallback_is_advisory(self, enricher: NamespaceProfileEnricher) -> None:
+        profile = enricher.get_profile_for_resource("some_unknown_resource_xyz")
+        assert profile["constraint"]["enforced"] is False
 
 
 class TestResourceTypeExtraction:


### PR DESCRIPTION
`constraint.enforced` was hardcoded `true` for every resource, so downstream tools (e.g. `terraform-provider-xcsh`, now emitting a fixed `namespace` for single-allowed resources) enforced even **unverified** classifications — over-restricting any resource that actually allows tenant namespaces.

## Fix
Emit `enforced = (_verification.status == "verified")`. Only live-CRUD-verified (or strong spec-signal) constraints are enforced; assumed/restricted/unverified and default-fallback resources are **advisory** (`enforced: false`). Of 167 single-allowed resources, 11 are `verified` (incl. all DNS use-case resources) and stay enforced; the other 156 become advisory until verified.

## Tests
verified→enforced, unverified-single-allowed→advisory, default-fallback→advisory; existing merge test updated. **Full suite green (2190 passed)**; ruff clean. `extension_registry.yaml` documents the gate.

Downstream: `terraform-provider-xcsh`'s generator will be updated to key the namespace default+OneOf on `enforced` (companion PR), so unverified single-allowed resources keep `namespace` Required.

Closes #933