### PR TITLE
feat(namespace): verify proxy as tenant; extend worklist probe payloads

### DIFF
--- a/config/crud_probe_payloads.yaml
+++ b/config/crud_probe_payloads.yaml
@@ -224,3 +224,48 @@ contact:
 customer_support:
   metadata: {name: crud-probe}
   spec: {description: "namespace probe test", product: distributed_cloud}
+
+# --- Worklist round 3 (2026-07-15): schema-derived payloads for the 14
+# validation-blocked resources, to reach the namespace verdict. ---
+address_allocator:
+  metadata: {name: crud-probe}
+  spec: {mode: LOCAL, address_allocation_scheme: {sequential: {}}, address_pool: [{start_address: "10.0.0.2", end_address: "10.0.0.100"}]}
+authentication:
+  metadata: {name: crud-probe}
+  spec: {cookie_params: {}, oidc_auth: {issuer: "https://issuer.example.com", client_id: probe, client_secret: {clear_secret_info: {url: "string:///dGVzdA=="}}}}
+cminstance:
+  metadata: {name: crud-probe}
+  spec: {ip: "10.0.0.5", port: 443, username: probe, password: {clear_secret_info: {url: "string:///dGVzdA=="}}, api_token: {clear_secret_info: {url: "string:///dGVzdA=="}}}
+contact:
+  metadata: {name: crud-probe}
+  spec: {contact_type: MAILING, address1: "1 Test St", address2: "", city: TestCity, county: TestCounty, state: California, state_code: CA, country: "United States", zip_code: "94089", phone_number: "+15551234567"}
+external_connector:
+  metadata: {name: crud-probe}
+  spec: {ce_site_reference: {tenant: t, namespace: system, name: dummy}, ipsec: {remote_gateway: {ipv4: {addr: "203.0.113.9"}}}}
+fast_acl_rule:
+  metadata: {name: crud-probe}
+  spec: {action: {simple_action: DENY}, prefix: ["10.0.0.0/8"]}
+k8s_cluster_role_binding:
+  metadata: {name: crud-probe}
+  spec: {k8s_cluster_role: {name: dummy, namespace: system, tenant: t}, subjects: [{user: {name: probe}}]}
+nfv_service:
+  metadata: {name: crud-probe}
+  spec: {disable_https_management: {}, disable_ssh_access: {}, f5_big_ip_aws_service: {}}
+report_config:
+  metadata: {name: crud-probe}
+  spec: {report_recipients: [{email: "probe@example.com"}], waap: {}}
+tpm_api_key:
+  metadata: {name: crud-probe}
+  spec: {need_mtls: false, category_ref: [{name: dummy, namespace: shared, tenant: t}]}
+tpm_category:
+  metadata: {name: crud-probe}
+  spec: {tpm_allow_list: {}, tpm_manager_ref: [{name: dummy, namespace: shared, tenant: t}]}
+usb_policy:
+  metadata: {name: crud-probe}
+  spec: {allowed_devices: [{vendor_id: "0x1234", product_id: "0x5678"}]}
+proxy:
+  metadata: {name: crud-probe}
+  spec: {http_proxy: {}, do_not_advertise: {}, no_forward_proxy_policy: {}, no_interception: {}, site_local_network: {}, connection_timeout: 2000}
+customer_support:
+  metadata: {name: crud-probe}
+  spec: {description: "namespace probe test", subject: "probe", product_data: {product: distributed_cloud}, type: TYPE_QUESTION, ongoing: false, relates_to: "", comments: "", timeline: "", tp_id: ""}

--- a/config/crud_probe_payloads.yaml
+++ b/config/crud_probe_payloads.yaml
@@ -1,271 +1,374 @@
-# Payload overrides for CRUD namespace probing.
-# These provide valid-enough payloads to get past field validation
-# so the namespace constraint check can fire.
-
-cdn_loadbalancer:
-  metadata: {name: crud-probe}
+---
+# CRUD probe payloads (machine-tuned). Used by discover_namespace_crud.py
+# to reach namespace verdicts past field validation.
+address_allocator:
+  metadata:
+    name: crud-probe
   spec:
-    domains: ["crud-probe.example.com"]
-    https_auto_cert: {http_redirect: true, add_hsts: false, tls_config: {default_security: {}}}
-    origin_pool:
-      origin_servers: [{public_ip: {ip: "203.0.113.1"}}]
-      port: 443
-      use_tls: {use_host_header_as_sni: {}, tls_config: {default_security: {}}, skip_server_cert_verification: {}}
-      loadbalancer_algorithm: ROUND_ROBIN
-      endpoint_selection: LOCAL_PREFERRED
-      same_as_endpoint_port: {}
-    disable_waf: {}
-    no_challenge: {}
-    disable_rate_limit: {}
-    no_service_policies: {}
+    address_allocation_scheme:
+      sequential: {}
+    address_pool:
+      - end_address: 10.0.0.100
+        start_address: 10.0.0.2
+    mode: LOCAL
+authentication:
+  metadata:
+    name: crud-probe
+  spec:
+    cookie_params: {}
+    oidc_auth:
+      client_id: probe
+      client_secret:
+        clear_secret_info:
+          url: string:///dGVzdA==
+      issuer: https://issuer.example.com
+cdn_loadbalancer:
+  metadata:
+    name: crud-probe
+  spec:
+    default_cache_action: {}
     disable_api_definition: {}
     disable_api_discovery: {}
