### PR TITLE
fix: propagate verification gate to namespace_profiles.json + verify network_firewall/virtual_network (staging CRUD)

### DIFF
--- a/config/namespace_profile.yaml
+++ b/config/namespace_profile.yaml
@@ -6,6 +6,17 @@
 # Used by NamespaceProfileEnricher to add x-f5xc-namespace-profile extension.
 #
 # Resources not listed use default_profile.
+#
+# _verification.status gates constraint.enforced (verified => enforced). Only
+# resources confirmed by a live CRUD probe (method: crud) or a strong spec
+# signal (method: spec_signal) are enforced; everything else is advisory so
+# downstream tooling never over-restricts a namespace on a guess.
+#
+# 2026-07-07 staging CRUD pass (nferreira.staging): re-confirmed the DNS
+# resources and existing system-only classifications; promoted network_firewall
+# and virtual_network to verified (same live signature as fleet_config /
+# rate_limit_threshold / k8s_cluster_role). Tenant-resource allowed-lists were
+# confirmed correct (system deliberately excluded — see test_tenant_resource_scope).
 
 default_profile:
   constraint:
@@ -190,6 +201,7 @@ resources:
       multi_tenant_pattern: "none"
 
   virtual_network:
+    _verification: {status: verified, method: crud, date: "2026-07-07"}
     constraint:
       allowed: ["system"]
     recommendation:
@@ -666,6 +678,7 @@ resources:
       multi_tenant_pattern: "none"
 
   network_firewall:
+    _verification: {status: verified, method: crud, date: "2026-07-07"}
     constraint:
       allowed: ["system"]
     recommendation:

