### PR TITLE
feat(namespace): authoritative default-deny classification from live CRUD

### DIFF
--- a/config/crud_probe_payloads.yaml
+++ b/config/crud_probe_payloads.yaml
@@ -167,3 +167,60 @@ ddos_protection:
   metadata: {name: crud-probe}
   spec:
     protected_entity: {}
+
+# --- Worklist payloads (2026-07-14): one required field each, from the API's
+# own 400 validation messages, to drive inconclusive resources to a verdict. ---
+address_allocator:
+  metadata: {name: crud-probe}
+  spec: {ipv4: {}, address_allocation_scheme: {sequential: {}}, address_pool: [{start_address: "10.0.0.1", end_address: "10.0.0.10"}]}
+authentication:
+  metadata: {name: crud-probe}
+  spec: {auth_type_choice: {}, cookie_params: {}}
+cminstance:
+  metadata: {name: crud-probe}
+  spec: {api_token: {clear_secret_info: {url: "string:///dGVzdA=="}}, ip: "10.0.0.1"}
+external_connector:
+  metadata: {name: crud-probe}
+  spec: {ce_site_reference: {tenant: t, namespace: system, name: dummy}, connection_type: {sli_to_global_dr: {}}}
+fast_acl_rule:
+  metadata: {name: crud-probe}
+  spec: {action: {simple_action: DENY}, source: {ip_prefixes: {ip_prefixes: ["1.2.3.4/32"]}}}
+k8s_cluster_role_binding:
+  metadata: {name: crud-probe}
+  spec: {k8s_cluster_role: {name: dummy, namespace: system, tenant: t}, subjects: [{user: {name: probe}}]}
+k8s_pod_security_admission:
+  metadata: {name: crud-probe}
+  spec: {pod_security_admission_specs: [{mode: enforce, level: privileged}]}
+nfv_service:
+  metadata: {name: crud-probe}
+  spec: {service_provider_choice: {}, f5_big_ip_aws_service: {}}
+proxy:
+  metadata: {name: crud-probe}
+  spec: {proxy_choice: {}, http_proxy: {}}
+report_config:
+  metadata: {name: crud-probe}
+  spec: {report_type: SECURITY, schedule_choice: {}}
+service_policy_rule:
+  metadata: {name: crud-probe}
+  spec: {waf_action: {none: {}}, action: DENY}
+srv6_network_slice:
+  metadata: {name: crud-probe}
+  spec: {sid_prefixes: ["fc00::/32"]}
+tpm_api_key:
+  metadata: {name: crud-probe}
+  spec: {category_ref: [{name: dummy, namespace: shared, tenant: t}]}
+tpm_category:
+  metadata: {name: crud-probe}
+  spec: {tpm_manager_ref: [{name: dummy, namespace: shared, tenant: t}]}
+usb_policy:
+  metadata: {name: crud-probe}
+  spec: {allowed_devices: {allowed_devices: [{vendor_id: "0x1234"}]}}
+workload_flavor:
+  metadata: {name: crud-probe}
+  spec: {vcpu: 2, memory: 4096}
+contact:
+  metadata: {name: crud-probe}
+  spec: {contact_choice: {}, email: {email: "probe@example.com"}}
+customer_support:
+  metadata: {name: crud-probe}
+  spec: {description: "namespace probe test", product: distributed_cloud}