+    disable_client_side_defense: {}
     disable_ip_reputation: {}
     disable_malicious_user_detection: {}
-    disable_client_side_defense: {}
+    disable_rate_limit: {}
     disable_threat_mesh: {}
-    user_id_client_ip: {}
+    disable_waf: {}
+    domains:
+      - crud-probe.example.com
+    https_auto_cert:
+      add_hsts: false
+      http_redirect: true
+      tls_config:
+        default_security: {}
     l7_ddos_action_default: {}
-    default_cache_action: {}
+    no_challenge: {}
+    no_service_policies: {}
+    origin_pool:
+      endpoint_selection: LOCAL_PREFERRED
+      loadbalancer_algorithm: ROUND_ROBIN
+      origin_servers:
+        - public_ip:
+            ip: 203.0.113.1
+      port: 443
+      same_as_endpoint_port: {}
+      use_tls:
+        skip_server_cert_verification: {}
+        tls_config:
+          default_security: {}
+        use_host_header_as_sni: {}
     system_default_timeouts: {}
-
-tcp_loadbalancer:
-  metadata: {name: crud-probe}
-  spec:
-    listen_port: 9443
-    do_not_advertise: {}
-    origin_pools_weights:
-      - pool: {namespace: "{namespace}", name: "crud-probe-pool"}
-        weight: 1
-  _prereqs:
-    - type: origin_pool
-      path: "/api/config/namespaces/{namespace}/origin_pools"
-      payload:
-        metadata: {name: crud-probe-pool}
-        spec:
-          origin_servers: [{public_ip: {ip: "203.0.113.1"}}]
-          port: 443
-          use_tls: {use_host_header_as_sni: {}, tls_config: {default_security: {}}, skip_server_cert_verification: {}}
-          loadbalancer_algorithm: ROUND_ROBIN
-          endpoint_selection: LOCAL_PREFERRED
-
+    user_id_client_ip: {}
 certificate:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
-    certificate_url: "string:///{CERT_B64}"
+    certificate_url: string:///{CERT_B64}
     private_key:
       clear_secret_info:
-        url: "string:///{KEY_B64}"
-
+        url: string:///{KEY_B64}
 certificate_chain:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
-    certificate_url: "string:///{CERT_B64}"
-
+    certificate_url: string:///{CERT_B64}
 cloud_credentials:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
     aws_secret_key:
-      access_key: "AKIAIOSFODNN7EXAMPLE"
+      access_key: AKIAIOSFODNN7EXAMPLE
       secret_key:
         blindfold_secret_info:
-          location: "string:///dGVzdA=="
-
-container_registry:
-  metadata: {name: crud-probe}
+          location: string:///dGVzdA==
+cminstance:
+  metadata:
+    name: crud-probe
   spec:
-    server_address: "registry.example.com"
-    user_name: "testuser"
+    api_token:
+      clear_secret_info:
+        url: string:///dGVzdA==
+    ip: 10.0.0.5
     password:
       clear_secret_info:
-        url: "string:///dGVzdHBhc3M="
-
+        url: string:///dGVzdA==
+    port: 443
+    username: probe
+contact:
+  metadata:
+    name: crud-probe
+  spec:
+    address1: 1 Test St
+    address2: ''
+    city: TestCity
+    contact_type: MAILING
+    country: United States
+    county: TestCounty
+    phone_number: '+15551234567'
+    state: California
+    state_code: CA
+    zip_code: '94089'
+container_registry:
+  metadata:
+    name: crud-probe
+  spec:
+    password:
+      clear_secret_info:
+        url: string:///dGVzdHBhc3M=
+    server_address: registry.example.com
+    user_name: testuser
+customer_support:
+  metadata:
+    name: crud-probe
+  spec:
+    comments: ''
+    description: namespace probe test
+    ongoing: false
+    product_data:
+      product: distributed_cloud
+    relates_to: ''
+    subject: probe
+    timeline: ''
+    tp_id: ''
+    type: TYPE_QUESTION
 data_classification:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
     rules:
-      - data_type_ref: {name: test, namespace: shared}
-
+      - data_type_ref:
+          name: test
+          namespace: shared
 ddos_mitigation_rule:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
-    mitigation_type: {ip_blocklist: {}}
-    destination_prefix: {ipv4: {prefix: "10.0.0.0", plen: 8}}
-
+    destination_prefix:
+      ipv4:
+        plen: 8
+        prefix: 10.0.0.0
+    mitigation_type:
+      ip_blocklist: {}
+ddos_protection:
+  metadata:
+    name: crud-probe
+  spec:
+    protected_entity: {}
 dns_domain:
-  metadata: {name: crud-probe-test.example.com}
+  metadata:
+    name: crud-probe-test.example.com
   spec:
     volterra_managed: {}
-
 dns_zone:
-  metadata: {name: crud-probe-zone.example.com}
+  metadata:
+    name: crud-probe-zone.example.com
   spec:
     primary: {}
-
 endpoint:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
-    protocol: TCP
     port: 80
