### PR TITLE
feat(enricher): emit structured cross-resource requires in x-f5xc-requires

### DIFF
--- a/scripts/utils/dependency_enricher.py
+++ b/scripts/utils/dependency_enricher.py
@@ -25,6 +25,30 @@ from .extension_constants import X_F5XC_REQUIRES
 
 logger = logging.getLogger(__name__)
 
+# Matches a cross-resource requirement declared in config in the resource-and-scope
+# form (for example, a protected_domain in the same namespace). It is parsed into a
+# structured requires_resource descriptor so downstream tooling (the
+# terraform-provider-xcsh preflight codegen) can mechanically derive an apply-time
+# prerequisite check instead of string-parsing the opaque requires_field. Issue #967.
+_RESOURCE_REQUIREMENT_RE = re.compile(
+    r"^resource:\s*(?P<resource>[a-z0-9_]+)\s*\(\s*(?P<scope>[^)]+?)\s*\)\s*$"
+)
+
+
+def _parse_resource_requirement(requires: str) -> dict[str, str] | None:
+    """Parse a ``resource:<name> (<scope>)`` requirement into a structured form.
+
+    Returns ``{"resource": <name>, "scope": <normalized scope>}`` when the string
+    matches the cross-resource form, else ``None`` (e.g. a sibling-field reference
+    such as ``spec.enable_waf``). Scope text is normalized to snake_case
+    (``"same namespace"`` -> ``"same_namespace"``).
+    """
+    match = _RESOURCE_REQUIREMENT_RE.match(requires)
+    if not match:
+        return None
+    scope = "_".join(match.group("scope").lower().split())
+    return {"resource": match.group("resource"), "scope": scope}
+
 
 @dataclass
 class DependencyEnrichmentStats:
@@ -245,7 +269,14 @@ class DependencyEnricher:
             requires_entry["required"] = dep["required"]
         if "requires" in dep:
             # Alternative format: 'requires' references another top-level field
+            # (opaque string, preserved for existing consumers).
             requires_entry["requires_field"] = dep["requires"]
+            # Additionally, if it names a cross-resource requirement
+            # ("resource:<name> (<scope>)"), emit a structured descriptor so the
+            # provider can auto-derive an apply-time preflight. Issue #967.
+            resource_requirement = _parse_resource_requirement(str(dep["requires"]))
+            if resource_requirement is not None:
+                requires_entry["requires_resource"] = resource_requirement
         if "reason" in dep:
             requires_entry["reason"] = dep["reason"]
         if "min_items" in dep:

--- a/tests/test_dependency_enricher.py
+++ b/tests/test_dependency_enricher.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Unit tests for the cross-field/cross-resource dependency enricher.
+
+Focus: the structured cross-resource requirement (`requires_resource`) that the
+enricher emits additively alongside the opaque `requires_field`, so downstream
+tooling (the terraform-provider-xcsh preflight codegen) can mechanically derive
+an apply-time prerequisite check. Issue #967.
+"""
+
+from scripts.utils.dependency_enricher import DependencyEnricher
+from scripts.utils.extension_constants import X_F5XC_REQUIRES
+
+
+def _stamp(dep, parent_prop="client_side_defense"):
+    """Stamp a single dependency onto a minimal schema and return the entry."""
+    enricher = DependencyEnricher()
+    schema = {"properties": {parent_prop: {}}}
+    enricher._stamp_dependency(schema, dep, "http_loadbalancerCreateSpecType")
+    return schema["properties"][parent_prop].get(X_F5XC_REQUIRES, [])
+
+
+def test_cross_resource_requires_emits_structured_form():
+    dep = {
+        "field": "spec.client_side_defense",
+        "requires": "resource:protected_domain (same namespace)",
+        "reason": "CSD needs a protected_domain in the same namespace.",
+    }
+    entries = _stamp(dep)
+    assert len(entries) == 1
+    entry = entries[0]
+    # Additive: opaque string preserved for existing consumers.
+    assert entry["requires_field"] == "resource:protected_domain (same namespace)"
+    # New structured form for mechanical consumers.
+    assert entry["requires_resource"] == {
+        "resource": "protected_domain",
+        "scope": "same_namespace",
+    }
+    assert entry["reason"].startswith("CSD needs")
+
+
+def test_sibling_field_requires_has_no_structured_resource():
+    dep = {"field": "spec.foo", "requires": "spec.enable_waf"}
+    entry = _stamp(dep, parent_prop="foo")[0]
+    assert entry["requires_field"] == "spec.enable_waf"
+    assert "requires_resource" not in entry
+
+
+def test_required_and_min_items_pass_through():
+    dep = {"field": "spec.bar", "required": True, "min_items": 2}
+    entry = _stamp(dep, parent_prop="bar")[0]
+    assert entry["required"] is True
+    assert entry["min_items"] == 2
+    assert "requires_resource" not in entry


### PR DESCRIPTION
## Summary

Makes the dependency enricher emit a **structured** cross-resource requirement in
`x-f5xc-requires`, so downstream tooling (the `terraform-provider-xcsh` apply-time preflight
codegen) can mechanically derive a prerequisite check instead of string-parsing an opaque field.

Closes #967.

## What changed

`scripts/utils/dependency_enricher.py`: when a config dependency's `requires:` names a
cross-resource requirement in the `resource:<name> (<scope>)` form, additionally emit:

```json
"requires_resource": { "resource": "protected_domain", "scope": "same_namespace" }
```

alongside the existing (preserved) `requires_field` / `reason`. **Additive** — sibling-field
`requires:` references (e.g. `spec.enable_waf`) still emit only `requires_field`, so existing
consumers are unaffected.

Adds `tests/test_dependency_enricher.py` — first unit coverage for the enricher (structured
form, sibling-field negative case, `required`/`min_items` pass-through).

## Verification

- `python -m pytest` — **2217 passed**, 2 skipped, 1 xfailed (incl. the 3 new tests, TDD red→green).
- `ruff check` + `ruff format --check` clean (repo config, py310).
- Integration run against the real config confirms the `client_side_defense` dependency now emits
  `requires_resource: {resource: protected_domain, scope: same_namespace}`.
- The contract-diff CI gate regenerates the enriched specs fresh and compares semantic shape; this
  change only adds an `x-` extension (additive metadata), so it does not drift the contract.

## Downstream (lock-step)

Unblocks a follow-up `terraform-provider-xcsh` PR that parses `requires_resource`, resolves the
target resource's LIST path from its own resource registry (`ResourceTemplate.APIPathPlural`,
including non-standard paths like CSD's `/api/shape/csd/...`), and auto-derives
`RequirementPreflight`s — making `preflight-requirements.json` override-only. No release is
triggered by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