--- a/config/namespace_crud_evidence.yaml
+++ b/config/namespace_crud_evidence.yaml
@@ -1,0 +1,2824 @@
+address_allocator:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/address_allocators
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.address_allocation_scheme should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.address_allocation_scheme should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.address_allocation_scheme should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+advertise_policy:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/advertise_policys
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.port_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.port_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.port_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+alert_policy:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/alert_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: statistics
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+alert_receiver:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/alert_receivers
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: statistics
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+api_definition:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/api_definitions
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: api
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: validation_error
+      error: ves.io.schema.views.api_definition.Object allowed to be created only
+        in shared or app, got system in request
+      status: 400
+  verdict: any_namespace
+app_api_group:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/app_api_groups
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: api
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: validation_error
+      error: ves.io.schema.views.app_api_group.Object allowed to be created only in
+        shared or app, got system in request
+      status: 400
+  verdict: any_namespace
+app_firewall:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/app_firewalls
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+app_setting:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/app_settings
+  domain: service_mesh
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.app_type_settings should have minimum items of 1, got 0 in
+        request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.app_type_settings should have minimum items of 1, got 0 in
+        request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.app_type_settings should have minimum items of 1, got 0 in
+        request.
+      status: 400
+  verdict: inconclusive
+app_type:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/app_types
+  domain: service_mesh
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: App Type can be created only in shared namespace
+      status: 400
+    demo:
+      classification: validation_error
+      error: App Type can be created only in shared namespace
+      status: 400
+    system:
+      classification: validation_error
+      error: App Type can be created only in shared namespace
+      status: 400
+  verdict: inconclusive
+authentication:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/authentications
+  domain: tenant_and_identity
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.auth_type_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.auth_type_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.auth_type_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+authorization_server:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/authorization_servers
+  domain: tenant_and_identity
+  probes:
+    default:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+    demo:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+    system:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+  verdict: inconclusive
+aws_tgw_site:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/aws_tgw_sites
+  domain: sites
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.aws_parameters should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.aws_parameters should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.aws_parameters should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+aws_vpc_site:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/aws_vpc_sites
+  domain: sites
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.deployment should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.deployment should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.deployment should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+azure_vnet_site:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/azure_vnet_sites
+  discovered_allowed:
+  - system
+  domain: sites
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.views.azure_vnet_site.Object allowed to be created only
+        in system, got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.views.azure_vnet_site.Object allowed to be created only
+        in system, got demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+bgp:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/bgps
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.bgp_parameters should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.bgp_parameters should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.bgp_parameters should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+bgp_asn_set:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/bgp_asn_sets
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.as_numbers should have minimum items of 1, got 0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.as_numbers should have minimum items of 1, got 0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.as_numbers should have minimum items of 1, got 0 in request.
+      status: 400
+  verdict: inconclusive
+bgp_routing_policy:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/bgp_routing_policys
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.rules should have minimum items of 1, got 0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.rules should have minimum items of 1, got 0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.rules should have minimum items of 1, got 0 in request.
+      status: 400
+  verdict: inconclusive
+bigip_http_proxy:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/bigip_http_proxys
+  domain: bigip
+  probes:
+    default:
+      classification: server_error
+      error: Not Implemented
+      status: 501
+    demo:
+      classification: server_error
+      error: Not Implemented
+      status: 501
+    system:
+      classification: server_error
+      error: Not Implemented
+      status: 501
+  verdict: inconclusive
+bigip_irule:
+  confidence: low
+  create_path: /api/bigipconnector/namespaces/{namespace}/bigip_irules
+  domain: bigip
+  probes:
+    default:
+      classification: forbidden
+      error: null
+      status: 403
+    demo:
+      classification: forbidden
+      error: null
+      status: 403
+    system:
+      classification: forbidden
+      error: null
+      status: 403
+  verdict: inconclusive
+bot_defense_app_infrastructure:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/bot_defense_app_infrastructures
+  domain: bot_and_threat_defense
+  probes:
+    default:
+      classification: forbidden
+      error: null
+      status: 403
+    demo:
+      classification: forbidden
+      error: null
+      status: 403
+    system:
+      classification: forbidden
+      error: null
+      status: 403
+  verdict: inconclusive
+cdn_cache_rule:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/cdn_cache_rules
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: cdn
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+cdn_loadbalancer:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/cdn_loadbalancers
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: cdn
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+cdn_purge_command:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/cdn_purge_commands
+  domain: cdn
+  probes:
+    default:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+    demo:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+    system:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+  verdict: inconclusive
+certificate:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/certificates
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: certificates
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+certificate_chain:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/certificate_chains
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: certificates
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+cloud_connect:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/cloud_connects
+  domain: cloud_infrastructure
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.cloud should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.cloud should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.cloud should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+cloud_credentials:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/cloud_credentialss
+  domain: cloud_infrastructure
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.cloud_credentials.Object allowed to be created only in
+        system, got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.cloud_credentials.Object allowed to be created only in
+        system, got demo in request
+      status: 400
+    system:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+  verdict: inconclusive
+cloud_elastic_ip:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/cloud_elastic_ips
+  domain: cloud_infrastructure
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.count should be greater than or equal to 1, got 0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.count should be greater than or equal to 1, got 0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.count should be greater than or equal to 1, got 0 in request.
+      status: 400
+  verdict: inconclusive
+cloud_link:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/cloud_links
+  domain: cloud_infrastructure
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.cloud_provider should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.cloud_provider should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.cloud_provider should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+cluster:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/clusters
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+cminstance:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/cminstances
+  domain: marketplace
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.api_token should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.api_token should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.api_token should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+contact:
+  confidence: low
+  create_path: /api/web/namespaces/{namespace}/contacts
+  domain: tenant_and_identity
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Address is not valid
+      status: 400
+    demo:
+      classification: validation_error
+      error: Address is not valid
+      status: 400
+    system:
+      classification: validation_error
+      error: Address is not valid
+      status: 400
+  verdict: inconclusive
+container_registry:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/container_registrys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: managed_kubernetes
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: validation_error
+      error: ves.io.schema.container_registry.Object allowed to be created only in
+        shared or app, got system in request
+      status: 400
+  verdict: any_namespace
+crl:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/crls
+  domain: certificates
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.refresh_interval should be greater than or equal to 6, got
+        0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.refresh_interval should be greater than or equal to 6, got
+        0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.refresh_interval should be greater than or equal to 6, got
+        0 in request.
+      status: 400
+  verdict: inconclusive
+customer_support:
+  confidence: low
+  create_path: /api/web/namespaces/{namespace}/customer_supports
+  domain: support
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: 'validate customer_support request: both description and product data
+        are empty'
+      status: 400
+    demo:
+      classification: validation_error
+      error: 'validate customer_support request: both description and product data
+        are empty'
+      status: 400
+    system:
+      classification: validation_error
+      error: 'validate customer_support request: both description and product data
+        are empty'
+      status: 400
+  verdict: inconclusive
+data_type:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/data_types
+  domain: data_and_privacy_security
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.rules should have minimum items of 1, got 0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.rules should have minimum items of 1, got 0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.rules should have minimum items of 1, got 0 in request.
+      status: 400
+  verdict: inconclusive
+dc_cluster_group:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/dc_cluster_groups
+  discovered_allowed:
+  - system
+  domain: network
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.dc_cluster_group.Object allowed to be created only in system,
+        got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.dc_cluster_group.Object allowed to be created only in system,
+        got demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+discovery:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/discoverys
+  domain: api
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.discovery_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.discovery_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.discovery_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+dns_compliance_checks:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/dns_compliance_checkss
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: dns
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+dns_domain:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/dns_domains
+  domain: dns
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Name of the DNS Domain object must be a valid fully qualified domain
+        name
+      status: 400
+    demo:
+      classification: validation_error
+      error: Name of the DNS Domain object must be a valid fully qualified domain
+        name
+      status: 400
+    system:
+      classification: validation_error
+      error: Name of the DNS Domain object must be a valid fully qualified domain
+        name
+      status: 400
+  verdict: inconclusive
+dns_lb_health_check:
+  confidence: low
+  create_path: /api/config/dns/namespaces/{namespace}/dns_lb_health_checks
+  domain: dns
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.health_check should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.health_check should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.health_check should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+dns_lb_pool:
+  confidence: low
+  create_path: /api/config/dns/namespaces/{namespace}/dns_lb_pools
+  domain: dns
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.pool_type_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.pool_type_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.pool_type_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+dns_load_balancer:
+  confidence: high
+  create_path: /api/config/dns/namespaces/{namespace}/dns_load_balancers
+  discovered_allowed:
+  - system
+  domain: dns
+  probes:
+    default:
+      classification: ns_restricted
+      error: 'Creation of DNS objects outside system namespace not permitted. Provided
+        namespace: default'
+      status: 400
+    demo:
+      classification: ns_restricted
+      error: 'Creation of DNS objects outside system namespace not permitted. Provided
+        namespace: demo'
+      status: 400
+    system:
+      classification: validation_error
+      error: Empty tenant or namespace
+      status: 400
+  verdict: system_only
+dns_proxy:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/dns_proxys
+  domain: dns
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.cache_profile should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.cache_profile should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.cache_profile should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+dns_zone:
+  confidence: low
+  create_path: /api/config/dns/namespaces/{namespace}/dns_zones
+  domain: dns
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Name of the dns_zone object must be a valid fully qualified domain name
+      status: 400
+    demo:
+      classification: validation_error
+      error: Name of the dns_zone object must be a valid fully qualified domain name
+      status: 400
+    system:
+      classification: validation_error
+      error: Name of the dns_zone object must be a valid fully qualified domain name
+      status: 400
+  verdict: inconclusive
+endpoint:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/endpoints
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: service_mesh
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+enhanced_firewall_policy:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/enhanced_firewall_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+external_connector:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/external_connectors
+  domain: marketplace
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.ce_site_reference should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.ce_site_reference should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.ce_site_reference should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+fast_acl:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/fast_acls
+  discovered_allowed:
+  - system
+  domain: network_security
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.fast_acl.Object allowed to be created only in system, got
+        default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.fast_acl.Object allowed to be created only in system, got
+        demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+fast_acl_rule:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/fast_acl_rules
+  domain: network_security
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.action should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.action should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.action should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+filter_set:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/filter_sets
+  domain: network_security
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.filter_fields should have minimum items of 1, got 0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.filter_fields should have minimum items of 1, got 0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.filter_fields should have minimum items of 1, got 0 in request.
+      status: 400
+  verdict: inconclusive
+fleet:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/fleets
+  domain: ce_management
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.fleet.Object allowed to be created only in system, got
+        default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.fleet.Object allowed to be created only in system, got
+        demo in request
+      status: 400
+    system:
+      classification: validation_error
+      error: 'Does not satisfy DNS-1035 label requirements: a DNS-1035 label must
+        consist of lower case alphanumeric characters or ''-'', start with an alphabetic
+        character, and end with an alphanumeric character'
+      status: 400
+  verdict: inconclusive
+forward_proxy_policy:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/forward_proxy_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: network_security
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: validation_error
+      error: forward_proxy_policy object with DrpHttpConnect enabled cannot be in
+        system namespace
+      status: 400
+  verdict: any_namespace
+forwarding_class:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/forwarding_classs
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.queueing_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.queueing_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.queueing_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+gcp_vpc_site:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/gcp_vpc_sites
+  domain: sites
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.deployment should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.deployment should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.deployment should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+geo_location_set:
+  confidence: high
+  create_path: /api/config/dns/namespaces/{namespace}/geo_location_sets
+  discovered_allowed:
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: ns_restricted
+      error: 'Creation of DNS objects outside system namespace not permitted. Provided
+        namespace: default'
+      status: 400
+    demo:
+      classification: ns_restricted
+      error: 'Creation of DNS objects outside system namespace not permitted. Provided
+        namespace: demo'
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_only
+global_log_receiver:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/global_log_receivers
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: statistics
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+healthcheck:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/healthchecks
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+http_loadbalancer:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/http_loadbalancers
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+ike1:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/ike1s
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: network
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+ike2:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/ike2s
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: network
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+ike_phase1_profile:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/ike_phase1_profiles
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: network
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+ike_phase2_profile:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/ike_phase2_profiles
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: network
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+infraprotect_asn:
+  confidence: low
+  create_path: /api/infraprotect/namespaces/{namespace}/infraprotect_asns
+  domain: ddos
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.asn should be greater than or equal to 1, got 0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.asn should be greater than or equal to 1, got 0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.asn should be greater than or equal to 1, got 0 in request.
+      status: 400
+  verdict: inconclusive
+infraprotect_asn_prefix:
+  confidence: low
+  create_path: /api/infraprotect/namespaces/{namespace}/infraprotect_asn_prefixs
+  domain: ddos
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.asn should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.asn should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.asn should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+infraprotect_deny_list_rule:
+  confidence: low
+  create_path: /api/infraprotect/namespaces/{namespace}/infraprotect_deny_list_rules
+  domain: ddos
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.infraprotect_deny_list_rule.Object allowed to be created
+        only in system, got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.infraprotect_deny_list_rule.Object allowed to be created
+        only in system, got demo in request
+      status: 400
+    system:
+      classification: validation_error
+      error: Invalid IP Prefix Provided
+      status: 400
+  verdict: inconclusive
+infraprotect_firewall_rule:
+  confidence: low
+  create_path: /api/infraprotect/namespaces/{namespace}/infraprotect_firewall_rules
+  domain: ddos
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.destination_prefix should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.destination_prefix should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.destination_prefix should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+infraprotect_firewall_rule_group:
+  confidence: medium
+  create_path: /api/infraprotect/namespaces/{namespace}/infraprotect_firewall_rule_groups
+  discovered_allowed:
+  - system
+  domain: ddos
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.infraprotect_firewall_rule_group.Object allowed to be created
+        only in system, got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.infraprotect_firewall_rule_group.Object allowed to be created
+        only in system, got demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+infraprotect_internet_prefix_advertisement:
+  confidence: low
+  create_path: /api/infraprotect/namespaces/{namespace}/infraprotect_internet_prefix_advertisements
+  domain: ddos
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.infraprotect_internet_prefix_advertisement.Object allowed
+        to be created only in system, got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.infraprotect_internet_prefix_advertisement.Object allowed
+        to be created only in system, got demo in request
+      status: 400
+    system:
+      classification: validation_error
+      error: prefix is required
+      status: 400
+  verdict: inconclusive
+infraprotect_tunnel:
+  confidence: low
+  create_path: /api/infraprotect/namespaces/{namespace}/infraprotect_tunnels
+  domain: ddos
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.bgp_information should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.bgp_information should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.bgp_information should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+ip_prefix_set:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/ip_prefix_sets
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: IP Prefix Set must contain at least one IP prefix
+      status: 400
+    demo:
+      classification: validation_error
+      error: IP Prefix Set must contain at least one IP prefix
+      status: 400
+    system:
+      classification: validation_error
+      error: IP Prefix Set must contain at least one IP prefix
+      status: 400
+  verdict: inconclusive
+k8s_cluster:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/k8s_clusters
+  discovered_allowed:
+  - system
+  domain: sites
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.k8s_cluster.Object allowed to be created only in system,
+        got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.k8s_cluster.Object allowed to be created only in system,
+        got demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+k8s_cluster_role:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/k8s_cluster_roles
+  discovered_allowed:
+  - system
+  domain: managed_kubernetes
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.k8s_cluster_role.Object allowed to be created only in system,
+        got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.k8s_cluster_role.Object allowed to be created only in system,
+        got demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+k8s_cluster_role_binding:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/k8s_cluster_role_bindings
+  domain: managed_kubernetes
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.k8s_cluster_role should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.k8s_cluster_role should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.k8s_cluster_role should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+k8s_pod_security_admission:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/k8s_pod_security_admissions
+  discovered_allowed:
+  - system
+  domain: managed_kubernetes
+  probes:
+    default:
+      classification: ns_restricted
+      error: ves.io.schema.k8s_pod_security_admission.Object allowed to be created
+        only in system, got default in request
+      restriction_allowed:
+      - system
+      status: 400
+    demo:
+      classification: ns_restricted
+      error: ves.io.schema.k8s_pod_security_admission.Object allowed to be created
+        only in system, got demo in request
+      restriction_allowed:
+      - system
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_only
+k8s_pod_security_policy:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/k8s_pod_security_policys
+  domain: managed_kubernetes
+  probes:
+    default:
+      classification: server_error
+      error: Not Implemented
+      status: 501
+    demo:
+      classification: server_error
+      error: Not Implemented
+      status: 501
+    system:
+      classification: server_error
+      error: Not Implemented
+      status: 501
+  verdict: inconclusive
+log_receiver:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/log_receivers
+  domain: statistics
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.log_receiver_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.log_receiver_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.log_receiver_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+malicious_user_mitigation:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/malicious_user_mitigations
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: secops_and_incident_response
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+nat_policy:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/nat_policys
+  domain: network_security
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.applies_to_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.applies_to_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.applies_to_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+network_connector:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/network_connectors
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.connector_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.connector_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.connector_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+network_firewall:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/network_firewalls
+  discovered_allowed:
+  - system
+  domain: network_security
+  probes:
+    default:
+      classification: validation_error
+      error: Network Firewall can be created only in system namespace
+      status: 400
+    demo:
+      classification: validation_error
+      error: Network Firewall can be created only in system namespace
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+network_interface:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/network_interfaces
+  domain: ce_management
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.interface_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.interface_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.interface_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+network_policy:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/network_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: network_security
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: validation_error
+      error: ves.io.schema.network_policy.Object allowed to be created only in shared
+        or app, got system in request
+      status: 400
+  verdict: any_namespace
+network_policy_rule:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/network_policy_rules
+  domain: network_security
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.protocol should be within set "["ALL","TCP","UDP","ICMP"]",
+        got "" in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.protocol should be within set "["ALL","TCP","UDP","ICMP"]",
+        got "" in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.protocol should be within set "["ALL","TCP","UDP","ICMP"]",
+        got "" in request.
+      status: 400
+  verdict: inconclusive
+network_policy_view:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/network_policy_views
+  discovered_allowed:
+  - system
+  domain: network_security
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.views.network_policy_view.Object allowed to be created
+        only in system, got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.views.network_policy_view.Object allowed to be created
+        only in system, got demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+nfv_service:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/nfv_services
+  domain: service_mesh
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.service_provider_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.service_provider_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.service_provider_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+origin_pool:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/origin_pools
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+policer:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/policers
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: rate_limiting
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+policy_based_routing:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/policy_based_routings
+  domain: network_security
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.forwarding_class_list should have minimum items of 1, got
+        0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.forwarding_class_list should have minimum items of 1, got
+        0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.forwarding_class_list should have minimum items of 1, got
+        0 in request.
+      status: 400
+  verdict: inconclusive
+protocol_inspection:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/protocol_inspections
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+protocol_policer:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/protocol_policers
+  discovered_allowed:
+  - system
+  domain: rate_limiting
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.protocol_policer.Object allowed to be created only in system,
+        got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.protocol_policer.Object allowed to be created only in system,
+        got demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+proxy:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/proxys
+  domain: virtual
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.proxy_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.proxy_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.proxy_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+quota:
+  confidence: low
+  create_path: /api/web/namespaces/{namespace}/quotas
+  domain: billing_and_usage
+  probes:
+    default:
+      classification: forbidden
+      error: null
+      status: 403
+    demo:
+      classification: forbidden
+      error: null
+      status: 403
+    system:
+      classification: forbidden
+      error: null
+      status: 403
+  verdict: inconclusive
+rate_limiter:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/rate_limiters
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: rate_limiting
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+rate_limiter_policy:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/rate_limiter_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: validation_error
+      error: ves.io.schema.views.rate_limiter_policy.Object allowed to be created
+        only in shared or app, got system in request
+      status: 400
+  verdict: any_namespace
+registration:
+  confidence: low
+  create_path: /api/register/namespaces/{namespace}/registrations
+  domain: ce_management
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.infra should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.infra should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.infra should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+report_config:
+  confidence: low
+  create_path: /api/report/namespaces/{namespace}/report_configs
+  domain: statistics
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.report_type should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.report_type should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.report_type should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+role:
+  confidence: high
+  create_path: /api/web/namespaces/{namespace}/roles
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: tenant_and_identity
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+route:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/routes
+  domain: network
+  probes:
+    default:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+    demo:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+    system:
+      classification: server_error
+      error: There was a server error in processing request
+      status: 500
+  verdict: inconclusive
+secret_management_access:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/secret_management_accesss
+  domain: blindfold
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.access_info should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.access_info should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.access_info should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+secret_policy:
+  confidence: high
+  create_path: /api/secret_management/namespaces/{namespace}/secret_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: blindfold
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+secret_policy_rule:
+  confidence: low
+  create_path: /api/secret_management/namespaces/{namespace}/secret_policy_rules
+  domain: blindfold
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.client_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.client_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.client_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+securemesh_site:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/securemesh_sites
+  domain: sites
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.master_node_configuration should be one of 1 or 3, got 0 in
+        request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.master_node_configuration should be one of 1 or 3, got 0 in
+        request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.master_node_configuration should be one of 1 or 3, got 0 in
+        request.
+      status: 400
+  verdict: inconclusive
+securemesh_site_v2:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/securemesh_site_v2s
+  discovered_allowed:
+  - system
+  domain: sites
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.views.securemesh_site_v2.Object allowed to be created only
+        in system, got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.views.securemesh_site_v2.Object allowed to be created only
+        in system, got demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+segment:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/segments
+  discovered_allowed:
+  - system
+  domain: network_security
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.segment.Object allowed to be created only in system, got
+        default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.segment.Object allowed to be created only in system, got
+        demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+sensitive_data_policy:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/sensitive_data_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: data_and_privacy_security
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+service_policy:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/service_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: network_security
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+service_policy_rule:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/service_policy_rules
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+site_mesh_group:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/site_mesh_groups
+  domain: service_mesh
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.bfd_choice should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.bfd_choice should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.bfd_choice should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+srv6_network_slice:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/srv6_network_slices
+  discovered_allowed:
+  - system
+  domain: network
+  probes:
+    default:
+      classification: ns_restricted
+      error: ves.io.schema.srv6_network_slice.Object allowed to be created only in
+        system, got default in request
+      restriction_allowed:
+      - system
+      status: 400
+    demo:
+      classification: ns_restricted
+      error: ves.io.schema.srv6_network_slice.Object allowed to be created only in
+        system, got demo in request
+      restriction_allowed:
+      - system
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_only
+subnet:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/subnets
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.site_subnet_params should have minimum items of 1, got 0 in
+        request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.site_subnet_params should have minimum items of 1, got 0 in
+        request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.site_subnet_params should have minimum items of 1, got 0 in
+        request.
+      status: 400
+  verdict: inconclusive
+tcp_loadbalancer:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/tcp_loadbalancers
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+tenant_configuration:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/tenant_configurations
+  domain: tenant_and_identity
+  probes:
+    default:
+      classification: server_error
+      error: Not Implemented
+      status: 501
+    demo:
+      classification: server_error
+      error: Not Implemented
+      status: 501
+    system:
+      classification: server_error
+      error: Not Implemented
+      status: 501
+  verdict: inconclusive
+token:
+  confidence: medium
+  create_path: /api/register/namespaces/{namespace}/tokens
+  discovered_allowed:
+  - system
+  domain: users
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.token.Object allowed to be created only in system, got
+        default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.token.Object allowed to be created only in system, got
+        demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+tpm_api_key:
+  confidence: low
+  create_path: /api/tpm/namespaces/{namespace}/tpm_api_keys
+  domain: bot_and_threat_defense
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.category_ref should have minimum items of 1, got 0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.category_ref should have minimum items of 1, got 0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.category_ref should have minimum items of 1, got 0 in request.
+      status: 400
+  verdict: inconclusive
+tpm_category:
+  confidence: low
+  create_path: /api/tpm/namespaces/{namespace}/tpm_categorys
+  domain: bot_and_threat_defense
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.tpm_manager_ref should have minimum items of 1, got 0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.tpm_manager_ref should have minimum items of 1, got 0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.tpm_manager_ref should have minimum items of 1, got 0 in request.
+      status: 400
+  verdict: inconclusive
+tpm_manager:
+  confidence: high
+  create_path: /api/tpm/namespaces/{namespace}/tpm_managers
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: bot_and_threat_defense
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+trusted_ca_list:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/trusted_ca_lists
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: certificates
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+tunnel:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/tunnels
+  domain: network
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.local_ip should be not nil, got nil in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.local_ip should be not nil, got nil in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.local_ip should be not nil, got nil in request.
+      status: 400
+  verdict: inconclusive
+udp_loadbalancer:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/udp_loadbalancers
+  domain: virtual
+  probes:
+    default:
+      classification: forbidden
+      error: null
+      status: 403
+    demo:
+      classification: forbidden
+      error: null
+      status: 403
+    system:
+      classification: forbidden
+      error: null
+      status: 403
+  verdict: inconclusive
+usb_policy:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/usb_policys
+  domain: ce_management
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.allowed_devices should have minimum items of 1, got 0 in request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.allowed_devices should have minimum items of 1, got 0 in request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.allowed_devices should have minimum items of 1, got 0 in request.
+      status: 400
+  verdict: inconclusive
+user_identification:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/user_identifications
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: tenant_and_identity
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+virtual_host:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/virtual_hosts
+  domain: virtual
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: Field spec.proxy should be within set [SMA_PROXY UDP_PROXY], got 0 in
+        request.
+      status: 400
+    demo:
+      classification: validation_error
+      error: Field spec.proxy should be within set [SMA_PROXY UDP_PROXY], got 0 in
+        request.
+      status: 400
+    system:
+      classification: validation_error
+      error: Field spec.proxy should be within set [SMA_PROXY UDP_PROXY], got 0 in
+        request.
+      status: 400
+  verdict: inconclusive
+virtual_k8s:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/virtual_k8ss
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: container_services
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+virtual_network:
+  confidence: medium
+  create_path: /api/config/namespaces/{namespace}/virtual_networks
+  discovered_allowed:
+  - system
+  domain: network
+  probes:
+    default:
+      classification: validation_error
+      error: ves.io.schema.virtual_network.Object allowed to be created only in system,
+        got default in request
+      status: 400
+    demo:
+      classification: validation_error
+      error: ves.io.schema.virtual_network.Object allowed to be created only in system,
+        got demo in request
+      status: 400
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: system_confirmed
+virtual_site:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/virtual_sites
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: sites
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+voltshare_admin_policy:
+  confidence: high
+  create_path: /api/secret_management/namespaces/{namespace}/voltshare_admin_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: blindfold
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+voltstack_site:
+  confidence: low
+  create_path: /api/config/namespaces/{namespace}/voltstack_sites
+  domain: sites
+  note: "All namespaces returned validation errors \u2014 namespace check may happen\
+    \ after field validation"
+  probes:
+    default:
+      classification: validation_error
+      error: 'Field spec.volterra_certified_hw should have minimum length of 1, got
+        0 (value: "") in request.'
+      status: 400
+    demo:
+      classification: validation_error
+      error: 'Field spec.volterra_certified_hw should have minimum length of 1, got
+        0 (value: "") in request.'
+      status: 400
+    system:
+      classification: validation_error
+      error: 'Field spec.volterra_certified_hw should have minimum length of 1, got
+        0 (value: "") in request.'
+      status: 400
+  verdict: inconclusive
+waf_exclusion_policy:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/waf_exclusion_policys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: virtual
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+workload:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/workloads
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
+  domain: container_services
+  probes:
+    default:
+      classification: created
+      error: null
+      status: 200
+    demo:
+      classification: created
+      error: null
+      status: 200
+    system:
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
+workload_flavor:
+  confidence: high
+  create_path: /api/config/namespaces/{namespace}/workload_flavors
+  discovered_allowed:
+  - shared
+  domain: container_services
+  probes:
+    default:
+      classification: ns_restricted
+      error: ves.io.schema.workload_flavor.Object allowed to be created only in shared,
+        got default in request
+      restriction_allowed:
+      - shared
+      status: 400
+    demo:
+      classification: ns_restricted
+      error: ves.io.schema.workload_flavor.Object allowed to be created only in shared,
+        got demo in request
+      restriction_allowed:
+      - shared
+      status: 400
+    system:
+      classification: ns_restricted
+      error: ves.io.schema.workload_flavor.Object allowed to be created only in shared,
+        got system in request
+      restriction_allowed:
+      - shared
+      status: 400
+  verdict: shared_only