-    where: {site: {name: test, network_type: VIRTUAL_NETWORK_SITE_LOCAL}}
-
+    protocol: TCP
+    where:
+      site:
+        name: test
+        network_type: VIRTUAL_NETWORK_SITE_LOCAL
+external_connector:
+  metadata:
+    name: crud-probe
+  spec:
+    ce_site_reference:
+      name: dummy
+      namespace: system
+      tenant: t
+    ipsec:
+      remote_gateway:
+        ipv4:
+          addr: 203.0.113.9
+fast_acl_rule:
+  metadata:
+    name: crud-probe
+  spec:
+    action:
+      simple_action: DENY
+    prefix:
+      - 10.0.0.0/8
+fleet_config:
+  metadata:
+    name: crud-probe
+  spec:
+    fleet_label: test
 k8s_cluster_role:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
     policy_rule_list:
       policy_rule:
         - resource_list:
-            resource_types: ["pods"]
-            api_groups: [""]
-            verbs: ["get"]
-
+            api_groups:
+              - ''
+            resource_types:
+              - pods
+            verbs:
+              - get
+k8s_cluster_role_binding:
+  metadata:
+    name: crud-probe
+  spec:
+    k8s_cluster_role:
+      name: dummy
+      namespace: system
+      tenant: t
+    subjects:
+      - user:
+          name: probe
+k8s_pod_security_admission:
+  metadata:
+    name: crud-probe
+  spec:
+    pod_security_admission_specs:
+      - level: privileged
+        mode: enforce
+nfv_service:
+  metadata:
+    name: crud-probe
+  spec:
+    disable_https_management: {}
+    disable_ssh_access: {}
+    f5_big_ip_aws_service: {}
+proxy:
+  metadata:
+    name: crud-probe
+  spec:
+    connection_timeout: 2000
+    do_not_advertise: {}
+    http_proxy: {}
+    no_forward_proxy_policy: {}
+    no_interception: {}
+    site_local_network: {}
 rate_limiter_policy:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
     burst_size: 10
     total_number: 100
     unit: SECOND
-
 registration_token:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
-    infra: {volterra: {}}
-    passport: {cluster_size: 1}
-
+    infra:
+      volterra: {}
+    passport:
+      cluster_size: 1
+report_config:
+  metadata:
+    name: crud-probe
+  spec:
+    report_recipients:
+      - email: probe@example.com
+    waap: {}
+service_policy_rule:
+  metadata:
+    name: crud-probe
+  spec:
+    action: DENY
+    waf_action:
+      none: {}
+srv6_network_slice:
+  metadata:
+    name: crud-probe
+  spec:
+    sid_prefixes:
+      - fc00::/32
 support_case:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
-    description: "Automated namespace CRUD probe - safe to ignore"
-
+    description: Automated namespace CRUD probe - safe to ignore
+tcp_loadbalancer:
+  _prereqs:
+    - path: /api/config/namespaces/{namespace}/origin_pools
+      payload:
+        metadata:
+          name: crud-probe-pool
+        spec:
+          endpoint_selection: LOCAL_PREFERRED
+          loadbalancer_algorithm: ROUND_ROBIN
+          origin_servers:
+            - public_ip:
+                ip: 203.0.113.1
+          port: 443
+          use_tls:
+            skip_server_cert_verification: {}
+            tls_config:
+              default_security: {}
+            use_host_header_as_sni: {}
+      type: origin_pool
+  metadata:
+    name: crud-probe
+  spec:
+    do_not_advertise: {}
+    listen_port: 9443
+    origin_pools_weights:
+      - pool:
+          name: crud-probe-pool
+          namespace: '{namespace}'
+        weight: 1
 threat_category:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
     tpm_manager_ref:
-      - {name: test, namespace: shared}
-
+      - name: test
+        namespace: shared
+tpm_api_key:
+  metadata:
+    name: crud-probe
+  spec:
+    category_ref:
+      - name: dummy
+        namespace: shared
+        tenant: t
+    need_mtls: false
+tpm_category:
+  metadata:
+    name: crud-probe
+  spec:
+    tpm_allow_list: {}
+    tpm_manager_ref:
+      - name: dummy
+        namespace: shared
+        tenant: t
+usage_report:
+  metadata:
+    name: crud-probe
+  spec: {}
+usb_policy:
+  metadata:
+    name: crud-probe
+  spec:
+    allowed_devices:
+      - product_id: '0x5678'
+        vendor_id: '0x1234'
 workload:
-  metadata: {name: crud-probe}
+  metadata:
+    name: crud-probe
   spec:
     simple_service:
       container:
+        image:
+          name: docker.io/library/nginx:latest
+          public: {}
         name: main
-        image: {name: "docker.io/library/nginx:latest", public: {}}
       do_not_advertise: {}
       no_replicas: {}
       no_volume: {}
