### PR TITLE
feat: normalize upstream prose terminology (Java Script, webpages)

### DIFF
--- a/config/enrichment.yaml
+++ b/config/enrichment.yaml
@@ -163,6 +163,20 @@ branding:
       replacement: "example-corp"
       case_sensitive: false
 
+    # Prose terminology fixes — genuine upstream typos flagged by the textlint
+    # terminology gate. ONLY true prose belongs here. API identifiers that look
+    # like terminology errors (the cloudfront / salesforce_commerce_connector
+    # connector enums, the literal /common.js path) are deliberately NOT listed —
+    # rewriting them would corrupt the API contract; those are allowlisted in the
+    # downstream provider's textlint config instead.
+    - pattern: "\\bJava Script\\b"
+      replacement: "JavaScript"
+      case_sensitive: true
+
+    - pattern: "\\bwebpages\\b"
+      replacement: "web pages"
+      case_sensitive: false
+
 # Grammar improvements
 grammar:
   # Capitalize first letter of sentences

--- a/config/enrichment.yaml
+++ b/config/enrichment.yaml
@@ -249,7 +249,7 @@ schema_fixes:
     enabled: true
     mappings:
       FlashBladeEndpoint:
-        lables: labels
+        lables: labels # codespell:ignore lables
 
 # Tag generation settings
 tags:

--- a/tests/test_prose_normalization.py
+++ b/tests/test_prose_normalization.py
@@ -27,7 +27,9 @@ def test_java_script_normalized_to_javascript() -> None:
 
 
 def test_webpages_normalized_to_web_pages() -> None:
-    out = _t().transform_text("For Client-Side Defense to work on the webpages where you injected the JS.")
+    out = _t().transform_text(
+        "For Client-Side Defense to work on the webpages where you injected the JS."
+    )
     assert "web pages" in out
     assert "webpages" not in out
 

--- a/tests/test_prose_normalization.py
+++ b/tests/test_prose_normalization.py
@@ -1,0 +1,44 @@
+"""Prose terminology normalization in upstream F5 descriptions.
+
+The Lint Code Base gate (textlint terminology) flags genuine prose typos in
+upstream F5 text — e.g. "Java Script" (should be "JavaScript") and "webpages"
+(should be "web pages"). These are normalized here at the enrichment source so
+the generated provider docs are lint-clean.
+
+Critically, API identifiers that merely *look* like terminology errors —
+the `cloudfront` connector enum, the `salesforce_commerce_connector` enum, and
+the literal `/common.js` path — MUST be preserved byte-for-byte; rewriting them
+would corrupt the API contract.
+"""
+
+from __future__ import annotations
+
+from scripts.utils.branding import BrandingTransformer
+
+
+def _t() -> BrandingTransformer:
+    return BrandingTransformer()
+
+
+def test_java_script_normalized_to_javascript() -> None:
+    out = _t().transform_text("Web client will fetch F5 Client Java Script from this path.")
+    assert "JavaScript" in out
+    assert "Java Script" not in out
+
+
+def test_webpages_normalized_to_web_pages() -> None:
+    out = _t().transform_text("For Client-Side Defense to work on the webpages where you injected the JS.")
+    assert "web pages" in out
+    assert "webpages" not in out
+
+
+def test_common_js_path_preserved() -> None:
+    # A literal path value — must not be rewritten to "CommonJS" or anything else.
+    text = "If not specified, default to '/common.js'. Example: `\"/common.js\"`."
+    assert _t().transform_text(text) == text
+
+
+def test_connector_enum_values_preserved() -> None:
+    # API enum values / schema identifiers — must survive untouched.
+    text = 'Enum: ["cloudflare","cloudfront","custom_connector","f5_big_ip","salesforce_commerce_connector"]'
+    assert _t().transform_text(text) == text


### PR DESCRIPTION
## What

Two `branding.replacements` rules in `config/enrichment.yaml` to normalize genuine
upstream prose typos that fail the downstream provider's textlint terminology gate
(blocking all provider auto-regenerates / releases since v3.68.0):

- `Java Script` → `JavaScript`
- `webpages` → `web pages`

## Not touched (API contract)

`cloudfront` / `salesforce_commerce_connector` connector enum values and the literal
`/common.js` path resemble terminology errors but are real API identifiers — preserved
byte-for-byte here and allowlisted in the provider's textlint config instead.

## Verification

- TDD: `tests/test_prose_normalization.py` — RED first (2 prose cases failing), GREEN after
  the rules; also asserts the three API identifiers are preserved.
- Integration: `transform_spec` on the real `protected_domain` / `protected_application`
  source specs → 0 remaining bad terms, identifiers intact.
- Related suites (branding, title-preservation) green; 38 passed.

Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)