--- a/config/namespace_verdicts.yaml
+++ b/config/namespace_verdicts.yaml
@@ -1,0 +1,583 @@
+# MACHINE-GENERATED — do not edit by hand.
+# Regenerate: python -m scripts.generate_namespace_verdicts
+# Source evidence: config/namespace_crud_evidence.yaml
+#
+# Authoritative, live-CRUD-verified namespace constraints. The enricher
+# layers these OVER config/namespace_profile.yaml (verdict wins).
+verdicts:
+  address_allocator:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: &id002
+      - system
+  alert_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: &id001
+      - custom
+      - default
+      - shared
+  alert_receiver:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  api_definition:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  app_api_group:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  app_firewall:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  authentication:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  authorization_server:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  azure_vnet_site:
+    _verification:
+      evidence: ves.io.schema.views.azure_vnet_site.Object allowed to be created only
+        in system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  bigip_http_proxy:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  cdn_cache_rule:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  cdn_loadbalancer:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  cdn_purge_command:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  certificate:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  certificate_chain:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  cluster:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  cminstance:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  contact:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  container_registry:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  customer_support:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  dc_cluster_group:
+    _verification:
+      evidence: ves.io.schema.dc_cluster_group.Object allowed to be created only in
+        system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  dns_compliance_checks:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  dns_load_balancer:
+    _verification:
+      evidence: 'Creation of DNS objects outside system namespace not permitted. Provided
+        namespace: default'
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  endpoint:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  enhanced_firewall_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  external_connector:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  fast_acl:
+    _verification:
+      evidence: ves.io.schema.fast_acl.Object allowed to be created only in system,
+        got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  fast_acl_rule:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  forward_proxy_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  geo_location_set:
+    _verification:
+      evidence: 'Creation of DNS objects outside system namespace not permitted. Provided
+        namespace: default'
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  global_log_receiver:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  healthcheck:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  http_loadbalancer:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  ike1:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  ike2:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  ike_phase1_profile:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  ike_phase2_profile:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  infraprotect_firewall_rule_group:
+    _verification:
+      evidence: ves.io.schema.infraprotect_firewall_rule_group.Object allowed to be
+        created only in system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  k8s_cluster:
+    _verification:
+      evidence: ves.io.schema.k8s_cluster.Object allowed to be created only in system,
+        got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  k8s_cluster_role:
+    _verification:
+      evidence: ves.io.schema.k8s_cluster_role.Object allowed to be created only in
+        system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  k8s_cluster_role_binding:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  k8s_pod_security_admission:
+    _verification:
+      evidence: ves.io.schema.k8s_pod_security_admission.Object allowed to be created
+        only in system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  k8s_pod_security_policy:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  malicious_user_mitigation:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  network_firewall:
+    _verification:
+      evidence: Network Firewall can be created only in system namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  network_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  network_policy_view:
+    _verification:
+      evidence: ves.io.schema.views.network_policy_view.Object allowed to be created
+        only in system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  nfv_service:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  origin_pool:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  policer:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  protocol_inspection:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  protocol_policer:
+    _verification:
+      evidence: ves.io.schema.protocol_policer.Object allowed to be created only in
+        system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  proxy:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  rate_limiter:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  rate_limiter_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  report_config:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  role:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  secret_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  securemesh_site_v2:
+    _verification:
+      evidence: ves.io.schema.views.securemesh_site_v2.Object allowed to be created
+        only in system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  segment:
+    _verification:
+      evidence: ves.io.schema.segment.Object allowed to be created only in system,
+        got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  sensitive_data_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  service_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  service_policy_rule:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  srv6_network_slice:
+    _verification:
+      evidence: ves.io.schema.srv6_network_slice.Object allowed to be created only
+        in system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  tcp_loadbalancer:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  token:
+    _verification:
+      evidence: ves.io.schema.token.Object allowed to be created only in system, got
+        default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  tpm_api_key:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  tpm_category:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  tpm_manager:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  trusted_ca_list:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  usb_policy:
+    _verification:
+      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
+      method: default_deny
+      status: restricted
+    constraint:
+      allowed: *id002
+  user_identification:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  virtual_k8s:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  virtual_network:
+    _verification:
+      evidence: ves.io.schema.virtual_network.Object allowed to be created only in
+        system, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id002
+  virtual_site:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  voltshare_admin_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  waf_exclusion_policy:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  workload:
+    _verification:
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
+    constraint:
+      allowed: *id001
+  workload_flavor:
+    _verification:
+      evidence: ves.io.schema.workload_flavor.Object allowed to be created only in
+        shared, got default in request
+      method: crud
+      status: verified
+    constraint:
+      allowed:
+      - shared
+version: 1

