### PR TITLE
feat: encode CSD provisioning requirement + error resolution

### DIFF
--- a/config/error_resolution.yaml
+++ b/config/error_resolution.yaml
@@ -215,6 +215,7 @@ http_errors:
       - "Bug in request handling"
       - "Backend service failure"
       - "Resource constraint"
+      - "Client-Side Defense enabled on an http_loadbalancer without a protected_domain registered in the same namespace ('Failed to get CSD JS Configuration ... ensure the domain to protect is configured')"
     diagnostic_steps:
       - step: 1
         action: "Retry request"
@@ -226,12 +227,17 @@ http_errors:
         action: "Simplify request"
         description: "Try with minimal configuration"
       - step: 4
+        action: "Client-Side Defense: verify prerequisite"
+        command: "GET /api/shape/csd/namespaces/{namespace}/js_configuration"
+        description: "If the error mentions 'CSD JS Configuration', register a protected_domain (eTLD+1) in the load balancer's OWN namespace before enabling client_side_defense (see the http_loadbalancer spec.client_side_defense x-f5xc-requires)"
+      - step: 5
         action: "Contact support"
         description: "If persistent, open support ticket with request ID"
     prevention:
       - "Implement retry logic"
       - "Monitor service status pages"
       - "Use health check endpoints"
+      - "For Client-Side Defense: register a protected_domain (eTLD+1) in the load balancer's namespace before enabling client_side_defense"
     related_errors: [502, 503]
 
   502:

--- a/config/minimum_configs.yaml
+++ b/config/minimum_configs.yaml
@@ -364,6 +364,10 @@ resources:
         required: true
         reason: "HTTP lb_type requires port_choice (400 when port omitted, unlike https_auto_cert)"
 
+      - field: "spec.client_side_defense"
+        requires: "resource:protected_domain (same namespace)"
+        reason: "Client-Side Defense requires a protected_domain (eTLD+1) registered in the load balancer's OWN namespace — F5 XC generates the per-namespace CSD JS configuration from it. Enabling client_side_defense without one fails with 500 'Failed to get CSD JS Configuration for <tenant>. Please ensure the domain to protect is configured in Client-Side Defense before proceeding'. Verified via live API 2026-07."
+
       - field: "spec.default_pool.use_tls.tls_config"
         required: true
         reason: "use_tls requires tls_config sub-field (400 without)"


### PR DESCRIPTION
Makes the Client-Side Defense cross-resource dependency **deterministic** instead of a discover-by-500 surprise.

Closes #954.

## What
- **`config/minimum_configs.yaml`** — add a `spec.client_side_defense` dependency under `resources.http_loadbalancer.dependencies`: requires a `protected_domain` (eTLD+1) in the **same namespace**, with the exact 500 signature in the `reason`. The `dependency_enricher` stamps `x-f5xc-requires` onto the field so AI/CLI tooling — and a future provider pre-flight check — can enforce it.
- **`config/error_resolution.yaml`** — extend the `500` entry with the CSD common-cause, a diagnostic step (`GET /api/shape/csd/namespaces/{namespace}/js_configuration`), and prevention guidance.

## Why
Enabling `client_side_defense` on an `http_loadbalancer` fails with an opaque 500 (`Failed to get CSD JS Configuration … ensure the domain to protect is configured`) unless a protected domain exists in the LB's own namespace — discovered empirically against the live tenant. This encodes that requirement in the specs.

## Verification
YAML valid (`yaml.safe_load`). Config-only change; the enrichment pipeline stamps the annotations on the next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)