-
-fleet_config:
-  metadata: {name: crud-probe}
-  spec:
-    fleet_label: test
-
-usage_report:
-  metadata: {name: crud-probe}
-  spec: {}
-
-ddos_protection:
-  metadata: {name: crud-probe}
-  spec:
-    protected_entity: {}
-
-# --- Worklist payloads (2026-07-14): one required field each, from the API's
-# own 400 validation messages, to drive inconclusive resources to a verdict. ---
-address_allocator:
-  metadata: {name: crud-probe}
-  spec: {ipv4: {}, address_allocation_scheme: {sequential: {}}, address_pool: [{start_address: "10.0.0.1", end_address: "10.0.0.10"}]}
-authentication:
-  metadata: {name: crud-probe}
-  spec: {auth_type_choice: {}, cookie_params: {}}
-cminstance:
-  metadata: {name: crud-probe}
-  spec: {api_token: {clear_secret_info: {url: "string:///dGVzdA=="}}, ip: "10.0.0.1"}
-external_connector:
-  metadata: {name: crud-probe}
-  spec: {ce_site_reference: {tenant: t, namespace: system, name: dummy}, connection_type: {sli_to_global_dr: {}}}
-fast_acl_rule:
-  metadata: {name: crud-probe}
-  spec: {action: {simple_action: DENY}, source: {ip_prefixes: {ip_prefixes: ["1.2.3.4/32"]}}}
-k8s_cluster_role_binding:
-  metadata: {name: crud-probe}
-  spec: {k8s_cluster_role: {name: dummy, namespace: system, tenant: t}, subjects: [{user: {name: probe}}]}
-k8s_pod_security_admission:
-  metadata: {name: crud-probe}
-  spec: {pod_security_admission_specs: [{mode: enforce, level: privileged}]}
-nfv_service:
-  metadata: {name: crud-probe}
-  spec: {service_provider_choice: {}, f5_big_ip_aws_service: {}}
-proxy:
-  metadata: {name: crud-probe}
-  spec: {proxy_choice: {}, http_proxy: {}}
-report_config:
-  metadata: {name: crud-probe}
-  spec: {report_type: SECURITY, schedule_choice: {}}
-service_policy_rule:
-  metadata: {name: crud-probe}
-  spec: {waf_action: {none: {}}, action: DENY}
-srv6_network_slice:
-  metadata: {name: crud-probe}
-  spec: {sid_prefixes: ["fc00::/32"]}
-tpm_api_key:
-  metadata: {name: crud-probe}
-  spec: {category_ref: [{name: dummy, namespace: shared, tenant: t}]}
-tpm_category:
-  metadata: {name: crud-probe}
-  spec: {tpm_manager_ref: [{name: dummy, namespace: shared, tenant: t}]}
-usb_policy:
-  metadata: {name: crud-probe}
-  spec: {allowed_devices: {allowed_devices: [{vendor_id: "0x1234"}]}}
 workload_flavor:
-  metadata: {name: crud-probe}
-  spec: {vcpu: 2, memory: 4096}
-contact:
-  metadata: {name: crud-probe}
-  spec: {contact_choice: {}, email: {email: "probe@example.com"}}
-customer_support:
-  metadata: {name: crud-probe}
-  spec: {description: "namespace probe test", product: distributed_cloud}
-
-# --- Worklist round 3 (2026-07-15): schema-derived payloads for the 14
-# validation-blocked resources, to reach the namespace verdict. ---
-address_allocator:
-  metadata: {name: crud-probe}
-  spec: {mode: LOCAL, address_allocation_scheme: {sequential: {}}, address_pool: [{start_address: "10.0.0.2", end_address: "10.0.0.100"}]}
-authentication:
-  metadata: {name: crud-probe}
-  spec: {cookie_params: {}, oidc_auth: {issuer: "https://issuer.example.com", client_id: probe, client_secret: {clear_secret_info: {url: "string:///dGVzdA=="}}}}
-cminstance:
-  metadata: {name: crud-probe}
-  spec: {ip: "10.0.0.5", port: 443, username: probe, password: {clear_secret_info: {url: "string:///dGVzdA=="}}, api_token: {clear_secret_info: {url: "string:///dGVzdA=="}}}
-contact:
-  metadata: {name: crud-probe}
-  spec: {contact_type: MAILING, address1: "1 Test St", address2: "", city: TestCity, county: TestCounty, state: California, state_code: CA, country: "United States", zip_code: "94089", phone_number: "+15551234567"}
-external_connector:
-  metadata: {name: crud-probe}
-  spec: {ce_site_reference: {tenant: t, namespace: system, name: dummy}, ipsec: {remote_gateway: {ipv4: {addr: "203.0.113.9"}}}}
-fast_acl_rule:
-  metadata: {name: crud-probe}
-  spec: {action: {simple_action: DENY}, prefix: ["10.0.0.0/8"]}
-k8s_cluster_role_binding:
-  metadata: {name: crud-probe}
-  spec: {k8s_cluster_role: {name: dummy, namespace: system, tenant: t}, subjects: [{user: {name: probe}}]}
-nfv_service:
-  metadata: {name: crud-probe}
-  spec: {disable_https_management: {}, disable_ssh_access: {}, f5_big_ip_aws_service: {}}
-report_config:
-  metadata: {name: crud-probe}
-  spec: {report_recipients: [{email: "probe@example.com"}], waap: {}}
-tpm_api_key:
-  metadata: {name: crud-probe}
-  spec: {need_mtls: false, category_ref: [{name: dummy, namespace: shared, tenant: t}]}
-tpm_category:
-  metadata: {name: crud-probe}
-  spec: {tpm_allow_list: {}, tpm_manager_ref: [{name: dummy, namespace: shared, tenant: t}]}
-usb_policy:
-  metadata: {name: crud-probe}
-  spec: {allowed_devices: [{vendor_id: "0x1234", product_id: "0x5678"}]}
-proxy:
-  metadata: {name: crud-probe}
-  spec: {http_proxy: {}, do_not_advertise: {}, no_forward_proxy_policy: {}, no_interception: {}, site_local_network: {}, connection_timeout: 2000}
-customer_support:
-  metadata: {name: crud-probe}
-  spec: {description: "namespace probe test", subject: "probe", product_data: {product: distributed_cloud}, type: TYPE_QUESTION, ongoing: false, relates_to: "", comments: "", timeline: "", tp_id: ""}
+  metadata:
+    name: crud-probe
+  spec:
+    memory: 4096
+    vcpu: 2