--- a/docs/specifications/api/namespace_profiles.json
+++ b/docs/specifications/api/namespace_profiles.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.1.176",
-  "generated_at": "2026-07-14T23:05:08.041780+00:00",
+  "version": "0.0.0",
+  "generated_at": "2026-07-15T02:46:03.352252+00:00",
   "source": "api-specs-enriched/config/namespace_profile.yaml",
   "default": {
     "constraint": {
@@ -22,6 +22,28 @@
     }
   },
   "resources": {
+    "address_allocator": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
     "advertise_policy": {
       "constraint": {
         "allowed": [
@@ -117,7 +139,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -130,8 +152,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "alert_policy_set": {
@@ -159,9 +181,11 @@
     "alert_receiver": {
       "constraint": {
         "allowed": [
-          "system"
+          "custom",
+          "default",
+          "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "system",
@@ -174,8 +198,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "allowed_domain": {
@@ -295,7 +319,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -308,8 +332,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "api_discovery": {
@@ -422,6 +446,30 @@
         "method": "conservative_default"
       }
     },
+    "app_api_group": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
     "app_firewall": {
       "constraint": {
         "allowed": [
@@ -429,7 +477,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -447,8 +495,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "app_setting": {
@@ -517,6 +565,28 @@
         "method": "conservative_default"
       }
     },
+    "authentication": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
     "authentication_policy": {
       "constraint": {
         "allowed": [
@@ -537,6 +607,28 @@
         "explicit": true,
         "verification": "restricted",
         "method": "conservative_default"
+      }
+    },
+    "authorization_server": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
       }
     },
     "aws_tgw_site": {
@@ -588,7 +680,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "system",
@@ -601,8 +693,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "bgp": {
@@ -691,6 +783,28 @@
         "explicit": true,
         "verification": "restricted",
         "method": "conservative_default"
+      }
+    },
+    "bigip_http_proxy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
       }
     },
     "bigip_irule": {
@@ -961,6 +1075,30 @@
         "method": "crud"
       }
     },
+    "cdn_cache_rule": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
     "cdn_loadbalancer": {
       "constraint": {
         "allowed": [
@@ -1007,6 +1145,28 @@
         "method": "conservative_default"
       }
     },
+    "cdn_purge_command": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
     "certificate": {
       "constraint": {
         "allowed": [
@@ -1014,7 +1174,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -1027,8 +1187,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "certificate_chain": {
@@ -1038,7 +1198,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -1051,8 +1211,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "cloud_connect": {
@@ -1143,6 +1303,74 @@
         "method": ""
       }
     },
+    "cluster": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "cminstance": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
+    "contact": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
     "container_registry": {
       "constraint": {
         "allowed": [
@@ -1189,6 +1417,28 @@
         "explicit": true,
         "verification": "unverified",
         "method": ""
+      }
+    },
+    "customer_support": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
       }
     },
     "dashboard": {
@@ -1310,7 +1560,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "system",
@@ -1323,8 +1573,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "ddos_mitigation_rule": {
@@ -1413,6 +1663,30 @@
         "explicit": true,
         "verification": "unverified",
         "method": ""
+      }
+    },
+    "dns_compliance_checks": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "dns_domain": {
@@ -1574,9 +1848,11 @@
     "enhanced_firewall_policy": {
       "constraint": {
         "allowed": [
-          "system"
+          "custom",
+          "default",
+          "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -1589,8 +1865,30 @@
       },
       "_meta": {
         "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "external_connector": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
         "verification": "restricted",
-        "method": "conservative_default"
+        "method": "default_deny"
       }
     },
     "fast_acl": {
@@ -1598,7 +1896,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "system",
@@ -1611,8 +1909,30 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "fast_acl_rule": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
       }
     },
     "filter_set": {
@@ -1712,7 +2032,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -1730,8 +2050,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "forwarding_class": {
@@ -1783,11 +2103,9 @@
     "geo_location_set": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -1800,16 +2118,18 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "global_log_receiver": {
       "constraint": {
         "allowed": [
-          "system"
+          "custom",
+          "default",
+          "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "system",
@@ -1822,8 +2142,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "global_network": {
@@ -1855,7 +2175,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -1868,8 +2188,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "http_loadbalancer": {
@@ -1879,7 +2199,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -1892,8 +2212,104 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "ike1": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "ike2": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "ike_phase1_profile": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "ike_phase2_profile": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "infraprotect_asn": {
@@ -1989,7 +2405,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -2002,8 +2418,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "restricted",
-        "method": "conservative_default"
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "infraprotect_firewall_ruleset": {
@@ -2150,7 +2566,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "system",
@@ -2163,8 +2579,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "k8s_cluster_role": {
@@ -2187,6 +2603,72 @@
         "explicit": true,
         "verification": "verified",
         "method": "crud"
+      }
+    },
+    "k8s_cluster_role_binding": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
+    "k8s_pod_security_admission": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "k8s_pod_security_policy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
       }
     },
     "known_label": {
@@ -2350,7 +2832,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -2363,8 +2845,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "malicious_user_rule": {
@@ -2725,6 +3207,50 @@
         "method": ""
       }
     },
+    "network_policy_view": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "nfv_service": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
     "nginx_config": {
       "constraint": {
         "allowed": [
@@ -2908,7 +3434,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -2921,8 +3447,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "otp_policy": {
@@ -2998,7 +3524,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -3011,8 +3537,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "policy_based_routing": {
@@ -3106,9 +3632,11 @@
     "protocol_inspection": {
       "constraint": {
         "allowed": [
-          "system"
+          "custom",
+          "default",
+          "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "system",
@@ -3121,18 +3649,16 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "protocol_policer": {
       "constraint": {
         "allowed": [
-          "custom",
-          "default",
-          "shared"
+          "system"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -3145,8 +3671,30 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "proxy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
       }
     },
     "quota": {
@@ -3200,7 +3748,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -3218,8 +3766,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "rate_limiter_policy": {
@@ -3229,7 +3777,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -3242,8 +3790,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "registration": {
@@ -3290,12 +3838,36 @@
         "method": "crud"
       }
     },
-    "role": {
+    "report_config": {
       "constraint": {
         "allowed": [
           "system"
         ],
         "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
+    "role": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
       },
       "recommendation": {
         "primary": "system",
@@ -3308,8 +3880,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "route": {
@@ -3407,7 +3979,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -3420,8 +3992,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "secret_policy_rule": {
@@ -3473,7 +4045,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -3486,8 +4058,30 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "restricted",
-        "method": "conservative_default"
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "segment": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "sensitive_data_policy": {
@@ -3497,7 +4091,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -3510,8 +4104,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "service_credential": {
@@ -3565,7 +4159,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -3583,8 +4177,32 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "service_policy_rule": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "session": {
@@ -3785,6 +4403,28 @@
         "method": ""
       }
     },
+    "srv6_network_slice": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
     "static_asset": {
       "constraint": {
         "allowed": [
@@ -3880,7 +4520,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -3893,8 +4533,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "telemetry_receiver": {
@@ -4034,7 +4674,7 @@
         "allowed": [
           "system"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "system",
@@ -4047,8 +4687,76 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "tpm_api_key": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
+    "tpm_category": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
+    "tpm_manager": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "trusted_ca_list": {
@@ -4058,7 +4766,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -4071,8 +4779,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "tunnel": {
@@ -4185,6 +4893,28 @@
         "method": "crud"
       }
     },
+    "usb_policy": {
+      "constraint": {
+        "allowed": [
+          "system"
+        ],
+        "enforced": false
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "restricted",
+        "method": "default_deny"
+      }
+    },
     "user": {
       "constraint": {
         "allowed": [
@@ -4214,7 +4944,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -4227,8 +4957,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "user_profile": {
@@ -4502,7 +5232,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -4515,8 +5245,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "virtual_network": {
@@ -4548,7 +5278,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -4561,8 +5291,32 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
+      }
+    },
+    "voltshare_admin_policy": {
+      "constraint": {
+        "allowed": [
+          "custom",
+          "default",
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "voltstack_site": {
@@ -4645,7 +5399,7 @@
           "default",
           "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "shared",
@@ -4663,8 +5417,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "unverified",
-        "method": ""
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "workload": {
@@ -4690,15 +5444,55 @@
         "verification": "verified",
         "method": "crud"
       }
+    },
+    "workload_flavor": {
+      "constraint": {
+        "allowed": [
+          "shared"
+        ],
+        "enforced": true
+      },
+      "recommendation": {
+        "primary": "custom",
+        "alternatives": [],
+        "rationale": "Standard tenant resource"
+      },
+      "classification": {
+        "category": "application",
+        "multi_tenant_pattern": "per-tenant"
+      },
+      "_meta": {
+        "explicit": true,
+        "verification": "verified",
+        "method": "crud"
+      }
     }
   },
   "_coverage": {
-    "total_explicit": 207,
-    "verified": 21,
+    "total_explicit": 241,
+    "verified": 73,
     "assumed": 10,
-    "unverified": 176
-  },
-  "info": {
-    "version": "2.1.177"
+    "unverified": 158,
+    "default_deny_worklist_count": 18,
+    "default_deny_worklist": [
+      "address_allocator",
+      "authentication",
+      "authorization_server",
+      "bigip_http_proxy",
+      "cdn_purge_command",
+      "cminstance",
+      "contact",
+      "customer_support",
+      "external_connector",
+      "fast_acl_rule",
+      "k8s_cluster_role_binding",
+      "k8s_pod_security_policy",
+      "nfv_service",
+      "proxy",
+      "report_config",
+      "tpm_api_key",
+      "tpm_category",
+      "usb_policy"
+    ]
   }
 }

--- a/scripts/classify_namespace_scope.py
+++ b/scripts/classify_namespace_scope.py
@@ -1,0 +1,265 @@
+"""Signal-fusion namespace-scope classifier.
+
+Determines, per resource, whether it is creatable in tenant (custom/default/shared)
+namespaces or restricted to the system namespace, by fusing several signals in
+priority order:
+
+  1. CRUD result (authoritative) — live create-probe verdict from
+     ``discover_namespace_crud.py`` output (``--crud <report.yaml>``).
+  2. Hardcoded-system path — a canonical create path templated to
+     ``/namespaces/system/`` with no ``{namespace}`` variant (strong: system).
+  3. NL description — schema ``namespace`` fields saying "namespace is always
+     system" / "only system namespace" (strong, upstream: system).
+  4. Console breadcrumb — ``config/console_ui.yaml`` breadcrumb containing the
+     ``{namespace}`` token implies the console renders a namespace selector
+     (soft: tenant); absence / administration workspace leans system.
+
+The output is deterministic and offline (except that the CRUD report is produced
+by a separate live run). It emits a per-resource verdict with confidence,
+method, and evidence, plus a reconciliation report of signal disagreements —
+the worklist for further CRUD verification.
+
+Usage:
+    python -m scripts.classify_namespace_scope --crud /tmp/nsverify/crud_full.yaml \
+        --output reports/namespace_scope_classification.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.audit_namespace_profiles import (
+    SYSTEM_DESCRIPTION_PATTERNS,
+    _schema_to_resource,
+)
+from scripts.discover_namespace_crud import build_create_path_index
+
+TENANT_ALLOWED = ["custom", "default", "shared"]
+SYSTEM_ALLOWED = ["system"]
+SHARED_ALLOWED = ["shared"]
+
+
+def _load_crud_verdicts(crud_path: Path | None) -> dict[str, dict[str, Any]]:
+    """Load per-resource verdicts from a discover_namespace_crud.py report."""
+    if not crud_path or not crud_path.exists():
+        return {}
+    with crud_path.open() as f:
+        data = yaml.safe_load(f) or {}
+    out: dict[str, dict[str, Any]] = {}
+    for name, entry in data.items():
+        verdict = entry.get("verdict")
+        if verdict in {"any_namespace", "tenant"}:
+            out[name] = {"scope": "tenant", "allowed": TENANT_ALLOWED}
+        elif verdict in {"system_only", "system_confirmed"}:
+            out[name] = {"scope": "system", "allowed": SYSTEM_ALLOWED}
+        elif verdict == "shared_only":
+            out[name] = {"scope": "shared", "allowed": SHARED_ALLOWED}
+        # inconclusive → not a verdict, leave for weaker signals
+    return out
+
+
+def _system_path_resources(specs_dir: Path) -> set[str]:
+    """Resources whose canonical create path is hardcoded to /namespaces/system/."""
+    system_only: set[str] = set()
+    opid = re.compile(r"^ves\.io\.schema\.(?:views\.)?([a-z0-9_]+)\.API\.Create$")
+    for spec_path in sorted(specs_dir.glob("*.json")):
+        if spec_path.name in {
+            "index.json",
+            "namespace_profiles.json",
+            "openapi.json",
+            "minimal-export-defaults.json",
+        }:
+            continue
+        try:
+            spec = json.loads(spec_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        for path, methods in spec.get("paths", {}).items():
+            post = methods.get("post") if isinstance(methods, dict) else None
+            if not isinstance(post, dict):
+                continue
+            if "{name}" in path or "{metadata.name}" in path:
+                continue
+            segs = path.rstrip("/").split("/")
+            if "namespaces" not in segs:
+                continue
+            ni = segs.index("namespaces")
+            if len(segs) != ni + 3:
+                continue
+            m = opid.match(post.get("operationId", ""))
+            if not m:
+                continue
+            if segs[ni + 1] == "system":
+                system_only.add(m.group(1))
+    return system_only
+
+
+def _nl_system_resources(specs_dir: Path) -> set[str]:
+    """Resources with an upstream NL 'only system namespace' description."""
+    hits: set[str] = set()
+    for spec_path in sorted(specs_dir.glob("*.json")):
+        if spec_path.name in {
+            "index.json",
+            "namespace_profiles.json",
+            "openapi.json",
+            "minimal-export-defaults.json",
+        }:
+            continue
+        try:
+            spec = json.loads(spec_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        for schema_name, schema in spec.get("components", {}).get("schemas", {}).items():
+            if not isinstance(schema, dict):
+                continue
+            ns = schema.get("properties", {}).get("namespace", {})
+            desc = ns.get("description", "") if isinstance(ns, dict) else ""
+            if any(p.search(desc) for p in SYSTEM_DESCRIPTION_PATTERNS):
+                hits.add(_schema_to_resource(schema_name))
+    return hits
+
+
+def _console_breadcrumb_scope(console_path: Path) -> dict[str, str]:
+    """Map resource -> 'tenant'|'system' from console_ui breadcrumb namespace token."""
+    if not console_path.exists():
+        return {}
+    with console_path.open() as f:
+        data = yaml.safe_load(f) or {}
+    out: dict[str, str] = {}
+    for name, entry in (data.get("resources") or {}).items():
+        if not isinstance(entry, dict):
+            continue
+        bc = entry.get("breadcrumbs", []) or []
+        has_ns = any("{namespace}" in str(x) for x in bc)
+        out[name] = "tenant" if has_ns else "system"
+    return out
+
+
+def classify(
+    specs_dir: Path,
+    crud_path: Path | None,
+    console_path: Path,
+) -> dict[str, dict[str, Any]]:
+    """Fuse all signals into a per-resource verdict."""
+    universe = sorted(build_create_path_index(specs_dir).keys())
+    crud = _load_crud_verdicts(crud_path)
+    system_path = _system_path_resources(specs_dir)
+    nl_system = _nl_system_resources(specs_dir)
+    console = _console_breadcrumb_scope(console_path)
+
+    results: dict[str, dict[str, Any]] = {}
+    for name in universe:
+        evidence: list[str] = []
+        # Priority 1: CRUD (authoritative)
+        if name in crud:
+            scope = crud[name]["scope"]
+            results[name] = {
+                "scope": scope,
+                "allowed": crud[name]["allowed"],
+                "method": "crud",
+                "confidence": "high",
+                "evidence": [f"crud: created/{scope}"],
+                "console": console.get(name),
+            }
+            continue
+        # Priority 2: hardcoded-system path (strong system)
+        if name in system_path:
+            evidence.append("path: hardcoded /namespaces/system/")
+        if name in nl_system:
+            evidence.append("nl: 'only system namespace' description")
+        if name in system_path or name in nl_system:
+            results[name] = {
+                "scope": "system",
+                "allowed": SYSTEM_ALLOWED,
+                "method": "spec_signal",
+                "confidence": "high",
+                "evidence": evidence,
+                "console": console.get(name),
+            }
+            continue
+        # Priority 3: console breadcrumb (soft)
+        cscope = console.get(name)
+        if cscope == "tenant":
+            results[name] = {
+                "scope": "tenant",
+                "allowed": TENANT_ALLOWED,
+                "method": "console_signal",
+                "confidence": "low",
+                "evidence": ["console: breadcrumb has {namespace}"],
+                "console": cscope,
+            }
+            continue
+        # Default: unknown -> default-deny (system) pending CRUD
+        results[name] = {
+            "scope": "system",
+            "allowed": SYSTEM_ALLOWED,
+            "method": "default_deny",
+            "confidence": "none",
+            "evidence": ["no conclusive signal — default-deny pending CRUD"],
+            "console": cscope,
+        }
+    return results
+
+
+def reconcile_report(results: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
+    """List resources where the console signal disagrees with the fused verdict."""
+    diffs = []
+    for name, r in sorted(results.items()):
+        c = r.get("console")
+        if c and c != r["scope"] and r["method"] != "crud":
+            diffs.append(
+                {
+                    "resource": name,
+                    "verdict": r["scope"],
+                    "method": r["method"],
+                    "console": c,
+                }
+            )
+    return diffs
+
+
+def main() -> None:
+    """Run the classifier and emit the report."""
+    parser = argparse.ArgumentParser(description="Signal-fusion namespace-scope classifier")
+    parser.add_argument("--specs-dir", type=Path, default=Path("docs/specifications/api"))
+    parser.add_argument("--crud", type=Path, default=None, help="discover_namespace_crud report")
+    parser.add_argument("--console", type=Path, default=Path("config/console_ui.yaml"))
+    parser.add_argument(
+        "--output", type=Path, default=Path("reports/namespace_scope_classification.yaml")
+    )
+    args = parser.parse_args()
+
+    results = classify(args.specs_dir, args.crud, args.console)
+
+    by_method = Counter(r["method"] for r in results.values())
+    by_scope = Counter(r["scope"] for r in results.values())
+    diffs = reconcile_report(results)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w") as f:
+        yaml.dump(
+            {"results": results, "disagreements": diffs},
+            f,
+            default_flow_style=False,
+            sort_keys=True,
+        )
+
+    print(f"Classified {len(results)} resources -> {args.output}")
+    print(f"  by scope:  {dict(by_scope)}")
+    print(f"  by method: {dict(by_method)}")
+    print(f"  console/verdict disagreements (worklist): {len(diffs)}")
+    for d in diffs[:30]:
+        print(
+            f"    {d['resource']:32s} verdict={d['verdict']:7s} console={d['console']} ({d['method']})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/discover_namespace_crud.py
+++ b/scripts/discover_namespace_crud.py
@@ -19,6 +19,7 @@ import base64
 import contextlib
 import json
 import os
+import re
 import subprocess
 import tempfile
 import time
@@ -45,71 +46,121 @@ def get_api_client() -> tuple[str, dict[str, str]]:
     return url.rstrip("/"), headers
 
 
+_CREATE_OPID = re.compile(r"^ves\.io\.schema\.(?:views\.)?([a-z0-9_]+)\.API\.Create$")
+
+
+def build_create_path_index(specs_dir: Path) -> dict[str, dict[str, str]]:
+    """Map every resource to its canonical create path by scanning all domain specs.
+
+    A canonical create endpoint is a POST to ``.../namespaces/<ns>/<plural>`` (no
+    ``{name}`` segment) whose ``operationId`` is ``ves.io.schema.<resource>.API.Create``.
+    This is the deterministic resource identity — index.json's ``api_paths`` are
+    incomplete (many resources have an empty list), so we derive paths from the
+    full ``paths`` objects instead.
+
+    Returns ``{resource_name: {"create_path": <path with {namespace}>, "spec_file": <file>}}``.
+    """
+    index: dict[str, dict[str, str]] = {}
+    for spec_path in sorted(specs_dir.glob("*.json")):
+        if spec_path.name in {
+            "index.json",
+            "namespace_profiles.json",
+            "openapi.json",
+            "minimal-export-defaults.json",
+        }:
+            continue
+        try:
+            with spec_path.open() as f:
+                spec = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            continue
+
+        for path, methods in spec.get("paths", {}).items():
+            post = methods.get("post") if isinstance(methods, dict) else None
+            if not isinstance(post, dict):
+                continue
+            if "{name}" in path or "{metadata.name}" in path:
+                continue
+            segs = path.rstrip("/").split("/")
+            if "namespaces" not in segs:
+                continue
+            ni = segs.index("namespaces")
+            # canonical create shape: .../namespaces/<ns>/<plural>
+            if len(segs) != ni + 3:
+                continue
+            m = _CREATE_OPID.match(post.get("operationId", ""))
+            if not m:
+                continue
+            resource = m.group(1)
+            # normalise the namespace segment to the {namespace} placeholder
+            segs[ni + 1] = "{namespace}"
+            normalized = "/".join(segs)
+            # prefer the shortest canonical path if a resource has several
+            if resource not in index or len(normalized) < len(index[resource]["create_path"]):
+                index[resource] = {"create_path": normalized, "spec_file": spec_path.name}
+    return index
+
+
+def _authoritative_resource_names(
+    specs_dir: Path, path_index: dict[str, dict[str, str]] | None = None
+) -> list[str]:
+    """Resource universe to test.
+
+    Union of: every resource with a canonical create path (the deterministic,
+    spec-derived universe), the namespace_profile config keys, and index primaries.
+    """
+    names: set[str] = set(path_index.keys()) if path_index else set()
+    profile_path = Path("config/namespace_profile.yaml")
+    if profile_path.exists():
+        with profile_path.open() as f:
+            cfg = yaml.safe_load(f) or {}
+        names.update((cfg.get("resources") or {}).keys())
+    index_path = specs_dir / "index.json"
+    if index_path.exists():
+        with index_path.open() as f:
+            index = json.load(f)
+        specs_list = index.get("specifications", [])
+        if isinstance(specs_list, dict):
+            specs_list = list(specs_list.values())
+        for domain_info in specs_list:
+            for primary in domain_info.get("x-f5xc-primary-resources", []):
+                if primary.get("name"):
+                    names.add(primary["name"])
+    return sorted(names)
+
+
 def load_resources_from_specs(
     specs_dir: Path,
     resource_filter: list[str] | None = None,
 ) -> list[dict[str, Any]]:
-    """Load resource types with their create paths and example payloads."""
-    index_path = specs_dir / "index.json"
-    with index_path.open() as f:
-        index = json.load(f)
+    """Load resource types with their create paths and example payloads.
 
-    resources = []
-    specs_list = index.get("specifications", [])
-    if isinstance(specs_list, dict):
-        specs_list = list(specs_list.values())
-
+    Driven by the authoritative resource universe (namespace_profile.yaml keys +
+    index primaries) and a deterministic create-path index built from the full
+    domain spec ``paths`` — not the incomplete ``api_paths`` in index.json.
+    """
+    path_index = build_create_path_index(specs_dir)
     spec_cache: dict[str, dict] = {}
+    resources = []
 
-    for domain_info in specs_list:
-        domain = domain_info.get("domain", "")
-        spec_file = domain_info.get("file", "")
-
-        for primary in domain_info.get("x-f5xc-primary-resources", []):
-            name = primary.get("name", "")
-            if resource_filter and name not in resource_filter:
-                continue
-
-            api_paths = primary.get("api_paths", [])
-            create_path = _find_create_path(api_paths)
-            if not create_path:
-                continue
-
-            example_payload = _get_example_payload(specs_dir, spec_file, name, spec_cache)
-
-            resources.append(
-                {
-                    "name": name,
-                    "domain": domain,
-                    "create_path": create_path,
-                    "example_payload": example_payload,
-                }
-            )
+    for name in _authoritative_resource_names(specs_dir, path_index):
+        if resource_filter and name not in resource_filter:
+            continue
+        entry = path_index.get(name)
+        if not entry:
+            continue
+        spec_file = entry["spec_file"]
+        example_payload = _get_example_payload(specs_dir, spec_file, name, spec_cache)
+        resources.append(
+            {
+                "name": name,
+                "domain": spec_file.replace(".json", ""),
+                "create_path": entry["create_path"],
+                "example_payload": example_payload,
+            }
+        )
 
     return resources
-
-
-def _find_create_path(api_paths: list[str]) -> str:
-    """Find the namespace-parameterized create (list) path."""
-    candidates = []
-    for p in api_paths:
-        if "{metadata.namespace}" in p:
-            continue
-        if "{name}" in p or "{metadata.name}" in p:
-            continue
-        if "/namespaces/{namespace}/" in p:
-            candidates.append(p)
-
-    if not candidates:
-        for p in api_paths:
-            if "/namespaces/" in p and "{name}" not in p and "{metadata.name}" not in p:
-                normalized = p.replace("{metadata.namespace}", "{namespace}")
-                candidates.append(normalized)
-
-    if candidates:
-        candidates.sort(key=len)
-        return candidates[0]
-    return ""
 
 
 def _get_example_payload(
@@ -156,7 +207,35 @@ NS_RESTRICTION_PATTERNS = [
     "restricted to",
     "invalid namespace",
     "namespace not allowed",
+    "allowed to be created only in",
 ]
+
+# The F5 XC API rejects a create in the wrong namespace with a message like
+# "ves.io.schema.X.Object allowed to be created only in shared or app, got demo".
+# Parse the allow-list out of that message. "app" is an internal alias for the
+# shared tenant scope, so it maps to "shared".
+_ONLY_IN_RE = re.compile(r"allowed to be created only in ([a-z ,or]+?),? got", re.IGNORECASE)
+_NS_ALIAS = {"app": "shared"}
+
+
+def restriction_allowed(error_msg: str) -> list[str]:
+    """Extract the allowed namespace set from an API namespace-restriction error.
+
+    Returns e.g. ["system"] or ["shared"]; empty if the message names none
+    explicitly (e.g. the generic DNS "outside system namespace not permitted",
+    which implies system).
+    """
+    m = _ONLY_IN_RE.search(error_msg)
+    if m:
+        tokens = re.split(r"[,\s]+or\s+|\s*,\s*|\s+or\s+", m.group(1).strip())
+        allowed = {_NS_ALIAS.get(t.strip(), t.strip()) for t in tokens if t.strip()}
+        allowed.discard("")
+        if allowed:
+            return sorted(allowed)
+    low = error_msg.lower()
+    if "outside system namespace" in low or "only system namespace" in low:
+        return ["system"]
+    return []
 
 
 def classify_response(status_code: int, error_msg: str) -> str:
@@ -213,6 +292,8 @@ def probe_create(
             "classification": result_class,
             "error": error_msg or None,
         }
+        if result_class == "ns_restricted":
+            result["restriction_allowed"] = restriction_allowed(error_msg)
 
         if result_class in ("created", "conflict"):
             _cleanup(
@@ -380,6 +461,7 @@ def discover_all(
         restricted_from: list[str] = []
         validation_errors: list[str] = []
         other_results: list[str] = []
+        restriction_allowed_set: list[str] = []
 
         for ns in namespaces_to_test:
             cleanup_paths = _setup_prereqs(base_url, headers, overrides, name, ns)
@@ -403,6 +485,9 @@ def discover_all(
                 print(f"+{ns}", end=" ", flush=True)
             elif c == "ns_restricted":
                 restricted_from.append(ns)
+                for a in probe.get("restriction_allowed", []):
+                    if a not in restriction_allowed_set:
+                        restriction_allowed_set.append(a)
                 print(f"!{ns}", end=" ", flush=True)
             elif c == "validation_error":
                 validation_errors.append(ns)
@@ -414,9 +499,18 @@ def discover_all(
             time.sleep(rate_limit_ms / 1000)
 
         if restricted_from:
-            entry["verdict"] = "system_only"
+            # The API named the allowed namespace(s) in its rejection. "shared" and
+            # "system" are NOT custom namespaces, so a shared-only/system-only
+            # resource must be scoped precisely, not lumped into the tenant bucket.
+            allowed = sorted(restriction_allowed_set) or ["system"]
+            if allowed == ["shared"]:
+                entry["verdict"] = "shared_only"
+            elif allowed == ["system"]:
+                entry["verdict"] = "system_only"
+            else:
+                entry["verdict"] = "restricted"
             entry["confidence"] = "high"
-            entry["discovered_allowed"] = ["system"]
+            entry["discovered_allowed"] = allowed
         elif created_in:
             non_system = [ns for ns in created_in if ns != "system"]
             if non_system:

--- a/scripts/generate_namespace_verdicts.py
+++ b/scripts/generate_namespace_verdicts.py
@@ -1,0 +1,149 @@
+"""Generate the machine-owned namespace verdicts file from CRUD evidence.
+
+Reads committed live-API CRUD evidence (``config/namespace_crud_evidence.yaml``,
+produced by ``discover_namespace_crud.py``) and writes ``config/namespace_verdicts.yaml``
+— an authoritative, wholesale-regenerated map of resource → verified namespace
+constraint. The enricher layers these verdicts OVER the hand-curated
+``config/namespace_profile.yaml`` so live-verified facts always win, while the
+curated file (with its section comments and default-deny classifications) stays
+pristine and human-owned.
+
+This split keeps verification deterministic and idempotent: the same evidence
+yields the same verdicts file in CI, with no comment-destroying round-trips.
+
+Usage:
+    python -m scripts.generate_namespace_verdicts
+    python -m scripts.generate_namespace_verdicts --crud config/namespace_crud_evidence.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.discover_namespace_crud import build_create_path_index
+
+TENANT_ALLOWED = ["custom", "default", "shared"]
+SYSTEM_ALLOWED = ["system"]
+SHARED_ALLOWED = ["shared"]
+
+_TENANT_VERDICTS = {"any_namespace", "tenant"}
+_SYSTEM_VERDICTS = {"system_only", "system_confirmed"}
+_SHARED_VERDICTS = {"shared_only"}
+
+
+def build_verdicts(crud_path: Path, specs_dir: Path, config_path: Path) -> dict[str, Any]:
+    """Map CRUD verdicts to authoritative constraints, then default-deny fill.
+
+    1. Conclusive CRUD → verified tenant/system verdicts.
+    2. Any resource with a canonical create path that is neither curated in
+       ``namespace_profile.yaml`` nor conclusively CRUD-verified is filled with a
+       default-deny (system, restricted) entry — so the authoritative layer covers
+       the entire create-path universe and nothing silently inherits the tenant
+       default. These fills are the worklist for future CRUD verification.
+    """
+    with crud_path.open() as f:
+        crud = yaml.safe_load(f) or {}
+
+    verdicts: dict[str, Any] = {}
+    for name, entry in sorted(crud.items()):
+        verdict = entry.get("verdict")
+        probes = entry.get("probes", {})
+        if verdict in _TENANT_VERDICTS:
+            allowed = TENANT_ALLOWED
+            evidence = "created in a custom namespace"
+        elif verdict in _SHARED_VERDICTS:
+            # "shared" is not a custom namespace — scope precisely to shared.
+            allowed = SHARED_ALLOWED
+            evidence = "API: allowed to be created only in shared"
+            for ns in ("default", "demo"):
+                err = (probes.get(ns, {}) or {}).get("error") or ""
+                if "shared" in err.lower():
+                    evidence = err[:160]
+                    break
+        elif verdict in _SYSTEM_VERDICTS:
+            allowed = SYSTEM_ALLOWED
+            evidence = "restricted to system namespace"
+            for ns in ("default", "demo"):
+                err = (probes.get(ns, {}) or {}).get("error") or ""
+                if "system" in err.lower():
+                    evidence = err[:160]
+                    break
+        else:
+            continue  # inconclusive → handled by default-deny fill below
+
+        verdicts[name] = {
+            "constraint": {"allowed": allowed},
+            "_verification": {
+                "status": "verified",
+                "method": "crud",
+                "evidence": evidence,
+            },
+        }
+
+    # Default-deny fill: every create-path resource not otherwise classified.
+    with config_path.open() as f:
+        curated = set((yaml.safe_load(f) or {}).get("resources", {}).keys())
+    universe = set(build_create_path_index(specs_dir).keys())
+    for name in sorted(universe):
+        if name in verdicts or name in curated:
+            continue
+        verdicts[name] = {
+            "constraint": {"allowed": SYSTEM_ALLOWED},
+            "_verification": {
+                "status": "restricted",
+                "method": "default_deny",
+                "evidence": "unclassified create-path resource — hidden pending CRUD verification",
+            },
+        }
+    return verdicts
+
+
+def main() -> None:
+    """Generate config/namespace_verdicts.yaml from CRUD evidence."""
+    parser = argparse.ArgumentParser(description="Generate namespace verdicts from CRUD evidence")
+    parser.add_argument(
+        "--crud",
+        type=Path,
+        default=Path("config/namespace_crud_evidence.yaml"),
+        help="Committed CRUD evidence file",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("config/namespace_verdicts.yaml"),
+        help="Machine-owned verdicts output",
+    )
+    parser.add_argument("--specs-dir", type=Path, default=Path("docs/specifications/api"))
+    parser.add_argument("--config", type=Path, default=Path("config/namespace_profile.yaml"))
+    args = parser.parse_args()
+
+    verdicts = build_verdicts(args.crud, args.specs_dir, args.config)
+
+    header = (
+        "# MACHINE-GENERATED — do not edit by hand.\n"
+        "# Regenerate: python -m scripts.generate_namespace_verdicts\n"
+        "# Source evidence: config/namespace_crud_evidence.yaml\n"
+        "#\n"
+        "# Authoritative, live-CRUD-verified namespace constraints. The enricher\n"
+        "# layers these OVER config/namespace_profile.yaml (verdict wins).\n"
+    )
+    with args.output.open("w") as f:
+        f.write(header)
+        yaml.dump(
+            {"version": 1, "verdicts": verdicts},
+            f,
+            default_flow_style=False,
+            sort_keys=True,
+        )
+
+    tenant = sum(1 for v in verdicts.values() if v["constraint"]["allowed"] == TENANT_ALLOWED)
+    system = sum(1 for v in verdicts.values() if v["constraint"]["allowed"] == SYSTEM_ALLOWED)
+    print(f"Wrote {len(verdicts)} verdicts to {args.output} (tenant={tenant}, system={system})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/utils/namespace_profile_enricher.py
+++ b/scripts/utils/namespace_profile_enricher.py
@@ -61,6 +61,22 @@ class NamespaceProfileEnricher:
     def _load_config(self) -> None:
         with self.config_path.open() as f:
             self.config = yaml.safe_load(f)
+        # Layer machine-owned, live-CRUD-verified verdicts over the hand-curated
+        # profile. Verdicts always win (they are authoritative live-API facts).
+        self.verdicts: dict[str, Any] = {}
+        verdicts_path = self.config_path.parent / "namespace_verdicts.yaml"
+        if verdicts_path.exists():
+            with verdicts_path.open() as f:
+                data = yaml.safe_load(f) or {}
+            self.verdicts = data.get("verdicts", {})
+
+    def _resolved_override(self, lookup: str) -> dict[str, Any]:
+        """Curated override for a resource, with any CRUD verdict layered on top."""
+        override = self.config.get("resources", {}).get(lookup, {})
+        verdict = self.verdicts.get(lookup)
+        if verdict:
+            return _deep_merge(override, verdict)
+        return override
 
     def get_profile_for_resource(
         self, resource_type: str, *, track_stats: bool = False
@@ -75,7 +91,7 @@ class NamespaceProfileEnricher:
             if lookup_without_views in resources:
                 lookup = lookup_without_views
 
-        override = resources.get(lookup, {})
+        override = self._resolved_override(lookup)
         is_explicit = bool(override)
 
         if track_stats:
@@ -108,25 +124,24 @@ class NamespaceProfileEnricher:
         return profile
 
     def is_resource_explicit(self, resource_type: str) -> bool:
-        """Check whether a resource has an explicit entry in the config."""
+        """Check whether a resource has an explicit entry (curated override or verdict)."""
         resources = self.config.get("resources", {})
         lookup = resource_type
         if lookup.startswith("views_") and lookup not in resources:
             lookup_without_views = lookup[len("views_") :]
             if lookup_without_views in resources:
                 lookup = lookup_without_views
-        return lookup in resources
+        return lookup in resources or lookup in self.verdicts
 
     def get_verification_status(self, resource_type: str) -> dict[str, Any]:
-        """Get the verification metadata for a resource."""
+        """Get the verification metadata for a resource (verdict layered over override)."""
         resources = self.config.get("resources", {})
         lookup = resource_type
         if lookup.startswith("views_") and lookup not in resources:
             lookup_without_views = lookup[len("views_") :]
             if lookup_without_views in resources:
                 lookup = lookup_without_views
-        override = resources.get(lookup, {})
-        return override.get("_verification", {})
+        return self._resolved_override(lookup).get("_verification", {})
 
     def enrich_spec(self, spec: dict[str, Any]) -> dict[str, Any]:
         """Add x-f5xc-namespace-profile to a spec. Removes old x-f5xc-namespace-scope.

--- a/scripts/utils/namespace_profiles_exporter.py
+++ b/scripts/utils/namespace_profiles_exporter.py
@@ -57,7 +57,11 @@ class NamespaceProfilesExporter:
             The artifact with ``default`` and per-resource merged profiles.
         """
         config = self.enricher.config
-        resource_keys = config.get("resources", {})
+        # Emit the union of hand-curated overrides and machine-owned verdicts so
+        # CRUD-verified and default-deny-filled resources (which may have no
+        # curated entry) are part of the authoritative export.
+        resource_keys = set(config.get("resources", {}).keys())
+        resource_keys |= set(getattr(self.enricher, "verdicts", {}).keys())
 
         resources: dict[str, Any] = {}
         verified_count = 0
@@ -91,6 +95,14 @@ class NamespaceProfilesExporter:
         default_profile = config["default_profile"]
         default_profile.pop("_verification", None)
 
+        # Worklist: resources hidden by default-deny that still need live CRUD
+        # verification to be either confirmed tenant-creatable or confirmed system.
+        worklist = sorted(
+            name
+            for name, e in resources.items()
+            if e.get("_meta", {}).get("method") == "default_deny"
+        )
+
         return {
             "version": version or "0.0.0",
             "generated_at": datetime.now(tz=timezone.utc).isoformat(),
@@ -102,6 +114,8 @@ class NamespaceProfilesExporter:
                 "verified": verified_count,
                 "assumed": assumed_count,
                 "unverified": unverified_count,
+                "default_deny_worklist_count": len(worklist),
+                "default_deny_worklist": worklist,
             },
         }
 

--- a/tests/test_namespace_profile_enricher.py
+++ b/tests/test_namespace_profile_enricher.py
@@ -137,9 +137,9 @@ class TestDeepMerge:
     def test_partial_override_merges_with_default(self, enricher: NamespaceProfileEnricher) -> None:
         profile = enricher.get_profile_for_resource("http_loadbalancer")
         assert profile["constraint"]["allowed"] == ["custom", "default", "shared"]
-        # enforced now reflects verification status, not a hardcoded default:
-        # http_loadbalancer is not 'verified', so the constraint is advisory.
-        assert profile["constraint"]["enforced"] is False
+        # http_loadbalancer is CRUD-verified tenant (namespace_verdicts.yaml), so the
+        # constraint is enforced.
+        assert profile["constraint"]["enforced"] is True
         assert profile["classification"]["category"] == "networking"
         assert profile["recommendation"]["primary"] == "custom"
 
@@ -376,13 +376,14 @@ class TestSpecEnrichment:
 # -- Parametrized Known Resource Tests --
 
 
+# NOTE: `role` is intentionally excluded — live CRUD probing (namespace_verdicts.yaml)
+# proved it is creatable in custom namespaces, correcting the earlier assumption.
 SYSTEM_RESOURCES = [
     "aws_vpc_site",
     "azure_vnet_site",
     "gcp_vpc_site",
     "fleet",
     "namespace",
-    "role",
     "user",
     "global_network",
     "virtual_network",
@@ -441,31 +442,26 @@ def test_tenant_resource_scope(enricher: NamespaceProfileEnricher, resource_name
 # -- Completeness Gate --
 
 
-def test_all_primary_resources_have_explicit_namespace_profile() -> None:
-    """Every primary resource in the spec index must have an explicit entry
-    in namespace_profile.yaml. Silent default inheritance is not acceptable
-    for primary resources — it leads to misclassified resources in the tree."""
-    import json
+def test_all_create_path_resources_have_explicit_namespace_profile() -> None:
+    """Every resource with a canonical create path must have an explicit
+    classification (curated override OR machine verdict). Silent inheritance of
+    the tenant default is not acceptable — under default-deny display it would
+    leak an unverified resource into user namespaces. Unknowns must be explicitly
+    default-denied (system, restricted) via namespace_verdicts.yaml."""
     from pathlib import Path
 
-    index_path = Path("docs/specifications/api/index.json")
-    if not index_path.exists():
-        pytest.skip("index.json not available")
+    from scripts.discover_namespace_crud import build_create_path_index
 
-    with index_path.open() as f:
-        index = json.load(f)
+    specs_dir = Path("docs/specifications/api")
+    if not (specs_dir / "index.json").exists():
+        pytest.skip("specs not available")
 
-    primary_names: set[str] = set()
-    specs = index.get("specifications", [])
-    if isinstance(specs, dict):
-        specs = list(specs.values())
-    for domain_info in specs:
-        for resource in domain_info.get("x-f5xc-primary-resources", []):
-            primary_names.add(resource["name"])
-
+    universe = set(build_create_path_index(specs_dir).keys())
     enricher = NamespaceProfileEnricher()
-    missing = sorted(name for name in primary_names if not enricher.is_resource_explicit(name))
+    missing = sorted(name for name in universe if not enricher.is_resource_explicit(name))
 
     assert missing == [], (
-        f"{len(missing)} primary resources lack explicit namespace profile entries: {missing}"
+        f"{len(missing)} create-path resources lack an explicit namespace "
+        f"classification (add to namespace_profile.yaml or regenerate "
+        f"namespace_verdicts.yaml): {missing}"
     )


### PR DESCRIPTION
## Summary
Replaces unverified namespace guesses with an authoritative, evidence-backed classification.

- **Deterministic create-path resolution** (operationId `ves.io.schema.<r>.API.Create`) across all domain specs — covers 131 resources vs the incomplete index.json.
- **Live-CRUD verdicts**: committed evidence (`config/namespace_crud_evidence.yaml`) → machine-owned `config/namespace_verdicts.yaml`, layered over the curated `namespace_profile.yaml` (verified wins, comments preserved).
- **Namespace-aware restriction parsing**: "only in shared" → `["shared"]`, "only in system" → `["system"]` — shared/system are not custom namespaces.
- **Signal-fusion classifier** + **completeness gate** over the full create-path universe; unknowns default-denied + tracked.

## Coverage
73 CRUD-verified; 18 on the default-deny worklist (6 are non-CRUD 500/501 action endpoints).

## Test plan
- [x] `pytest` 2112 passed, 3 skipped
- [x] ruff clean, idempotent regeneration
- [x] downstream vscode-xcsh regenerated: custom-ns tree = 32 verified-tenant resources

Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)