--- a/docs/specifications/api/namespace_profiles.json
+++ b/docs/specifications/api/namespace_profiles.json
@@ -1,6 +1,6 @@
 {
   "version": "2.1.169",
-  "generated_at": "2026-07-07T14:07:53.746268+00:00",
+  "generated_at": "2026-07-07T14:48:55.928293+00:00",
   "source": "api-specs-enriched/config/namespace_profile.yaml",
   "default": {
     "constraint": {
@@ -27,7 +27,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -49,7 +49,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -71,7 +71,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -93,7 +93,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -117,7 +117,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -139,7 +139,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -161,7 +161,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -183,7 +183,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -205,7 +205,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -227,7 +227,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -249,7 +249,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -271,7 +271,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -295,7 +295,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -317,7 +317,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -339,7 +339,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -361,7 +361,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -383,7 +383,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -405,7 +405,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -429,7 +429,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -456,7 +456,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -478,7 +478,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -500,7 +500,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -522,7 +522,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -544,7 +544,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -566,7 +566,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -588,7 +588,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -610,7 +610,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -632,7 +632,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -654,7 +654,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -676,7 +676,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -698,7 +698,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -720,7 +720,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -742,7 +742,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -764,7 +764,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -786,7 +786,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -810,7 +810,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -832,7 +832,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -854,7 +854,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -876,7 +876,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -898,7 +898,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -920,7 +920,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -990,7 +990,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1014,7 +1014,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1038,7 +1038,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1060,7 +1060,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1082,7 +1082,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1104,7 +1104,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1126,7 +1126,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1174,7 +1174,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -1196,7 +1196,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1218,7 +1218,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1240,7 +1240,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1264,7 +1264,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -1288,7 +1288,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -1310,7 +1310,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1332,7 +1332,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1354,7 +1354,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1376,7 +1376,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1398,7 +1398,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1576,7 +1576,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1598,7 +1598,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1622,7 +1622,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -1644,7 +1644,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1688,7 +1688,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1712,7 +1712,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -1741,7 +1741,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -1763,7 +1763,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1787,7 +1787,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -1809,7 +1809,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1831,7 +1831,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -1855,7 +1855,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1879,7 +1879,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1901,7 +1901,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1923,7 +1923,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1945,7 +1945,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1967,7 +1967,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -1989,7 +1989,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2011,7 +2011,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2033,7 +2033,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2055,7 +2055,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2077,7 +2077,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2099,7 +2099,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2123,7 +2123,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -2150,7 +2150,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2194,7 +2194,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2216,7 +2216,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2238,7 +2238,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2260,7 +2260,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2282,7 +2282,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2304,7 +2304,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2326,7 +2326,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2350,7 +2350,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -2396,7 +2396,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2418,7 +2418,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2440,7 +2440,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2486,7 +2486,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2508,7 +2508,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2530,7 +2530,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2552,7 +2552,7 @@
         "allowed": [
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -2574,7 +2574,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2596,7 +2596,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2631,8 +2631,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "network_interface": {
@@ -2640,7 +2640,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2686,7 +2686,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2708,7 +2708,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2730,7 +2730,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2752,7 +2752,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2774,7 +2774,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2796,7 +2796,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2818,7 +2818,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2840,7 +2840,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2862,7 +2862,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2884,7 +2884,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2908,7 +2908,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2930,7 +2930,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2952,7 +2952,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -2974,7 +2974,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -2998,7 +2998,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -3020,7 +3020,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3042,7 +3042,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3064,7 +3064,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3086,7 +3086,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3108,7 +3108,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3132,7 +3132,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -3154,7 +3154,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3200,7 +3200,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -3229,7 +3229,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -3251,7 +3251,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3295,7 +3295,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3317,7 +3317,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3339,7 +3339,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3361,7 +3361,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3383,7 +3383,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3407,7 +3407,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -3429,7 +3429,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3451,7 +3451,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3473,7 +3473,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3497,7 +3497,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -3519,7 +3519,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3541,7 +3541,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3565,7 +3565,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -3592,7 +3592,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3614,7 +3614,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3636,7 +3636,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3658,7 +3658,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3680,7 +3680,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3702,7 +3702,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3724,7 +3724,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3746,7 +3746,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3768,7 +3768,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3790,7 +3790,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3812,7 +3812,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3834,7 +3834,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3856,7 +3856,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3880,7 +3880,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3902,7 +3902,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -3924,7 +3924,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3946,7 +3946,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3968,7 +3968,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -3990,7 +3990,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -4012,7 +4012,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -4034,7 +4034,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4058,7 +4058,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -4080,7 +4080,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4102,7 +4102,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -4124,7 +4124,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -4146,7 +4146,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4190,7 +4190,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4214,7 +4214,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -4236,7 +4236,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4258,7 +4258,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -4280,7 +4280,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -4302,7 +4302,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -4324,7 +4324,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4346,7 +4346,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4368,7 +4368,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4390,7 +4390,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4412,7 +4412,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4434,7 +4434,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4456,7 +4456,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4478,7 +4478,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4502,7 +4502,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -4537,8 +4537,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "virtual_site": {
@@ -4548,7 +4548,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "custom",
@@ -4570,7 +4570,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4592,7 +4592,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "system",
@@ -4616,7 +4616,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -4645,7 +4645,7 @@
           "default",
           "shared"
         ],
-        "enforced": true
+        "enforced": false
       },
       "recommendation": {
         "primary": "shared",
@@ -4694,11 +4694,8 @@
   },
   "_coverage": {
     "total_explicit": 207,
-    "verified": 19,
+    "verified": 21,
     "assumed": 10,
-    "unverified": 178
-  },
-  "info": {
-    "version": "2.1.170"
+    "unverified": 176
   }
 }

--- a/tests/test_namespace_profile_enricher.py
+++ b/tests/test_namespace_profile_enricher.py
@@ -214,6 +214,18 @@ class TestVerificationGate:
         profile = enricher.get_profile_for_resource("some_unknown_resource_xyz")
         assert profile["constraint"]["enforced"] is False
 
+    @pytest.mark.parametrize("resource_name", ["network_firewall", "virtual_network"])
+    def test_staging_crud_promoted_resources_are_enforced(
+        self, enricher: NamespaceProfileEnricher, resource_name: str
+    ) -> None:
+        # Promoted to verified by the 2026-07-07 staging CRUD pass (same live
+        # signature as fleet_config / rate_limit_threshold / k8s_cluster_role):
+        # created in system, rejected in tenant namespaces. Must be enforced and
+        # remain system-only.
+        profile = enricher.get_profile_for_resource(resource_name)
+        assert profile["constraint"]["allowed"] == ["system"], resource_name
+        assert profile["constraint"]["enforced"] is True, resource_name
+
 
 class TestResourceTypeExtraction:
     def test_from_title(self, enricher: NamespaceProfileEnricher) -> None:


### PR DESCRIPTION
Closes #940.

## Summary

Live CRUD verification against the **staging** tenant (`nferreira.staging.volterra.us`, 2026-07-07) using the existing `scripts/discover_namespace_crud.py` (57 probeable resources; created objects cleaned up). Two related fixes:

### 1. Propagate the verification gate to `namespace_profiles.json`
The gate — `constraint.enforced = (_verification.status == "verified")` — is implemented in `namespace_profile_enricher.py` and committed to `main`, but the committed `namespace_profiles.json` was a **pre-gate build**: 186 unverified single-allowed resources still carried `enforced: true` (while `_coverage` reported them `unverified`). Regenerating from current code flips them to `enforced: false`, so downstream consumers (vscode-xcsh, xcsh) stop over-enforcing restrictions the gate keeps advisory.

### 2. Promote `network_firewall` + `virtual_network` → `verified/crud`
Both show the **identical live signature** as already-`verified` peers `fleet_config` / `rate_limit_threshold` / `k8s_cluster_role` — created in `system`, rejected in tenant namespaces (`default`, `demo`). Both were already authored `allowed: ["system"]`, `multi_tenant_pattern: none`; they only lacked a `_verification` block. Now enforced → the generated provider locks them to `system`.

## What the pass confirmed (no change needed)
- **DNS resources** re-confirmed (`dns_load_balancer` → system-only, explicit restriction signal). Methodology validated on staging.
- **Tenant `allowed`-lists are correct.** The tool's 23 `any_namespace` "drift" ([c,d,s] → [c,d,s,system]) is an artifact of its coarse `any_namespace` bucket (it never measures `shared`/`system` individually). Excluding `system` from tenant resources is deliberate and **test-enforced** (`test_tenant_resource_scope`). 4 of the 23 were pure over-claims (system was a validation error, not a create).
- **27 conservative infra/read-only resources** are unprobeable via CRUD (404/403/500/masked-validation) and correctly remain advisory. This is the read-path/empty-POST limitation: the API only enforces namespace on a *valid* create, and validation errors mask the namespace check.

## Changes
- `config/namespace_profile.yaml`: `_verification` for the two promotions + header note documenting the gate + the 2026-07-07 pass.
- `docs/specifications/api/namespace_profiles.json`: regenerated (`_coverage.verified` 19 → 21; 186 unverified → `enforced: false`).
- `tests/test_namespace_profile_enricher.py`: regression test asserting both promoted resources are verified → enforced and stay system-only.

Evidence follows the established convention (the 2026-06-28 CRUD pass recorded no report file): the `_verification: {method: crud, date}` metadata + the committed `discover_namespace_crud.py` are the reproducible record.

## Verification
- `pytest`: **2210 passed, 2 skipped, 1 xfailed**; new promotion test green; `test_tenant_resource_scope` stays green (no tenant resource gains `system`).
- Fresh export: exactly 21 resources `enforced: true` (= verified count); `aws_vpc_site` and other unverified single-allowed → `enforced: false`.
- `pre-commit` (YAML, Biome/JSON, spelling, secrets) all pass.

## Follow-up
Per-domain enriched specs carry the same pre-gate staleness; `sync-and-enrich` regenerates them on merge of this `config/**` change. Worth confirming that workflow is green post-merge.