--- a/config/namespace_crud_evidence.yaml
+++ b/config/namespace_crud_evidence.yaml
@@ -1947,25 +1947,28 @@ protocol_policer:
       status: 200
   verdict: system_confirmed
 proxy:
-  confidence: low
+  confidence: high
   create_path: /api/config/namespaces/{namespace}/proxys
+  discovered_allowed:
+  - custom
+  - default
+  - shared
+  - system
   domain: virtual
-  note: "All namespaces returned validation errors \u2014 namespace check may happen\
-    \ after field validation"
   probes:
     default:
-      classification: validation_error
-      error: Field spec.proxy_choice should be not nil, got nil in request.
-      status: 400
+      classification: created
+      error: null
+      status: 200
     demo:
-      classification: validation_error
-      error: Field spec.proxy_choice should be not nil, got nil in request.
-      status: 400
+      classification: created
+      error: null
+      status: 200
     system:
-      classification: validation_error
-      error: Field spec.proxy_choice should be not nil, got nil in request.
-      status: 400
-  verdict: inconclusive
+      classification: created
+      error: null
+      status: 200
+  verdict: any_namespace
 quota:
   confidence: low
   create_path: /api/web/namespaces/{namespace}/quotas

--- a/config/namespace_crud_evidence.yaml
+++ b/config/namespace_crud_evidence.yaml
@@ -1,3 +1,5 @@
+---
+# MACHINE-GENERATED live-API CRUD evidence. Source for namespace_verdicts.yaml.
 address_allocator:
   confidence: low
   create_path: /api/config/namespaces/{namespace}/address_allocators
@@ -42,10 +44,10 @@ alert_policy:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/alert_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: statistics
   probes:
     default:
@@ -65,10 +67,10 @@ alert_receiver:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/alert_receivers
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: statistics
   probes:
     default:
@@ -88,10 +90,10 @@ api_definition:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/api_definitions
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: api
   probes:
     default:
@@ -112,10 +114,10 @@ app_api_group:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/app_api_groups
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: api
   probes:
     default:
@@ -136,10 +138,10 @@ app_firewall:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/app_firewalls
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -280,7 +282,7 @@ azure_vnet_site:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/azure_vnet_sites
   discovered_allowed:
-  - system
+    - system
   domain: sites
   probes:
     default:
@@ -416,10 +418,10 @@ cdn_cache_rule:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/cdn_cache_rules
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: cdn
   probes:
     default:
@@ -439,10 +441,10 @@ cdn_loadbalancer:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/cdn_loadbalancers
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: cdn
   probes:
     default:
@@ -480,10 +482,10 @@ certificate:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/certificates
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: certificates
   probes:
     default:
@@ -503,10 +505,10 @@ certificate_chain:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/certificate_chains
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: certificates
   probes:
     default:
@@ -608,10 +610,10 @@ cluster:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/clusters
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -671,10 +673,10 @@ container_registry:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/container_registrys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: managed_kubernetes
   probes:
     default:
@@ -761,7 +763,7 @@ dc_cluster_group:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/dc_cluster_groups
   discovered_allowed:
-  - system
+    - system
   domain: network
   probes:
     default:
@@ -803,10 +805,10 @@ dns_compliance_checks:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/dns_compliance_checkss
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: dns
   probes:
     default:
@@ -889,7 +891,7 @@ dns_load_balancer:
   confidence: high
   create_path: /api/config/dns/namespaces/{namespace}/dns_load_balancers
   discovered_allowed:
-  - system
+    - system
   domain: dns
   probes:
     default:
@@ -951,10 +953,10 @@ endpoint:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/endpoints
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: service_mesh
   probes:
     default:
@@ -974,10 +976,10 @@ enhanced_firewall_policy:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/enhanced_firewall_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -1017,7 +1019,7 @@ fast_acl:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/fast_acls
   discovered_allowed:
-  - system
+    - system
   domain: network_security
   probes:
     default:
@@ -1103,10 +1105,10 @@ forward_proxy_policy:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/forward_proxy_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: network_security
   probes:
     default:
@@ -1167,7 +1169,7 @@ geo_location_set:
   confidence: high
   create_path: /api/config/dns/namespaces/{namespace}/geo_location_sets
   discovered_allowed:
-  - system
+    - system
   domain: virtual
   probes:
     default:
@@ -1189,10 +1191,10 @@ global_log_receiver:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/global_log_receivers
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: statistics
   probes:
     default:
@@ -1212,10 +1214,10 @@ healthcheck:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/healthchecks
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -1235,10 +1237,10 @@ http_loadbalancer:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/http_loadbalancers
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -1258,10 +1260,10 @@ ike1:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/ike1s
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: network
   probes:
     default:
@@ -1281,10 +1283,10 @@ ike2:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/ike2s
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: network
   probes:
     default:
@@ -1304,10 +1306,10 @@ ike_phase1_profile:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/ike_phase1_profiles
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: network
   probes:
     default:
@@ -1327,10 +1329,10 @@ ike_phase2_profile:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/ike_phase2_profiles
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: network
   probes:
     default:
@@ -1432,7 +1434,7 @@ infraprotect_firewall_rule_group:
   confidence: medium
   create_path: /api/infraprotect/namespaces/{namespace}/infraprotect_firewall_rule_groups
   discovered_allowed:
-  - system
+    - system
   domain: ddos
   probes:
     default:
@@ -1516,7 +1518,7 @@ k8s_cluster:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/k8s_clusters
   discovered_allowed:
-  - system
+    - system
   domain: sites
   probes:
     default:
@@ -1538,7 +1540,7 @@ k8s_cluster_role:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/k8s_cluster_roles
   discovered_allowed:
-  - system
+    - system
   domain: managed_kubernetes
   probes:
     default:
@@ -1580,7 +1582,7 @@ k8s_pod_security_admission:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/k8s_pod_security_admissions
   discovered_allowed:
-  - system
+    - system
   domain: managed_kubernetes
   probes:
     default:
@@ -1588,14 +1590,14 @@ k8s_pod_security_admission:
       error: ves.io.schema.k8s_pod_security_admission.Object allowed to be created
         only in system, got default in request
       restriction_allowed:
-      - system
+        - system
       status: 400
     demo:
       classification: ns_restricted
       error: ves.io.schema.k8s_pod_security_admission.Object allowed to be created
         only in system, got demo in request
       restriction_allowed:
-      - system
+        - system
       status: 400
     system:
       classification: created
@@ -1644,10 +1646,10 @@ malicious_user_mitigation:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/malicious_user_mitigations
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: secops_and_incident_response
   probes:
     default:
@@ -1707,7 +1709,7 @@ network_firewall:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/network_firewalls
   discovered_allowed:
-  - system
+    - system
   domain: network_security
   probes:
     default:
@@ -1747,10 +1749,10 @@ network_policy:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/network_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: network_security
   probes:
     default:
@@ -1794,7 +1796,7 @@ network_policy_view:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/network_policy_views
   discovered_allowed:
-  - system
+    - system
   domain: network_security
   probes:
     default:
@@ -1836,10 +1838,10 @@ origin_pool:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/origin_pools
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -1859,10 +1861,10 @@ policer:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/policers
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: rate_limiting
   probes:
     default:
@@ -1905,10 +1907,10 @@ protocol_inspection:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/protocol_inspections
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -1928,7 +1930,7 @@ protocol_policer:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/protocol_policers
   discovered_allowed:
-  - system
+    - system
   domain: rate_limiting
   probes:
     default:
@@ -1950,10 +1952,10 @@ proxy:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/proxys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -1991,10 +1993,10 @@ rate_limiter:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/rate_limiters
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: rate_limiting
   probes:
     default:
@@ -2014,10 +2016,10 @@ rate_limiter_policy:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/rate_limiter_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -2078,10 +2080,10 @@ role:
   confidence: high
   create_path: /api/web/namespaces/{namespace}/roles
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: tenant_and_identity
   probes:
     default:
@@ -2139,10 +2141,10 @@ secret_policy:
   confidence: high
   create_path: /api/secret_management/namespaces/{namespace}/secret_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: blindfold
   probes:
     default:
@@ -2205,7 +2207,7 @@ securemesh_site_v2:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/securemesh_site_v2s
   discovered_allowed:
-  - system
+    - system
   domain: sites
   probes:
     default:
@@ -2227,7 +2229,7 @@ segment:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/segments
   discovered_allowed:
-  - system
+    - system
   domain: network_security
   probes:
     default:
@@ -2249,10 +2251,10 @@ sensitive_data_policy:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/sensitive_data_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: data_and_privacy_security
   probes:
     default:
@@ -2272,10 +2274,10 @@ service_policy:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/service_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: network_security
   probes:
     default:
@@ -2295,10 +2297,10 @@ service_policy_rule:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/service_policy_rules
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -2338,7 +2340,7 @@ srv6_network_slice:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/srv6_network_slices
   discovered_allowed:
-  - system
+    - system
   domain: network
   probes:
     default:
@@ -2346,14 +2348,14 @@ srv6_network_slice:
       error: ves.io.schema.srv6_network_slice.Object allowed to be created only in
         system, got default in request
       restriction_allowed:
-      - system
+        - system
       status: 400
     demo:
       classification: ns_restricted
       error: ves.io.schema.srv6_network_slice.Object allowed to be created only in
         system, got demo in request
       restriction_allowed:
-      - system
+        - system
       status: 400
     system:
       classification: created
@@ -2387,10 +2389,10 @@ tcp_loadbalancer:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/tcp_loadbalancers
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -2428,7 +2430,7 @@ token:
   confidence: medium
   create_path: /api/register/namespaces/{namespace}/tokens
   discovered_allowed:
-  - system
+    - system
   domain: users
   probes:
     default:
@@ -2490,10 +2492,10 @@ tpm_manager:
   confidence: high
   create_path: /api/tpm/namespaces/{namespace}/tpm_managers
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: bot_and_threat_defense
   probes:
     default:
@@ -2513,10 +2515,10 @@ trusted_ca_list:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/trusted_ca_lists
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: certificates
   probes:
     default:
@@ -2594,10 +2596,10 @@ user_identification:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/user_identifications
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: tenant_and_identity
   probes:
     default:
@@ -2640,10 +2642,10 @@ virtual_k8s:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/virtual_k8ss
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: container_services
   probes:
     default:
@@ -2663,7 +2665,7 @@ virtual_network:
   confidence: medium
   create_path: /api/config/namespaces/{namespace}/virtual_networks
   discovered_allowed:
-  - system
+    - system
   domain: network
   probes:
     default:
@@ -2685,10 +2687,10 @@ virtual_site:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/virtual_sites
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: sites
   probes:
     default:
@@ -2708,10 +2710,10 @@ voltshare_admin_policy:
   confidence: high
   create_path: /api/secret_management/namespaces/{namespace}/voltshare_admin_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: blindfold
   probes:
     default:
@@ -2754,10 +2756,10 @@ waf_exclusion_policy:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/waf_exclusion_policys
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: virtual
   probes:
     default:
@@ -2777,10 +2779,10 @@ workload:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/workloads
   discovered_allowed:
-  - custom
-  - default
-  - shared
-  - system
+    - custom
+    - default
+    - shared
+    - system
   domain: container_services
   probes:
     default:
@@ -2800,7 +2802,7 @@ workload_flavor:
   confidence: high
   create_path: /api/config/namespaces/{namespace}/workload_flavors
   discovered_allowed:
-  - shared
+    - shared
   domain: container_services
   probes:
     default:
@@ -2808,20 +2810,20 @@ workload_flavor:
       error: ves.io.schema.workload_flavor.Object allowed to be created only in shared,
         got default in request
       restriction_allowed:
-      - shared
+        - shared
       status: 400
     demo:
       classification: ns_restricted
       error: ves.io.schema.workload_flavor.Object allowed to be created only in shared,
         got demo in request
       restriction_allowed:
-      - shared
+        - shared
       status: 400
     system:
       classification: ns_restricted
       error: ves.io.schema.workload_flavor.Object allowed to be created only in shared,
         got system in request
       restriction_allowed:
-      - shared
+        - shared
       status: 400
   verdict: shared_only

--- a/config/namespace_verdicts.yaml
+++ b/config/namespace_verdicts.yaml
@@ -386,11 +386,11 @@ verdicts:
       allowed: *id002
   proxy:
     _verification:
-      evidence: "unclassified create-path resource \u2014 hidden pending CRUD verification"
-      method: default_deny
-      status: restricted
+      evidence: created in a custom namespace
+      method: crud
+      status: verified
     constraint:
-      allowed: *id002
+      allowed: *id001
   rate_limiter:
     _verification:
       evidence: created in a custom namespace

--- a/config/namespace_verdicts.yaml
+++ b/config/namespace_verdicts.yaml
@@ -1,3 +1,4 @@
+---
 # MACHINE-GENERATED — do not edit by hand.
 # Regenerate: python -m scripts.generate_namespace_verdicts
 # Source evidence: config/namespace_crud_evidence.yaml
@@ -12,7 +13,7 @@ verdicts:
       status: restricted
     constraint:
       allowed: &id002
-      - system
+        - system
   alert_policy:
     _verification:
       evidence: created in a custom namespace
@@ -20,9 +21,9 @@ verdicts:
       status: verified
     constraint:
       allowed: &id001
-      - custom
-      - default
-      - shared
+        - custom
+        - default
+        - shared
   alert_receiver:
     _verification:
       evidence: created in a custom namespace
@@ -579,5 +580,5 @@ verdicts:
       status: verified
     constraint:
       allowed:
-      - shared
+        - shared
 version: 1

--- a/docs/specifications/api/namespace_profiles.json
+++ b/docs/specifications/api/namespace_profiles.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "generated_at": "2026-07-15T10:01:37.245380+00:00",
+  "generated_at": "2026-07-15T10:14:12.311281+00:00",
   "source": "api-specs-enriched/config/namespace_profile.yaml",
   "default": {
     "constraint": {

--- a/docs/specifications/api/namespace_profiles.json
+++ b/docs/specifications/api/namespace_profiles.json
@@ -1,6 +1,6 @@
 {
-  "version": "2.1.177",
-  "generated_at": "2026-07-15T03:21:01.368614+00:00",
+  "version": "0.0.0",
+  "generated_at": "2026-07-15T10:01:37.245380+00:00",
   "source": "api-specs-enriched/config/namespace_profile.yaml",
   "default": {
     "constraint": {
@@ -3678,9 +3678,11 @@
     "proxy": {
       "constraint": {
         "allowed": [
-          "system"
+          "custom",
+          "default",
+          "shared"
         ],
-        "enforced": false
+        "enforced": true
       },
       "recommendation": {
         "primary": "custom",
@@ -3693,8 +3695,8 @@
       },
       "_meta": {
         "explicit": true,
-        "verification": "restricted",
-        "method": "default_deny"
+        "verification": "verified",
+        "method": "crud"
       }
     },
     "quota": {
@@ -5470,10 +5472,10 @@
   },
   "_coverage": {
     "total_explicit": 241,
-    "verified": 73,
+    "verified": 74,
     "assumed": 10,
-    "unverified": 158,
-    "default_deny_worklist_count": 18,
+    "unverified": 157,
+    "default_deny_worklist_count": 17,
     "default_deny_worklist": [
       "address_allocator",
       "authentication",
@@ -5488,14 +5490,10 @@
       "k8s_cluster_role_binding",
       "k8s_pod_security_policy",
       "nfv_service",
-      "proxy",
       "report_config",
       "tpm_api_key",
       "tpm_category",
       "usb_policy"
     ]
-  },
-  "info": {
-    "version": "2.1.178"
   }
 }

--- a/scripts/discover_namespace_crud.py
+++ b/scripts/discover_namespace_crud.py
@@ -29,6 +29,8 @@ from typing import Any
 import requests
 import yaml
 
+from scripts.utils.yaml_writer import write_yaml
+
 
 def get_api_client() -> tuple[str, dict[str, str]]:
     """Return (base_url, headers) for the F5 XC API."""
@@ -650,8 +652,7 @@ def main() -> None:
         payload_overrides_path=payload_overrides_path,
     )
 
-    with Path(args.output).open("w") as f:
-        yaml.dump(results, f, default_flow_style=False, sort_keys=True)
+    write_yaml(results, Path(args.output), sort_keys=True)
     print(f"\nReport written to {args.output}")
 
     diffs = None
@@ -662,8 +663,7 @@ def main() -> None:
 
     if diffs:
         drift_path = Path(args.output).with_suffix(".drift.yaml")
-        with drift_path.open("w") as f:
-            yaml.dump(diffs, f, default_flow_style=False, sort_keys=True)
+        write_yaml(diffs, drift_path, sort_keys=True)
         print(f"Drift details written to {drift_path}")
 
 

--- a/scripts/generate_namespace_verdicts.py
+++ b/scripts/generate_namespace_verdicts.py
@@ -25,6 +25,7 @@ from typing import Any
 import yaml
 
 from scripts.discover_namespace_crud import build_create_path_index
+from scripts.utils.yaml_writer import write_yaml
 
 TENANT_ALLOWED = ["custom", "default", "shared"]
 SYSTEM_ALLOWED = ["system"]
@@ -129,16 +130,9 @@ def main() -> None:
         "# Source evidence: config/namespace_crud_evidence.yaml\n"
         "#\n"
         "# Authoritative, live-CRUD-verified namespace constraints. The enricher\n"
-        "# layers these OVER config/namespace_profile.yaml (verdict wins).\n"
+        "# layers these OVER config/namespace_profile.yaml (verdict wins)."
     )
-    with args.output.open("w") as f:
-        f.write(header)
-        yaml.dump(
-            {"version": 1, "verdicts": verdicts},
-            f,
-            default_flow_style=False,
-            sort_keys=True,
-        )
+    write_yaml({"version": 1, "verdicts": verdicts}, args.output, header=header, sort_keys=True)
 
     tenant = sum(1 for v in verdicts.values() if v["constraint"]["allowed"] == TENANT_ALLOWED)
     system = sum(1 for v in verdicts.values() if v["constraint"]["allowed"] == SYSTEM_ALLOWED)

--- a/scripts/utils/yaml_writer.py
+++ b/scripts/utils/yaml_writer.py
@@ -1,0 +1,55 @@
+"""Shared YAML writer producing yamllint-compliant output.
+
+PyYAML's default dump does not indent block sequences under their mapping key
+and omits the document-start marker, both of which the repo's yamllint config
+flags. This helper forces sequence indentation and emits ``---`` so generated
+YAML passes the ``Lint Code Base`` gate.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _IndentDumper(yaml.Dumper):
+    """Dumper that indents block sequences under their parent key."""
+
+    def increase_indent(self, flow: bool = False, indentless: bool = False) -> Any:  # noqa: ARG002
+        return super().increase_indent(flow, False)
+
+
+def dump_yaml(data: Any, *, sort_keys: bool = True) -> str:
+    """Serialize ``data`` to a yamllint-compliant YAML string (with ``---``)."""
+    body = yaml.dump(
+        data,
+        Dumper=_IndentDumper,
+        default_flow_style=False,
+        sort_keys=sort_keys,
+        indent=2,
+    )
+    return "---\n" + body
+
+
+def write_yaml(data: Any, path: Path, *, header: str = "", sort_keys: bool = True) -> None:
+    """Write ``data`` to ``path`` as yamllint-compliant YAML.
+
+    ``header`` (if given) is inserted as leading comment lines after the ``---``
+    document-start marker.
+    """
+    body = yaml.dump(
+        data,
+        Dumper=_IndentDumper,
+        default_flow_style=False,
+        sort_keys=sort_keys,
+        indent=2,
+    )
+    with path.open("w") as f:
+        f.write("---\n")
+        if header:
+            f.write(header if header.endswith("\n") else header + "\n")
+        f.write(body)


### PR DESCRIPTION
## Summary
Continues driving the default-deny worklist to conclusive CRUD verdicts.
- **`proxy` → tenant** (CRUD-verified creatable in custom); now unlocked in user namespaces.
- Added schema-derived probe payloads (required fields, oneof choices, enums) for 14 previously validation-blocked resources.
- Remaining 17 stay default-deny (policy-correct): 4 are non-CRUD 500/501 endpoints (authorization_server, bigip_http_proxy, cdn_purge_command, k8s_pod_security_policy); 13 need deeper nested payloads / prerequisite chains, tracked for future rounds.

Coverage: 74 CRUD-verified (was 73), 17 worklist.

## Test plan
- [x] pytest green; ruff clean
- [x] regenerated namespace_profiles.json (proxy → verified tenant)

Closes #980

🤖 Generated with [Claude Code](https://claude.com/claude-code)